### PR TITLE
Feature/cli look improvement

### DIFF
--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from app.core.settings import AtelierSettings
-from app.modules.engine import Engine, TaskEventCallback
+from app.modules.engine import Engine, FlowStartedCallback, TaskEventCallback
 from app.schemas.progress import Progress
 from app.services.executor.bash import BashExecutor
 from app.services.executor.conduit import ConduitExecutor
@@ -71,6 +71,7 @@ class Atelier:
         name: str,
         inputs: dict[str, Any],
         on_task_event: TaskEventCallback | None = None,
+        on_flow_started: FlowStartedCallback | None = None,
     ) -> str:
         """Start a new flow for the named conduit.
 
@@ -80,11 +81,17 @@ class Atelier:
             :class:`TaskEvent` after every task iteration finishes (success
             or failure). Exceptions raised by the callback are logged but
             do not affect the flow.
+        :param on_flow_started: optional callback invoked once with the
+            new flow id, before any task runs. Lets the caller record the
+            id and surface it on failure as well as on success.
         :returns: the newly created flow id
         """
         conduit = self.store.read_conduit(name)
         return await self.engine.run(
-            conduit, inputs, on_task_event=on_task_event
+            conduit,
+            inputs,
+            on_task_event=on_task_event,
+            on_flow_started=on_flow_started,
         )
 
     def get_status(self, flow_id: str) -> Progress:

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import time
+from collections import Counter
+from datetime import datetime
 from pathlib import Path
 
 import typer
@@ -11,7 +15,9 @@ from rich.table import Table
 from rich.text import Text
 
 from app.core.atelier import Atelier
+from app.schemas.flow import parse_flow_id
 from app.schemas.log import TaskEvent
+from app.schemas.progress import FlowStatus, Progress, TaskStatus
 
 HELLO_CONDUIT_YAML = """name: hello
 description: Say hello
@@ -28,20 +34,24 @@ tasks:
 app = typer.Typer(
     help="flow-atelier: run reproducible async DAG workflows (conduits).",
     no_args_is_help=True,
+    rich_markup_mode="rich",
 )
-list_app = typer.Typer(help="List conduits or flows.", no_args_is_help=True)
+list_app = typer.Typer(
+    help="List conduits or flows.",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
 app.add_typer(list_app, name="list")
 
 console = Console()
 
 
-@app.command("init")
+@app.command(
+    "init",
+    help="Scaffold a local .atelier/ directory with a hello-world conduit.",
+)
 def init_cmd() -> None:
-    """Scaffold a local ``.atelier/`` with a hello-world conduit.
-
-    If ``.atelier/`` already exists in the current directory, prints a
-    message and exits 0 without touching anything.
-    """
+    """Scaffold ``.atelier/`` with a hello-world conduit; idempotent."""
     atelier_dir = Path.cwd() / ".atelier"
     if atelier_dir.exists():
         console.print("[yellow]atelier is already set up in this project[/yellow]")
@@ -86,12 +96,50 @@ def _truncate_tail(text: str, max_lines: int = 20) -> tuple[str, int]:
     return "\n".join(lines[-max_lines:]), dropped
 
 
+def _truncated_section(text: str, max_lines: int = 20) -> Text:
+    """Truncate ``text`` to its last ``max_lines`` lines and return a
+    Rich :class:`Text` with an italic-dim header noting the dropped count.
+    """
+    displayed, dropped = _truncate_tail(text, max_lines=max_lines)
+    body = Text()
+    if dropped:
+        body.append(f"… ({dropped} lines truncated)\n", style="dim italic")
+    body.append(displayed)
+    return body
+
+
+def _build_failure_body(stdout: str, stderr: str) -> Text:
+    """Render a failure body that always surfaces stderr.
+
+    - Both empty → ``(empty)``.
+    - Only one populated → the existing single-body (truncated) form.
+    - Both populated → labelled sections so the diagnostic stderr is
+      visible alongside the stdout context.
+    """
+    has_stdout = bool(stdout)
+    has_stderr = bool(stderr)
+    if not has_stdout and not has_stderr:
+        return Text("(empty)")
+    if has_stdout and not has_stderr:
+        return _truncated_section(stdout)
+    if has_stderr and not has_stdout:
+        return _truncated_section(stderr)
+    body = Text()
+    body.append("stdout:\n", style="dim bold")
+    body.append(_truncated_section(stdout))
+    body.append("\n\n")
+    body.append("stderr:\n", style="bold red")
+    body.append(_truncated_section(stderr))
+    return body
+
+
 def _render_task_event(event: TaskEvent, console: Console) -> None:
     """Pretty-print a :class:`TaskEvent` to ``console``.
 
     Success with non-empty output → green-bordered :class:`Panel`.
-    Failure → red-bordered panel, preferring ``output`` and falling back
-    to ``stderr``.
+    Failure → red-bordered panel showing stdout *and* stderr when both
+    are populated (stderr is the primary diagnostic and used to be
+    hidden whenever stdout had any content).
     Success with empty output → compact single-line summary (no panel)
     to avoid visual noise for echo-style tasks.
 
@@ -102,31 +150,53 @@ def _render_task_event(event: TaskEvent, console: Console) -> None:
     title_core = f"{event.task} [{event.tool}]{iter_suffix}"
     subtitle = f"exit={event.exit_code} · {event.duration_seconds}s"
 
-    if event.success:
-        body_source = event.output
-        border_style = "green"
-        title = Text(f"✓ {title_core}", style="bold green")
-    else:
-        body_source = event.output or event.stderr
-        border_style = "red"
-        title = Text(f"✗ {title_core}", style="bold red")
-
-    # Compact single-line path: successful task with nothing to show.
-    if event.success and not body_source.strip():
+    # Compact one-liners for non-running dispositions — these never had
+    # a real iteration so a full panel of "(empty)" output is misleading.
+    if event.status == TaskStatus.skipped:
+        reason = f"  [dim italic]({event.reason})[/dim italic]" if event.reason else ""
         console.print(
-            f"[green]✓[/green] [bold]{event.task}[/bold] "
+            f"[yellow]⏭[/yellow] [bold]{event.task}[/bold] "
             f"[dim]\\[{event.tool}]{iter_suffix}[/dim]  "
-            f"[dim]{subtitle}  (no output)[/dim]"
+            f"[yellow]skipped[/yellow]{reason}"
+        )
+        return
+    if event.status == TaskStatus.cancelled:
+        reason = f"  [dim italic]({event.reason})[/dim italic]" if event.reason else ""
+        console.print(
+            f"[red]⊘[/red] [bold]{event.task}[/bold] "
+            f"[dim]\\[{event.tool}]{iter_suffix}[/dim]  "
+            f"[red]cancelled[/red]{reason}"
         )
         return
 
-    displayed, dropped = _truncate_tail(body_source, max_lines=20)
-    if dropped:
-        body_text = Text()
-        body_text.append(f"… ({dropped} lines truncated)\n", style="dim italic")
-        body_text.append(displayed)
+    if event.success:
+        border_style = "green"
+        title = Text(f"✓ {title_core}", style="bold green")
+        body_source = event.output
+        # Compact single-line path: successful task with nothing to show.
+        if not body_source.strip():
+            console.print(
+                f"[green]✓[/green] [bold]{event.task}[/bold] "
+                f"[dim]\\[{event.tool}]{iter_suffix}[/dim]  "
+                f"[dim]{subtitle}  (no output)[/dim]"
+            )
+            return
+        # Interactive harness tasks already streamed their full
+        # transcript live (incl. multi-turn user replies), so a body
+        # panel here would just duplicate what scrolled by. Show a
+        # compact single-line summary instead.
+        if event.live_streamed:
+            console.print(
+                f"[green]✓[/green] [bold]{event.task}[/bold] "
+                f"[dim]\\[{event.tool}]{iter_suffix}[/dim]  "
+                f"[dim]{subtitle}  (streamed live above)[/dim]"
+            )
+            return
+        body_text = _truncated_section(body_source)
     else:
-        body_text = Text(displayed or "(empty)")
+        border_style = "red"
+        title = Text(f"✗ {title_core}", style="bold red")
+        body_text = _build_failure_body(event.output or event.stdout, event.stderr)
 
     console.print(
         Panel(
@@ -141,7 +211,106 @@ def _render_task_event(event: TaskEvent, console: Console) -> None:
     )
 
 
-@app.command("run")
+_FLOW_STATUS_STYLE: dict[str, str] = {
+    FlowStatus.completed.value: "green",
+    FlowStatus.failed.value: "red",
+    FlowStatus.running.value: "yellow",
+}
+
+_TASK_STATUS_GLYPHS: list[tuple[TaskStatus, str, str]] = [
+    (TaskStatus.completed, "✓", "green"),
+    (TaskStatus.failed, "✗", "red"),
+    (TaskStatus.skipped, "⏭", "yellow"),
+    (TaskStatus.cancelled, "⊘", "red"),
+    (TaskStatus.running, "⏳", "yellow"),
+    (TaskStatus.pending, "·", "dim"),
+]
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        # Engine emits Z-suffixed ISO; fromisoformat handles +00:00 form.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_duration_seconds(seconds: float | None) -> str:
+    if seconds is None:
+        return "—"
+    if seconds < 1:
+        return f"{seconds:.2f}s"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes < 60:
+        return f"{minutes}m {secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+def _flow_duration_seconds(progress: Progress) -> float | None:
+    start = _parse_iso(progress.started_at)
+    end = _parse_iso(progress.finished_at) if progress.finished_at else None
+    if start is None:
+        return None
+    if end is None:
+        # In-flight: don't try to compute against wall-clock here — just omit.
+        return None
+    return (end - start).total_seconds()
+
+
+def _format_clock(ts: str | None) -> str:
+    dt = _parse_iso(ts)
+    if dt is None:
+        return "—"
+    return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _task_status_summary(progress: Progress) -> Text:
+    """Render `✓3 ✗1 ⏭2 ⊘0 ⏳1` with only non-zero entries."""
+    counts: Counter[TaskStatus] = Counter(
+        tp.status for tp in progress.tasks.values()
+    )
+    text = Text()
+    first = True
+    for status, glyph, style in _TASK_STATUS_GLYPHS:
+        n = counts.get(status, 0)
+        if n == 0:
+            continue
+        if not first:
+            text.append("  ")
+        text.append(f"{glyph}{n}", style=style)
+        first = False
+    if first:
+        text.append("—", style="dim")
+    return text
+
+
+def _render_run_footer(events: list[TaskEvent], console: Console) -> None:
+    """One-line aggregate summary printed at the end of `atelier run`."""
+    if not events:
+        return
+    counts: Counter[TaskStatus] = Counter(e.status for e in events)
+    total_dur = sum(e.duration_seconds for e in events)
+    parts: list[str] = []
+    for status, glyph, style in _TASK_STATUS_GLYPHS:
+        n = counts.get(status, 0)
+        if n == 0:
+            continue
+        parts.append(f"[{style}]{glyph}{n}[/{style}]")
+    summary = "  ".join(parts) if parts else "—"
+    console.print(
+        f"[dim]{summary}  ·  total {_format_duration_seconds(total_dur)}[/dim]"
+    )
+
+
+@app.command(
+    "run",
+    help="Start a new flow for the named conduit. Use --input key=value to pass inputs.",
+)
 def run_cmd(
     conduit_name: str = typer.Argument(..., help="Name of the conduit to run."),
     inputs_raw: list[str] = typer.Option(
@@ -151,77 +320,447 @@ def run_cmd(
         help="key=value input (repeatable).",
     ),
 ) -> None:
-    """Start a new flow for ``conduit_name``.
-
-    :param conduit_name: name of the conduit to run
-    :param inputs_raw: list of ``key=value`` input strings
-    :returns: None
-    """
+    """Start a new flow for the named conduit."""
     inputs = _parse_inputs(inputs_raw)
     atelier = Atelier()
 
+    collected_events: list[TaskEvent] = []
+
     def _on_event(event: TaskEvent) -> None:
+        collected_events.append(event)
         _render_task_event(event, console)
+
+    captured_flow_id: dict[str, str | None] = {"id": None}
+
+    def _on_started(fid: str) -> None:
+        captured_flow_id["id"] = fid
 
     try:
         flow_id = asyncio.run(
-            atelier.run_conduit(conduit_name, inputs, on_task_event=_on_event)
+            atelier.run_conduit(
+                conduit_name,
+                inputs,
+                on_task_event=_on_event,
+                on_flow_started=_on_started,
+            )
         )
     except Exception as e:  # noqa: BLE001
+        _render_run_footer(collected_events, console)
         console.print(f"[red]flow failed:[/red] {e}")
+        fid = captured_flow_id["id"]
+        if fid:
+            console.print(f"[red]flow_id:[/red] {fid}")
+            console.print(f"[dim]→ atelier status {fid}[/dim]")
         raise typer.Exit(code=1)
+    _render_run_footer(collected_events, console)
     console.print(f"[green]flow_id:[/green] {flow_id}")
 
 
 @app.command("status")
-def status_cmd(flow_id: str = typer.Argument(..., help="Flow id to inspect.")) -> None:
-    """Show live progress for a flow."""
+def status_cmd(
+    flow_id: str = typer.Argument(..., help="Flow id (or unique prefix) to inspect."),
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of a table."
+    ),
+) -> None:
+    """Show progress for a flow."""
     atelier = Atelier()
+    flow_id = _resolve_flow_id(atelier, flow_id)
     try:
         progress = atelier.get_status(flow_id)
     except FileNotFoundError:
         console.print(f"[red]unknown flow:[/red] {flow_id}")
         raise typer.Exit(code=1)
 
-    console.print(f"[bold]flow[/bold] {flow_id}  status={progress.status.value}")
-    table = Table("task", "status", "iteration", "reason")
+    if json_mode:
+        payload = progress.model_dump(mode="json")
+        payload["flow_id"] = flow_id
+        payload["duration_seconds"] = _flow_duration_seconds(progress)
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    flow_status_style = _FLOW_STATUS_STYLE.get(progress.status.value, "white")
+    duration = _flow_duration_seconds(progress)
+    header = (
+        f"[bold]flow[/bold] {flow_id}  "
+        f"status=[{flow_status_style}]{progress.status.value}[/{flow_status_style}]  "
+        f"started={_format_clock(progress.started_at)}  "
+        f"duration={_format_duration_seconds(duration)}"
+    )
+    console.print(header)
+
+    show_iteration = any(tp.of > 1 for tp in progress.tasks.values())
+    columns = ["task", "status"]
+    if show_iteration:
+        columns.append("iteration")
+    columns.append("reason")
+    table = Table(*columns)
     for name, tp in progress.tasks.items():
-        table.add_row(
-            name,
-            tp.status.value,
-            f"{tp.iteration}/{tp.of}" if tp.of > 1 else "",
-            tp.reason or "",
-        )
+        row = [name, tp.status.value]
+        if show_iteration:
+            row.append(f"{tp.iteration}/{tp.of}" if tp.of > 1 else "")
+        row.append(tp.reason or "")
+        table.add_row(*row)
     console.print(table)
+    console.print(_task_status_summary(progress))
+
+
+def _resolve_flow_id(atelier: Atelier, candidate: str) -> str:
+    """Resolve ``candidate`` to a full flow id, supporting git-style prefixes.
+
+    - Exact id present on disk → returned as-is.
+    - Otherwise scans all known flows. Exactly one prefix match → that id.
+    - Zero matches → exits with ``unknown flow`` (code 1).
+    - More than one → exits with ``ambiguous flow id`` and lists candidates.
+    """
+    all_flows = atelier.list_flows()
+    if candidate in all_flows:
+        return candidate
+    matches = [fid for fid in all_flows if fid.startswith(candidate)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) == 0:
+        console.print(f"[red]unknown flow:[/red] {candidate}")
+        raise typer.Exit(code=1)
+    console.print(f"[red]ambiguous flow id:[/red] {candidate} matches:")
+    for m in matches[:10]:
+        console.print(f"  - {m}")
+    if len(matches) > 10:
+        console.print(f"  … and {len(matches) - 10} more")
+    raise typer.Exit(code=1)
+
+
+_LOG_SHOW_CHOICES = ("output", "stdout", "stderr", "all")
+
+
+def _render_log_entry(entry, show: str, console: Console) -> None:
+    """Render one LogEntry as a Rich Panel.
+
+    ``show`` controls which body channel is displayed:
+    ``output`` (default), ``stdout``, ``stderr``, or ``all`` (both
+    labelled when present).
+    """
+    iter_suffix = f" ({entry.iteration}/{entry.of})" if entry.of > 1 else ""
+    title_core = f"{entry.task} [{entry.tool}]{iter_suffix}"
+    success = entry.exit_code == 0
+    glyph = "✓" if success else "✗"
+    border = "green" if success else "red"
+    title = Text(f"{glyph} {title_core}", style=f"bold {border}")
+    started = _format_clock(entry.started_at)
+    subtitle = (
+        f"{started}  ·  exit={entry.exit_code}  ·  "
+        f"{entry.duration_seconds}s"
+    )
+
+    if show == "all":
+        body = Text()
+        if entry.stdout:
+            body.append("stdout:\n", style="dim bold")
+            body.append(entry.stdout)
+            if entry.stderr:
+                body.append("\n\n")
+        if entry.stderr:
+            body.append("stderr:\n", style="bold red")
+            body.append(entry.stderr)
+        if not entry.stdout and not entry.stderr:
+            body = Text("(empty)")
+    else:
+        raw = {
+            "output": entry.output,
+            "stdout": entry.stdout,
+            "stderr": entry.stderr,
+        }[show]
+        body = Text(raw or "(empty)")
+
+    console.print(
+        Panel(
+            body,
+            title=title,
+            title_align="left",
+            subtitle=subtitle,
+            subtitle_align="right",
+            border_style=border,
+            padding=(0, 1),
+        )
+    )
+
+
+@app.command(
+    "logs",
+    help="Show recorded stdout/stderr/output for each task in a flow.",
+)
+def logs_cmd(
+    flow_id: str = typer.Argument(..., help="Flow id (or unique prefix) to inspect."),
+    task: str | None = typer.Option(
+        None, "--task", "-t", help="Show only entries for this task."
+    ),
+    show: str = typer.Option(
+        "output",
+        "--show",
+        "-s",
+        help="Which channel to print: output | stdout | stderr | all.",
+    ),
+    last: int | None = typer.Option(
+        None, "--last", "-n", help="Show only the last N entries."
+    ),
+    follow: bool = typer.Option(
+        False,
+        "--follow",
+        "-f",
+        help="Tail mode: print existing entries, then poll for new ones until the flow finishes.",
+    ),
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of panels."
+    ),
+) -> None:
+    """Show recorded stdout/stderr/output for each task iteration in a flow."""
+    if show not in _LOG_SHOW_CHOICES:
+        console.print(
+            f"[red]invalid --show value:[/red] {show}  "
+            f"(allowed: {', '.join(_LOG_SHOW_CHOICES)})"
+        )
+        raise typer.Exit(code=2)
+    if follow and json_mode:
+        console.print("[red]--follow and --json are mutually exclusive[/red]")
+        raise typer.Exit(code=2)
+    if follow and last is not None:
+        console.print("[red]--follow and --last are mutually exclusive[/red]")
+        raise typer.Exit(code=2)
+
+    atelier = Atelier()
+    flow_id = _resolve_flow_id(atelier, flow_id)
+
+    if follow:
+        _follow_logs(atelier, flow_id, task, show)
+        return
+
+    try:
+        entries = atelier.store.read_logs(flow_id)
+    except FileNotFoundError:
+        console.print(f"[red]unknown flow:[/red] {flow_id}")
+        raise typer.Exit(code=1)
+
+    if task is not None:
+        entries = [e for e in entries if e.task == task]
+
+    if not entries:
+        scope = f"task {task!r}" if task else "this flow"
+        if json_mode:
+            typer.echo("[]")
+            raise typer.Exit(code=1)
+        console.print(f"[yellow]no log entries for {scope}[/yellow]")
+        raise typer.Exit(code=1)
+
+    if last is not None and last > 0:
+        entries = entries[-last:]
+
+    if json_mode:
+        typer.echo(
+            json.dumps([e.model_dump(mode="json") for e in entries], indent=2)
+        )
+        return
+
+    for entry in entries:
+        _render_log_entry(entry, show, console)
+
+
+def _follow_logs(
+    atelier: Atelier,
+    flow_id: str,
+    task: str | None,
+    show: str,
+    poll_seconds: float = 0.25,
+) -> None:
+    """Render existing entries, then poll for new ones until the flow ends.
+
+    Exits cleanly when the flow's progress.json reports a terminal status
+    (``completed`` or ``failed``). Exits 130 on KeyboardInterrupt.
+    """
+    rendered = 0
+
+    def _read() -> list:
+        try:
+            entries = atelier.store.read_logs(flow_id)
+        except FileNotFoundError:
+            console.print(f"[red]unknown flow:[/red] {flow_id}")
+            raise typer.Exit(code=1)
+        if task is not None:
+            entries = [e for e in entries if e.task == task]
+        return entries
+
+    def _drain_and_render() -> None:
+        nonlocal rendered
+        entries = _read()
+        for entry in entries[rendered:]:
+            _render_log_entry(entry, show, console)
+        rendered = len(entries)
+
+    try:
+        while True:
+            _drain_and_render()
+            try:
+                progress = atelier.store.read_progress(flow_id)
+            except FileNotFoundError:
+                # Flow vanished mid-stream; nothing more to do.
+                return
+            if progress.status != FlowStatus.running:
+                # Final pass to capture any entries written between the last
+                # read and the terminal state transition.
+                _drain_and_render()
+                return
+            time.sleep(poll_seconds)
+    except KeyboardInterrupt:
+        console.print("[dim]— follow interrupted —[/dim]")
+        raise typer.Exit(code=130)
 
 
 @list_app.command("conduits")
-def list_conduits_cmd() -> None:
+def list_conduits_cmd(
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of a table."
+    ),
+) -> None:
     """List all available conduits (project and global)."""
     atelier = Atelier()
     entries = atelier.store.list_conduits_with_source()
-    if not entries:
+
+    rows: list[dict[str, object]] = []
+    for name, source in entries:
+        try:
+            conduit = atelier.store.read_conduit(name)
+            description = (
+                conduit.description.splitlines()[0] if conduit.description else ""
+            )
+            num_tasks = len(conduit.tasks)
+            num_inputs = len(conduit.inputs)
+            readable = True
+        except Exception:  # noqa: BLE001 — broken yaml shouldn't break list
+            description = ""
+            num_tasks = -1
+            num_inputs = -1
+            readable = False
+        rows.append(
+            {
+                "name": name,
+                "source": source,
+                "description": description,
+                "tasks": num_tasks,
+                "inputs": num_inputs,
+                "readable": readable,
+            }
+        )
+
+    if json_mode:
+        # Drop the internal `readable` key from JSON output for cleanliness.
+        typer.echo(
+            json.dumps([{k: v for k, v in r.items() if k != "readable"} for r in rows], indent=2)
+        )
+        return
+
+    if not rows:
         console.print("[yellow]no conduits found[/yellow]")
         return
-    for name, source in entries:
-        tag_color = "cyan" if source == "project" else "magenta"
-        console.print(
-            f"- {name} [{tag_color}]\\[{source}][/{tag_color}]"
+    table = Table("name", "source", "description", "tasks", "inputs")
+    for r in rows:
+        source_style = "cyan" if r["source"] == "project" else "magenta"
+        if not r["readable"]:
+            description_cell = "[red](unreadable)[/red]"
+            tasks_cell = "?"
+            inputs_cell = "?"
+        else:
+            description_cell = str(r["description"])
+            tasks_cell = str(r["tasks"])
+            inputs_cell = str(r["inputs"])
+        table.add_row(
+            str(r["name"]),
+            f"[{source_style}]{r['source']}[/{source_style}]",
+            description_cell,
+            tasks_cell,
+            inputs_cell,
         )
+    console.print(table)
 
 
 @list_app.command("flows")
 def list_flows_cmd(
     conduit: str | None = typer.Option(None, "--conduit", "-c"),
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of a table."
+    ),
 ) -> None:
     """List all flows, optionally filtered by conduit."""
     atelier = Atelier()
     flows = atelier.list_flows(conduit)
-    if not flows:
+
+    rows: list[dict[str, object]] = []
+    progresses: dict[str, Progress | None] = {}
+    for fid in flows:
+        try:
+            conduit_name, _uuid, _ts = parse_flow_id(fid)
+        except ValueError:
+            conduit_name = "?"
+        progress: Progress | None
+        try:
+            progress = atelier.store.read_progress(fid)
+        except Exception:  # noqa: BLE001
+            progress = None
+        progresses[fid] = progress
+        if progress is None:
+            rows.append(
+                {
+                    "flow_id": fid,
+                    "conduit": conduit_name,
+                    "status": None,
+                    "started_at": None,
+                    "finished_at": None,
+                    "duration_seconds": None,
+                    "task_counts": {},
+                }
+            )
+            continue
+        counts: Counter[str] = Counter(
+            tp.status.value for tp in progress.tasks.values()
+        )
+        rows.append(
+            {
+                "flow_id": fid,
+                "conduit": conduit_name,
+                "status": progress.status.value,
+                "started_at": progress.started_at,
+                "finished_at": progress.finished_at,
+                "duration_seconds": _flow_duration_seconds(progress),
+                "task_counts": dict(counts),
+            }
+        )
+
+    if json_mode:
+        typer.echo(json.dumps(rows, indent=2))
+        return
+
+    if not rows:
         console.print("[yellow]no flows found[/yellow]")
         return
-    for fid in flows:
-        console.print(f"- {fid}")
+
+    table = Table()
+    # flow_id must not be ellipsised: users need to copy it whole.
+    table.add_column("flow_id", overflow="fold", no_wrap=False)
+    for col in ("conduit", "status", "started", "duration", "tasks"):
+        table.add_column(col)
+    for r in rows:
+        progress = progresses[str(r["flow_id"])]
+        if progress is None:
+            table.add_row(str(r["flow_id"]), str(r["conduit"]), "[red]?[/red]", "—", "—", "—")
+            continue
+        status_style = _FLOW_STATUS_STYLE.get(progress.status.value, "white")
+        table.add_row(
+            str(r["flow_id"]),
+            str(r["conduit"]),
+            f"[{status_style}]{progress.status.value}[/{status_style}]",
+            _format_clock(progress.started_at),
+            _format_duration_seconds(_flow_duration_seconds(progress)),
+            _task_status_summary(progress),
+        )
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -30,6 +30,7 @@ from app.schemas.conduit import Conduit, TaskDefinition, ToolType
 from app.schemas.log import ExecutionResult, LogEntry, TaskEvent
 
 TaskEventCallback = Callable[[TaskEvent], None]
+FlowStartedCallback = Callable[[str], None]
 from app.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
 from app.services.executor.base import ExecutorBase, FlowContext
 from app.services.store.base import StoreBase
@@ -107,12 +108,17 @@ class Engine:
         inputs: dict[str, Any],
         parent_flow_id: str | None = None,
         on_task_event: TaskEventCallback | None = None,
+        on_flow_started: FlowStartedCallback | None = None,
     ) -> str:
         """Execute a conduit to completion, returning the flow id.
 
         :param conduit: parsed :class:`Conduit` definition
         :param inputs: conduit input map (must cover all required keys)
         :param parent_flow_id: parent flow id for nested ``tool:conduit`` runs
+        :param on_flow_started: optional callback invoked exactly once with
+            the new flow id, immediately after it is created and before any
+            task runs. Lets callers (e.g. the CLI) record the id so they
+            can surface it even if the flow later fails.
         :returns: the new flow id on success
         :raises ConduitValidationError: DAG is invalid (cycle, unknown dep, bad regex)
         :raises ValueError: required inputs are missing
@@ -126,6 +132,17 @@ class Engine:
         parsed_deps = _validate_dag(conduit)
 
         flow_id = self.store.create_flow(conduit.name, inputs, parent_flow_id)
+        if on_flow_started is not None:
+            try:
+                on_flow_started(flow_id)
+            except Exception as cb_exc:  # noqa: BLE001
+                # Caller-supplied callback bugs must never break the flow.
+                print(
+                    f"[flow-atelier] on_flow_started callback raised: "
+                    f"{type(cb_exc).__name__}: {cb_exc}",
+                    file=sys.stderr,
+                )
+                traceback.print_exc(file=sys.stderr)
 
         progress = Progress(
             status=FlowStatus.running,
@@ -154,30 +171,11 @@ class Engine:
         state_changed = asyncio.Event()
         state_changed.set()
 
-        def emit_event(
-            t: TaskDefinition,
-            iteration: int,
-            result: ExecutionResult,
-            duration: float,
-        ) -> None:
-            """Invoke the on_task_event callback, isolating renderer errors."""
+        def _safe_emit(event: TaskEvent) -> None:
             if on_task_event is None:
                 return
             try:
-                on_task_event(
-                    TaskEvent(
-                        task=t.name,
-                        tool=t.tool.value,
-                        iteration=iteration,
-                        of=t.repeat,
-                        exit_code=result.exit_code,
-                        duration_seconds=round(duration, 3),
-                        output=result.output,
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        success=result.success,
-                    )
-                )
+                on_task_event(event)
             except Exception as cb_exc:  # noqa: BLE001
                 # Renderer bugs must never break the flow.
                 print(
@@ -186,6 +184,46 @@ class Engine:
                     file=sys.stderr,
                 )
                 traceback.print_exc(file=sys.stderr)
+
+        def emit_event(
+            t: TaskDefinition,
+            iteration: int,
+            result: ExecutionResult,
+            duration: float,
+        ) -> None:
+            """Emit a TaskEvent for a completed/failed iteration."""
+            _safe_emit(
+                TaskEvent(
+                    task=t.name,
+                    tool=t.tool.value,
+                    iteration=iteration,
+                    of=t.repeat,
+                    exit_code=result.exit_code,
+                    duration_seconds=round(duration, 3),
+                    output=result.output,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                    success=result.success,
+                    status=TaskStatus.completed if result.success else TaskStatus.failed,
+                    live_streamed=t.interactive,
+                )
+            )
+
+        def emit_disposition(
+            name: str, status: TaskStatus, reason: str = ""
+        ) -> None:
+            """Emit a TaskEvent for a non-running disposition (skip/cancel)."""
+            t = task_map[name]
+            _safe_emit(
+                TaskEvent(
+                    task=t.name,
+                    tool=t.tool.value,
+                    of=t.repeat,
+                    success=False,
+                    status=status,
+                    reason=reason,
+                )
+            )
 
         def mark_skipped(name: str, reason: str) -> None:
             statuses[name] = TaskStatus.skipped
@@ -196,6 +234,7 @@ class Engine:
                 reason=reason,
             )
             self.store.write_progress(flow_id, progress)
+            emit_disposition(name, TaskStatus.skipped, reason)
 
         def mark_running(name: str, iteration: int) -> None:
             statuses[name] = TaskStatus.running
@@ -334,6 +373,9 @@ class Engine:
                         status=TaskStatus.cancelled, of=t.repeat
                     )
                     self.store.write_progress(flow_id, progress)
+                    emit_disposition(
+                        t.name, TaskStatus.cancelled, "fail-fast: upstream failed"
+                    )
                 raise
             finally:
                 state_changed.set()
@@ -406,6 +448,9 @@ class Engine:
                     statuses[name] = TaskStatus.cancelled
                     progress.tasks[name] = TaskProgress(
                         status=TaskStatus.cancelled, of=task_map[name].repeat
+                    )
+                    emit_disposition(
+                        name, TaskStatus.cancelled, "upstream failed"
                     )
 
             progress.current_tasks = []

--- a/app/schemas/log.py
+++ b/app/schemas/log.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.schemas.progress import TaskStatus
+
 
 class ExecutionResult(BaseModel):
     """Primary result of a single executor invocation."""
@@ -38,11 +40,16 @@ class LogEntry(BaseModel):
 
 
 class TaskEvent(BaseModel):
-    """Live notification emitted by the engine as each task iteration finishes.
+    """Live notification emitted by the engine as a task transitions.
 
     Passed to the optional ``on_task_event`` callback of :meth:`Engine.run`.
     Carries everything a renderer needs to display per-task progress without
     reaching into the store.
+
+    Events fire on every task disposition, not just completed iterations:
+    ``status`` distinguishes ``completed`` / ``failed`` / ``skipped`` /
+    ``cancelled`` so renderers can show skipped & cancelled tasks instead of
+    silently dropping them.
     """
 
     task: str
@@ -55,3 +62,6 @@ class TaskEvent(BaseModel):
     stdout: str = ""
     stderr: str = ""
     success: bool = True
+    status: TaskStatus = TaskStatus.completed
+    reason: str = ""
+    live_streamed: bool = False

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -73,10 +73,26 @@ class _BufferingClient:
     The harness capabilities default to "no filesystem, no terminal" so the
     agent should not call the file/terminal methods — if it does, they raise
     :class:`NotImplementedError`.
+
+    :param sink: surface for permission requests and (when enabled) live
+        chunk streaming
+    :param live_stream: when ``True`` (interactive turns), agent message
+        chunks are mirrored to ``sink.display`` as they arrive so the user
+        can follow the agent before deciding their next reply. When
+        ``False`` (single-turn / non-interactive), chunks are only buffered
+        for the result — the caller renders them once when the turn ends,
+        avoiding double-rendering of the same text.
     """
 
-    def __init__(self, sink: PromptSink) -> None:
+    def __init__(
+        self,
+        sink: PromptSink,
+        live_stream: bool = False,
+        done_marker: str = DEFAULT_DONE_MARKER,
+    ) -> None:
         self._sink = sink
+        self._live_stream = live_stream
+        self._done_marker = done_marker
         self.buffer: list[str] = []
 
     async def session_update(self, session_id: str, update, **kwargs) -> None:
@@ -85,8 +101,15 @@ class _BufferingClient:
             content = update.content
             text = getattr(content, "text", None)
             if text:
+                # Buffer keeps the raw text so the executor can detect the
+                # done marker for loop termination.
                 self.buffer.append(text)
-                await self._sink.display(text)
+                if self._live_stream:
+                    # Hide the protocol marker from what the user sees on
+                    # screen (per-chunk strip — won't catch a marker split
+                    # across two chunks, but the model emits it whole in
+                    # practice).
+                    await self._sink.display(text.replace(self._done_marker, ""))
 
     async def request_permission(
         self, options, session_id: str, tool_call, **kwargs
@@ -180,7 +203,11 @@ class AcpHarnessExecutor(ExecutorBase):
             prompt_text = prompt_text + build_interactive_suffix(self.done_marker)
 
         cwd = str(Path.cwd())
-        client = _BufferingClient(self.sink)
+        client = _BufferingClient(
+            self.sink,
+            live_stream=task.interactive,
+            done_marker=self.done_marker,
+        )
 
         try:
             return await asyncio.wait_for(
@@ -285,7 +312,12 @@ class AcpHarnessExecutor(ExecutorBase):
     ) -> ExecutionResult:
         next_prompt = initial_prompt
         last_stop = "end_turn"
+        # Sinks that don't render visually (e.g. API/queue transports)
+        # may omit start_agent_turn; only call it if implemented.
+        start_turn = getattr(self.sink, "start_agent_turn", None)
         for _ in range(MAX_INTERACTIVE_TURNS):
+            if start_turn is not None:
+                await start_turn()
             resp = await conn.prompt(
                 prompt=[TextContentBlock(type="text", text=next_prompt)],
                 session_id=session_id,
@@ -294,11 +326,14 @@ class AcpHarnessExecutor(ExecutorBase):
             last_stop = resp.stop_reason
             buffer_text = "".join(client.buffer)
             if self.done_marker in buffer_text:
+                # Strip the protocol sentinel from anything we hand back to
+                # the user — it's an internal coordination marker, not content.
+                cleaned = buffer_text.replace(self.done_marker, "").rstrip()
                 return ExecutionResult(
                     exit_code=0,
-                    stdout=buffer_text,
+                    stdout=cleaned,
                     stderr="",
-                    output=buffer_text,
+                    output=cleaned,
                 )
             if resp.stop_reason not in ("end_turn", "max_tokens"):
                 break

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -210,7 +210,16 @@ class AcpHarnessExecutor(ExecutorBase):
         cwd: str,
     ) -> ExecutionResult:
         cmd, *args = self.launch_cmd
-        async with acp.spawn_agent_process(client, cmd, *args, cwd=cwd) as (
+        # Raise the per-line StreamReader limit well above asyncio's 64 KiB
+        # default; Codex and similar harnesses emit large JSON-RPC frames
+        # (tool results, planning output) that routinely exceed it.
+        async with acp.spawn_agent_process(
+            client,
+            cmd,
+            *args,
+            cwd=cwd,
+            transport_kwargs={"limit": 8 * 1024 * 1024},
+        ) as (
             conn,
             _proc,
         ):

--- a/app/services/executor/hitl.py
+++ b/app/services/executor/hitl.py
@@ -48,6 +48,11 @@ class HitlExecutor(ExecutorBase):
         for name, description in task.inputs.items():
             prompt = f"  {name} ({description}): "
             response = await asyncio.to_thread(builtins.input, prompt)
+            # Piped stdin doesn't echo keystrokes nor add a newline; print
+            # the consumed value so scripted transcripts read like a real
+            # terminal session instead of two prompts smashed together.
+            if not sys.stdin.isatty():
+                print(response, file=sys.stdout, flush=True)
             collected[name] = response
             context.store.append_input(context.flow_id, name, response)
             context.inputs[name] = response

--- a/app/services/executor/prompt_sink.py
+++ b/app/services/executor/prompt_sink.py
@@ -13,6 +13,8 @@ import sys
 from dataclasses import dataclass
 from typing import Protocol, TextIO, runtime_checkable
 
+from rich.console import Console
+
 
 @dataclass(frozen=True)
 class PermissionOption:
@@ -47,15 +49,41 @@ class PromptSink(Protocol):
         """Ask the user to pick one of ``options``; return the chosen ``id``."""
         ...
 
+    async def start_agent_turn(self, label: str = "agent") -> None:
+        """Optional: print a visual marker that a new agent turn is starting.
+
+        Called by interactive harness executors immediately before each
+        ``conn.prompt(...)`` so the terminal UI can bracket each turn
+        with a divider. Sinks that don't render visually may no-op.
+        """
+        ...
+
 
 class TerminalPromptSink:
     """Default :class:`PromptSink` backed by ``stdout``/``stdin``.
 
-    :param out: stream for :meth:`display` output (defaults to ``sys.stdout``)
+    Agent token chunks are streamed raw to ``out`` (preserving the live
+    feel). Turn-boundary markers, the user-turn prompt, and permission
+    menus are rendered through a Rich :class:`Console` so they share the
+    same visual language as the rest of the CLI (panels, tables).
+
+    :param out: stream for :meth:`display` output (defaults to
+        ``sys.stdout``); the Rich console writes to the same stream so
+        styled rules and raw stream chunks interleave correctly
+    :param console: optional Rich console override (mostly for tests)
     """
 
-    def __init__(self, out: TextIO | None = None) -> None:
+    def __init__(
+        self,
+        out: TextIO | None = None,
+        console: Console | None = None,
+    ) -> None:
         self._out = out if out is not None else sys.stdout
+        self._console = (
+            console
+            if console is not None
+            else Console(file=self._out, soft_wrap=True)
+        )
 
     async def display(self, text: str) -> None:
         """Stream ``text`` to the output verbatim.
@@ -67,31 +95,55 @@ class TerminalPromptSink:
         self._out.write(text)
         self._out.flush()
 
-    async def request_input(self, prompt: str) -> str:
-        """Ask the user for a reply with a clear visual break.
+    async def start_agent_turn(self, label: str = "agent") -> None:
+        """Print a styled rule announcing a new agent turn.
 
-        Inserts a blank line + horizontal rule before the prompt so the
-        user can tell exactly when streamed agent output has stopped and
-        it's their turn to type.
+        Always prefixed with a blank line so the rule is cleanly
+        separated from any previous raw stream output.
         """
-        self._out.write("\n\n─── your turn ───\n")
-        self._out.write(prompt)
-        if not prompt.endswith("\n"):
-            self._out.write("\n")
+        self._out.write("\n")
         self._out.flush()
-        return await asyncio.to_thread(builtins.input, "> ")
+        self._console.rule(
+            f"[bold cyan]🤖 {label}[/bold cyan]",
+            align="left",
+            style="cyan",
+        )
+
+    async def request_input(self, prompt: str) -> str:
+        """Render a styled "your turn" rule, then read one line of input.
+
+        - On a TTY: shows the ``› `` cursor; the terminal echoes the
+          user's keystrokes naturally.
+        - When stdin is piped (scripted runs): the consumed line is
+          echoed back as ``› <answer>`` so transcripts read cleanly.
+        """
+        self._out.write("\n")
+        self._out.flush()
+        self._console.rule(
+            "[bold green]👤 you[/bold green]", align="left", style="green"
+        )
+        if prompt and prompt.strip():
+            self._console.print(f"[dim]{prompt.strip()}[/dim]")
+        if sys.stdin.isatty():
+            answer = await asyncio.to_thread(builtins.input, "› ")
+        else:
+            answer = await asyncio.to_thread(builtins.input)
+            self._console.print(f"[green]›[/green] {answer}")
+        return answer
 
     async def request_permission(
         self, summary: str, options: list[PermissionOption]
     ) -> str:
         if not options:
             raise ValueError("request_permission requires at least one option")
-        self._out.write(summary)
-        if not summary.endswith("\n"):
-            self._out.write("\n")
+        self._console.rule(
+            "[bold yellow]🔐 permission[/bold yellow]",
+            align="left",
+            style="yellow",
+        )
+        self._console.print(summary)
         for idx, opt in enumerate(options, start=1):
-            self._out.write(f"  {idx}) {opt.label}\n")
-        self._out.flush()
+            self._console.print(f"  [bold]{idx})[/bold] {opt.label}")
 
         while True:
             raw = await asyncio.to_thread(
@@ -103,12 +155,10 @@ class TerminalPromptSink:
             try:
                 choice = int(raw)
             except ValueError:
-                self._out.write("  invalid input, try again\n")
-                self._out.flush()
+                self._console.print("[yellow]  invalid input, try again[/yellow]")
                 continue
             if 1 <= choice <= len(options):
                 return options[choice - 1].id
-            self._out.write(
-                f"  out of range (1-{len(options)}), try again\n"
+            self._console.print(
+                f"[yellow]  out of range (1-{len(options)}), try again[/yellow]"
             )
-            self._out.flush()

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -345,6 +345,51 @@ async def test_on_task_event_callback_error_does_not_break_flow(store, capsys):
     assert "renderer exploded" in captured.err
 
 
+async def test_on_task_event_fires_for_skipped_task(store):
+    """A task skipped via a conditional dependency must still emit a
+    TaskEvent so renderers can show it (previously it disappeared)."""
+    conduit = _conduit(
+        [
+            {"name": "review", "description": "d", "task": "x",
+             "tool": "tool:bash", "depends_on": []},
+            {"name": "deploy", "description": "d", "task": "x",
+             "tool": "tool:bash",
+             "depends_on": ["review.output.match(APPROVE)"]},
+        ]
+    )
+    fake = FakeExecutor(outputs={"review": "REJECT"})
+    engine = Engine({"tool:bash": fake}, store)
+    events = []
+    await engine.run(conduit, {}, on_task_event=events.append)
+    by_task = {e.task: e for e in events}
+    assert "deploy" in by_task
+    assert by_task["deploy"].status == TaskStatus.skipped
+    assert by_task["deploy"].reason  # populated with skip reason
+
+
+async def test_on_task_event_fires_for_cancelled_task(store):
+    """When fail-fast cancels still-pending tasks, those tasks must
+    emit a TaskEvent so the user sees they were cancelled rather than
+    just silently missing from the live output.
+    """
+    conduit = _conduit(
+        [
+            {"name": "fail", "description": "d", "task": "x",
+             "tool": "tool:bash", "depends_on": []},
+            {"name": "after", "description": "d", "task": "x",
+             "tool": "tool:bash", "depends_on": ["fail"]},
+        ]
+    )
+    fake = FakeExecutor(fail={"fail"})
+    engine = Engine({"tool:bash": fake}, store)
+    events = []
+    with pytest.raises(RuntimeError):
+        await engine.run(conduit, {}, on_task_event=events.append)
+    by_task = {e.task: e for e in events}
+    assert "after" in by_task
+    assert by_task["after"].status == TaskStatus.cancelled
+
+
 async def test_on_task_event_fires_per_repeat_iteration(store):
     conduit = _conduit(
         [

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -53,12 +53,16 @@ class RecordingSink:
     ) -> None:
         self.display_log: list[str] = []
         self.input_prompts: list[str] = []
+        self.agent_turn_starts: list[str] = []
         self._replies = list(replies or [])
         self.perm_log: list[str] = []
         self._perm_choice = perm_choice
 
     async def display(self, text: str) -> None:
         self.display_log.append(text)
+
+    async def start_agent_turn(self, label: str = "agent") -> None:
+        self.agent_turn_starts.append(label)
 
     async def request_input(self, prompt: str) -> str:
         self.input_prompts.append(prompt)
@@ -135,7 +139,10 @@ class TestNonInteractive:
         assert result.exit_code == 124
         assert "timeout" in result.stderr.lower()
 
-    async def test_streams_chunks_to_sink(self) -> None:
+    async def test_non_interactive_does_not_stream_to_sink(self) -> None:
+        """Non-interactive harness tasks must not double-render: chunks
+        are captured into the result but NOT mirrored to the sink (the
+        engine renders a final panel from result.output afterwards)."""
         sink = RecordingSink()
         executor = AcpHarnessExecutor(
             launch_cmd=_fake_cmd(
@@ -143,12 +150,80 @@ class TestNonInteractive:
             ),
             sink=sink,
         )
-        await executor.execute(_task("x"), "x", _ctx())
+        result = await executor.execute(_task("x"), "x", _ctx())
+        assert "AB" in result.output
+        assert sink.display_log == []
+
+
+class TestInteractiveStreaming:
+    async def test_interactive_streams_chunks_to_sink(self) -> None:
+        """Interactive mode keeps a live stream so the user can follow
+        the agent while deciding their next reply."""
+        sink = RecordingSink()
+        executor = AcpHarnessExecutor(
+            launch_cmd=_fake_cmd(
+                {
+                    "turns": [
+                        {
+                            "chunks": ["A", "B", "[ATELIER_DONE]"],
+                            "stop": "end_turn",
+                        }
+                    ]
+                }
+            ),
+            sink=sink,
+        )
+        await executor.execute(_task("x", interactive=True), "x", _ctx())
         assert "A" in "".join(sink.display_log)
         assert "B" in "".join(sink.display_log)
 
 
 class TestInteractive:
+    async def test_interactive_calls_start_agent_turn_per_turn(self) -> None:
+        """The interactive loop must signal each agent turn to the sink so
+        the terminal UI can bracket it with a styled rule."""
+        sink = RecordingSink(replies=["my answer"])
+        executor = AcpHarnessExecutor(
+            launch_cmd=_fake_cmd(
+                {
+                    "turns": [
+                        {"chunks": ["asking?"], "stop": "end_turn"},
+                        {"chunks": ["thanks [ATELIER_DONE]"], "stop": "end_turn"},
+                    ]
+                }
+            ),
+            sink=sink,
+        )
+        await executor.execute(
+            _task("go", interactive=True), "go", _ctx()
+        )
+        # Two agent turns ⇒ two calls.
+        assert len(sink.agent_turn_starts) == 2
+
+    async def test_marker_hidden_from_live_stream(self) -> None:
+        """The done marker must not be displayed to the user even in
+        interactive mode (live stream path)."""
+        sink = RecordingSink()
+        executor = AcpHarnessExecutor(
+            launch_cmd=_fake_cmd(
+                {
+                    "turns": [
+                        {
+                            "chunks": ["here is the answer ", "[ATELIER_DONE]"],
+                            "stop": "end_turn",
+                        }
+                    ]
+                }
+            ),
+            sink=sink,
+        )
+        await executor.execute(
+            _task("x", interactive=True), "x", _ctx()
+        )
+        displayed = "".join(sink.display_log)
+        assert "here is the answer" in displayed
+        assert "[ATELIER_DONE]" not in displayed
+
     async def test_marker_first_turn_terminates(self) -> None:
         sink = RecordingSink()
         executor = AcpHarnessExecutor(
@@ -168,7 +243,11 @@ class TestInteractive:
             _task("do it", interactive=True), "do it", _ctx()
         )
         assert result.exit_code == 0
-        assert "[ATELIER_DONE]" in result.output
+        # The done marker is an internal protocol sentinel — it must NOT
+        # be returned to callers as user-visible content (would otherwise
+        # also persist into logs.json).
+        assert "[ATELIER_DONE]" not in result.output
+        assert "doing work" in result.output
         assert sink.input_prompts == []
 
     async def test_multi_turn_with_user_reply(self) -> None:
@@ -193,7 +272,8 @@ class TestInteractive:
         assert result.exit_code == 0
         assert "what is your name?" in result.output
         assert "hello luis" in result.output
-        assert "[ATELIER_DONE]" in result.output
+        # Marker stripped from the user-visible result.
+        assert "[ATELIER_DONE]" not in result.output
         assert len(sink.input_prompts) == 1
 
     async def test_missing_marker_fails_when_sink_exhausted(self) -> None:
@@ -223,7 +303,9 @@ class TestInteractive:
             _task("x", interactive=True), "x", _ctx()
         )
         assert result.exit_code == 0
-        assert "<<FIN>>" in result.output
+        # Custom markers are stripped just like the default.
+        assert "<<FIN>>" not in result.output
+        assert "done" in result.output
 
     async def test_permission_routed_to_sink(self) -> None:
         sink = RecordingSink(perm_choice="allow")

--- a/tests/services/executor/test_prompt_sink.py
+++ b/tests/services/executor/test_prompt_sink.py
@@ -54,17 +54,76 @@ class TestTerminalPromptSink:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """User must see a clear break between streamed agent output and
-        the turn-over prompt; otherwise the '> ' gets glued onto the last
-        agent token."""
+        the turn-over prompt; otherwise the prompt gets glued onto the last
+        agent token. The styled "you" rule lives on its own line after a
+        compensating newline.
+        """
         stream = io.StringIO()
         sink = TerminalPromptSink(out=stream)
         await sink.display("agent finished mid-sentence")
         monkeypatch.setattr(builtins, "input", lambda _prompt="": "ok")
         await sink.request_input("reply?")
         rendered = stream.getvalue()
-        # A blank line separates the streamed text from the prompt.
-        assert "agent finished mid-sentence\n\n" in rendered
+        # The streamed agent text gets its own newline before the rule.
+        assert "agent finished mid-sentence\n" in rendered
+        # The styled "you" rule renders, followed by the prompt label.
+        assert "you" in rendered
         assert "reply?" in rendered
+        # The rule is not glued to the streamed text — its first glyph
+        # (the 👤 emoji) is on a new line.
+        before_rule = rendered.split("👤")[0]
+        assert before_rule.endswith("\n")
+
+    async def test_request_input_echoes_piped_reply(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Piped stdin doesn't echo keystrokes — the sink must echo the
+        consumed line back so scripted transcripts read like a real
+        terminal session."""
+        import sys as _sys
+        stream = io.StringIO()
+        sink = TerminalPromptSink(out=stream)
+        monkeypatch.setattr(builtins, "input", lambda _prompt="": "scripted reply")
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: False)
+        await sink.request_input("reply?")
+        rendered = stream.getvalue()
+        assert "scripted reply" in rendered
+        assert "you" in rendered  # styled rule label
+
+    async def test_request_input_does_not_double_echo_on_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the user is actually typing, the terminal already echoes
+        keystrokes — we must not write the answer back ourselves."""
+        import sys as _sys
+        stream = io.StringIO()
+        sink = TerminalPromptSink(out=stream)
+        monkeypatch.setattr(builtins, "input", lambda _prompt="": "typed live")
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+        await sink.request_input("reply?")
+        # The TTY branch must NOT print the answer; only the prompt label.
+        assert "typed live" not in stream.getvalue()
+
+    async def test_start_agent_turn_renders_styled_rule(self) -> None:
+        """The agent-turn marker must be a horizontal rule with the
+        'agent' label so the user can see when the agent starts speaking."""
+        stream = io.StringIO()
+        sink = TerminalPromptSink(out=stream)
+        await sink.start_agent_turn()
+        rendered = stream.getvalue()
+        assert "agent" in rendered
+        # A rule renders box-drawing horizontal characters.
+        assert "─" in rendered
+
+    async def test_start_agent_turn_separates_from_previous_stream(self) -> None:
+        """A turn rule must start on its own line, not glued to the
+        previous chunk of streamed agent text."""
+        stream = io.StringIO()
+        sink = TerminalPromptSink(out=stream)
+        await sink.display("trailing token without newline")
+        await sink.start_agent_turn()
+        rendered = stream.getvalue()
+        assert "trailing token without newline\n" in rendered
 
     async def test_request_permission_returns_selected_option_id(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,11 @@ def test_list_conduits(workdir):
     result = runner.invoke(app, ["list", "conduits"])
     assert result.exit_code == 0, result.output
     assert "hello" in result.output
-    assert "[project]" in result.output
+    # New table includes the source tag and column headers.
+    assert "project" in result.output
+    assert "name" in result.output
+    assert "tasks" in result.output
+    assert "inputs" in result.output
 
 
 GLOBAL_DEPLOY_YAML = """
@@ -71,11 +75,15 @@ def test_list_conduits_shows_global_and_shadowing(
     result = runner.invoke(app, ["list", "conduits"])
     assert result.exit_code == 0, result.output
     out = result.output
-    assert "deploy" in out and "[global]" in out
-    assert "hello" in out and "[project]" in out
-    # hello only appears once (shadowed, not duplicated)
-    hello_lines = [l for l in out.splitlines() if "hello" in l]
-    assert len(hello_lines) == 1
+    assert "deploy" in out and "global" in out
+    assert "hello" in out and "project" in out
+    # hello only appears once (shadowed, not duplicated). Match by row,
+    # i.e. lines containing the conduit name in the first column.
+    name_col_lines = [
+        l for l in out.splitlines()
+        if l.startswith("│") and "hello" in l.split("│")[1]
+    ]
+    assert len(name_col_lines) == 1
 
 
 def test_run_and_status(workdir):
@@ -101,6 +109,237 @@ def test_list_flows(workdir):
     result = runner.invoke(app, ["list", "flows"])
     assert result.exit_code == 0
     assert "hello_" in result.output
+    # New table-based output includes per-flow status and conduit columns.
+    assert "status" in result.output
+    assert "completed" in result.output
+    assert "duration" in result.output
+
+
+def test_status_includes_duration_and_summary(workdir):
+    runner = CliRunner()
+    run_result = runner.invoke(app, ["run", "hello", "--input", "name=a"])
+    line = [l for l in run_result.output.splitlines() if "flow_id" in l][0]
+    flow_id = line.split()[-1]
+    result = runner.invoke(app, ["status", flow_id])
+    assert result.exit_code == 0
+    assert "started=" in result.output
+    assert "duration=" in result.output
+    # Aggregate summary uses ✓ glyph for the completed task.
+    assert "✓" in result.output
+
+
+def test_run_prints_summary_footer(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "hello", "--input", "name=a"])
+    assert result.exit_code == 0, result.output
+    # Footer line: glyph(s) + total duration.
+    assert "✓1" in result.output
+    assert "total" in result.output
+
+
+# ---------------------------------------------------------------- logs cmd
+
+
+MULTI_CONDUIT_YAML = """
+name: multi
+description: multi-task
+tasks:
+  - alpha:
+      description: a
+      task: "echo alpha-output; echo alpha-err >&2"
+      tool: tool:bash
+      depends_on: []
+  - beta:
+      description: b
+      task: "echo beta-output"
+      tool: tool:bash
+      depends_on: [alpha]
+"""
+
+
+def _write_multi(workdir):
+    d = workdir / ".atelier" / "conduits" / "multi"
+    d.mkdir(parents=True)
+    (d / "conduit.yaml").write_text(MULTI_CONDUIT_YAML)
+
+
+def _run_and_id(runner, conduit, *args):
+    res = runner.invoke(app, ["run", conduit, *args])
+    line = [l for l in res.output.splitlines() if "flow_id" in l][0]
+    return line.split()[-1]
+
+
+def test_logs_unknown_flow(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["logs", "no_such_flow"])
+    assert result.exit_code != 0
+    assert "unknown flow" in result.output
+
+
+def test_logs_shows_task_output(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id])
+    assert result.exit_code == 0, result.output
+    assert "alpha" in result.output
+    assert "beta" in result.output
+    assert "alpha-output" in result.output
+    assert "beta-output" in result.output
+
+
+def test_logs_filter_by_task(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id, "--task", "alpha"])
+    assert result.exit_code == 0, result.output
+    assert "alpha-output" in result.output
+    assert "beta-output" not in result.output
+
+
+def test_logs_show_stderr(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id, "--task", "alpha", "--show", "stderr"])
+    assert result.exit_code == 0, result.output
+    assert "alpha-err" in result.output
+    # stdout body should be omitted in stderr-only mode.
+    assert "alpha-output" not in result.output
+
+
+def test_logs_unknown_task_filter(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id, "--task", "ghost"])
+    assert result.exit_code != 0
+    assert "no log entries" in result.output
+
+
+# ---------------------------------------------------------------- prefix match
+
+
+def test_status_accepts_short_prefix(workdir):
+    """git-style: a unique short prefix should resolve to the full flow id."""
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "hello", "--input", "name=a")
+    short = flow_id[: len(flow_id.split("_")[0]) + 5]  # conduit + 4 hex chars
+    result = runner.invoke(app, ["status", short])
+    assert result.exit_code == 0, result.output
+    assert "completed" in result.output
+
+
+def test_logs_accepts_short_prefix(workdir):
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "hello", "--input", "name=a")
+    short = flow_id[: len(flow_id.split("_")[0]) + 5]
+    result = runner.invoke(app, ["logs", short])
+    assert result.exit_code == 0, result.output
+    assert "greet" in result.output
+
+
+def test_status_ambiguous_prefix(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    # Two flows from the same conduit → "multi_" is ambiguous.
+    _run_and_id(runner, "multi")
+    _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["status", "multi_"])
+    assert result.exit_code != 0
+    assert "ambiguous" in result.output.lower()
+
+
+def test_status_prefix_no_match(workdir):
+    runner = CliRunner()
+    _run_and_id(runner, "hello", "--input", "name=a")
+    result = runner.invoke(app, ["status", "nope_"])
+    assert result.exit_code != 0
+    assert "unknown flow" in result.output
+
+
+# ---------------------------------------------------------------- --json mode
+
+
+import json as _json
+
+
+def test_list_flows_json(workdir):
+    runner = CliRunner()
+    _run_and_id(runner, "hello", "--input", "name=a")
+    result = runner.invoke(app, ["list", "flows", "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    entry = data[0]
+    for key in ("flow_id", "conduit", "status", "started_at", "finished_at",
+                "duration_seconds", "task_counts"):
+        assert key in entry
+    assert entry["conduit"] == "hello"
+    assert entry["status"] == "completed"
+    assert entry["task_counts"]["completed"] == 1
+
+
+def test_list_conduits_json(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["list", "conduits", "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert isinstance(data, list)
+    by_name = {e["name"]: e for e in data}
+    assert "hello" in by_name
+    assert by_name["hello"]["source"] == "project"
+    assert by_name["hello"]["tasks"] == 1
+
+
+def test_status_json(workdir):
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "hello", "--input", "name=a")
+    result = runner.invoke(app, ["status", flow_id, "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert data["flow_id"] == flow_id
+    assert data["status"] == "completed"
+    assert "tasks" in data and "greet" in data["tasks"]
+    assert data["tasks"]["greet"]["status"] == "completed"
+
+
+def test_logs_json(workdir):
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id, "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert isinstance(data, list)
+    tasks = [e["task"] for e in data]
+    assert "alpha" in tasks and "beta" in tasks
+    alpha = next(e for e in data if e["task"] == "alpha")
+    assert "alpha-output" in alpha["output"]
+
+
+# ---------------------------------------------------------------- --follow
+
+
+def test_logs_follow_on_completed_flow_exits(workdir):
+    """--follow on an already-terminal flow must print all entries and exit
+    on the first poll iteration (status != running)."""
+    _write_multi(workdir)
+    runner = CliRunner()
+    flow_id = _run_and_id(runner, "multi")
+    result = runner.invoke(app, ["logs", flow_id, "--follow"])
+    assert result.exit_code == 0, result.output
+    assert "alpha" in result.output
+    assert "beta" in result.output
+
+
+def test_logs_follow_unknown_flow(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["logs", "no_such_flow", "--follow"])
+    assert result.exit_code != 0
+    assert "unknown flow" in result.output
 
 
 def test_run_missing_input_fails(workdir):
@@ -110,6 +349,43 @@ def test_run_missing_input_fails(workdir):
     # will fail only because the template references a missing input.
     result = runner.invoke(app, ["run", "hello"])
     assert result.exit_code != 0
+
+
+FAILING_CONDUIT_YAML = """
+name: failing
+description: Always fails
+tasks:
+  - boom:
+      description: fail on purpose
+      task: "echo bye; exit 9"
+      tool: tool:bash
+      depends_on: []
+"""
+
+
+def test_run_failure_prints_flow_id_and_status_hint(tmp_path, monkeypatch):
+    """Failure output must include the flow_id and a next-step hint so
+    the user can inspect what happened. Previously the flow_id was only
+    printed on success, leaving failed runs un-inspectable.
+    """
+    atelier_dir = tmp_path / ".atelier"
+    (atelier_dir / "conduits" / "failing").mkdir(parents=True)
+    (atelier_dir / "conduits" / "failing" / "conduit.yaml").write_text(
+        FAILING_CONDUIT_YAML
+    )
+    monkeypatch.chdir(tmp_path)
+    for k in list(os.environ):
+        if k.startswith("ATELIER_") and k != "ATELIER_GLOBAL_ATELIER_DIR":
+            monkeypatch.delenv(k, raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "failing"])
+    assert result.exit_code != 0, result.output
+    assert "flow_id" in result.output
+    # Hint should point the user at how to investigate.
+    assert "atelier status" in result.output
+    # The id should match the failing_<...> shape.
+    assert "failing_" in result.output
 
 
 # ---------------------------------------------------------------- renderer
@@ -202,6 +478,49 @@ def test_render_failed_task_falls_back_to_stderr():
     assert "exit=1" in out
 
 
+def test_render_failed_task_shows_both_stdout_and_stderr():
+    """When a failure has both stdout and stderr, the panel must show
+    both — stderr is the most important diagnostic and was previously
+    hidden by `body_source = event.output or event.stderr`.
+    """
+    event = TaskEvent(
+        task="boom",
+        tool="tool:bash",
+        exit_code=7,
+        duration_seconds=0.01,
+        output="about to fail on stdout",
+        stdout="about to fail on stdout",
+        stderr="this is the actual error",
+        success=False,
+    )
+    out = _capture(event)
+    assert "about to fail on stdout" in out
+    assert "this is the actual error" in out
+    # Section labels make the split unambiguous to a human reader.
+    assert "stdout" in out.lower()
+    assert "stderr" in out.lower()
+
+
+def test_render_failed_task_with_only_output_does_not_label_sections():
+    """When only stdout/output is present (no stderr), keep the
+    existing single-body rendering — don't gratuitously add labels.
+    """
+    event = TaskEvent(
+        task="boom",
+        tool="tool:bash",
+        exit_code=2,
+        duration_seconds=0.02,
+        output="just some output",
+        stdout="just some output",
+        stderr="",
+        success=False,
+    )
+    out = _capture(event)
+    assert "just some output" in out
+    # No "stderr:" label since there's nothing to label.
+    assert "stderr:" not in out.lower()
+
+
 def test_render_truncates_long_output():
     long_out = "\n".join(f"line{i}" for i in range(100))
     event = TaskEvent(
@@ -217,6 +536,63 @@ def test_render_truncates_long_output():
     # First line of original data should be gone; tail lines present.
     assert "line0\n" not in out
     assert "line99" in out
+
+
+def test_render_live_streamed_task_is_compact():
+    """Interactive harness tasks already streamed their full transcript;
+    the after-the-fact panel should be a one-line summary, not a body.
+    """
+    event = TaskEvent(
+        task="ask_then_answer",
+        tool="harness:claude-code",
+        exit_code=0,
+        duration_seconds=12.5,
+        output="long multi-turn transcript that already streamed",
+        success=True,
+        live_streamed=True,
+    )
+    out = _capture(event)
+    assert "ask_then_answer" in out
+    assert "harness:claude-code" in out
+    assert "streamed live above" in out
+    # No box-drawing — compact line, not a panel.
+    assert "─" not in out
+    # Body content must NOT be re-rendered.
+    assert "long multi-turn transcript" not in out
+
+
+def test_render_skipped_task_shows_reason():
+    from app.schemas.progress import TaskStatus
+    event = TaskEvent(
+        task="deploy",
+        tool="tool:bash",
+        success=False,
+        status=TaskStatus.skipped,
+        reason="condition not met: review.output.match(APPROVE)",
+    )
+    out = _capture(event)
+    # One-line summary, not a panel.
+    assert "deploy" in out
+    assert "skipped" in out.lower()
+    assert "condition not met" in out
+    # No box-drawing characters — must be a compact line.
+    assert "─" not in out
+
+
+def test_render_cancelled_task_shows_reason():
+    from app.schemas.progress import TaskStatus
+    event = TaskEvent(
+        task="after",
+        tool="tool:bash",
+        success=False,
+        status=TaskStatus.cancelled,
+        reason="upstream failed",
+    )
+    out = _capture(event)
+    assert "after" in out
+    assert "cancelled" in out.lower()
+    assert "upstream failed" in out
+    assert "─" not in out
 
 
 def test_render_iteration_shown_when_repeat_gt_one():


### PR DESCRIPTION
## What

A focused UX rework of the `atelier` CLI. Fixes four critical bugs in the
live-render path, rebuilds the inspection commands as proper Rich tables,
adds the missing `atelier logs` command, and restyles the interactive
(HITL + multi-turn AI) experience so it shares the same visual language
as the rest of the CLI.

**One commit, +1373 / −120 across 11 files.** Tests: **122 → 153** (+31).

## Why

The CLI was usable but rough around the edges in ways that mattered for
opening this project up:

- **Several outright bugs** broke the user's mental model of what
  happened. Harness output rendered twice. `stderr` was hidden on
  failure. Tasks cancelled by fail-fast disappeared silently. On
  failure, the `flow_id` wasn't even printed, leaving no way to
  inspect what went wrong.
- **Inspection commands shipped as bare bullet lists** (`- demo_…`)
  with no status, no timestamps, no duration, no task summary. Useless
  for monitoring or scripting. Rich was already a dependency.
- **No `atelier logs` command at all** — the per-task `stdout` /
  `stderr` / `output` was only readable via `cat .atelier/flows/<id>/logs.json | jq`.
- **The interactive Q&A path looked alien** compared to the rest of
  the CLI: hand-drawn `─── your turn ───` dividers, no distinction
  between agent and user turns, no echo of piped replies, the
  `[ATELIER_DONE]` protocol marker leaking into user-visible output.

## Where (what changed and why each one)

### Critical bug fixes (live render & engine)

| File | Fix |
|---|---|
| `app/services/executor/harness.py` | Gate live streaming on `task.interactive`, so non-interactive runs no longer double-render the agent's text (live + panel). Also strip the done marker from `result.output` and per-chunk before live `display`. Add `start_agent_turn()` hook for interactive turn boundaries. |
| `app/main.py` (`_render_task_event`) | On failure, render `stdout` AND `stderr` as labelled sections (was hiding `stderr` whenever `stdout` was non-empty). Compact one-liner for `live_streamed` events to avoid duplicating just-streamed transcripts. |
| `app/modules/engine.py` | Emit synthetic `TaskEvent`s for `skipped` / `cancelled` tasks so they show up in the live render instead of disappearing. New `on_flow_started` callback so callers (the CLI) can surface `flow_id` even on failure. |
| `app/schemas/log.py` | `TaskEvent` gains `status`, `reason`, `live_streamed`. |
| `app/core/atelier.py` | Pass `on_flow_started` through to the engine. |

### CLI / inspection polish

| File | Change |
|---|---|
| `app/main.py` | `list flows` and `list conduits` rebuilt as Rich `Table`s (status, started, duration, task glyph summary, etc.). `flow_id` column uses `overflow="fold"` so the id stays selectable. `status` shows started + duration in the header, drops the empty `iteration` column, prints a trailing summary. New `atelier logs` command with `--task` / `--show output\|stdout\|stderr\|all` / `--last` / `--follow / -f` / `--json`. Aggregate footer line `✓N ✗N ⏭N ⊘N · total Ds` after every `run`. Git-style flow_id prefix matching (`atelier status demo_2a35`). `--json` output mode on every inspection command for scripting. Help text cleaned: `rich_markup_mode="rich"`, Sphinx `:param:` noise + literal RST double-backticks removed. |

### Interactive UX (HITL + multi-turn AI)

| File | Change |
|---|---|
| `app/services/executor/prompt_sink.py` | Rich `console.rule()` boundaries: `🤖 agent` (cyan) before each agent turn, `👤 you` (green) before the user's reply, `🔐 permission` for permission menus. Echoes the consumed reply as `› <answer>` when stdin is piped (non-TTY only). |
| `app/services/executor/hitl.py` | Same echo-on-piped-stdin so multi-input HITL prompts no longer smash together when scripted. |
| `app/services/executor/harness.py` | Calls `sink.start_agent_turn()` before each `conn.prompt(...)` in interactive mode. Strips done marker from both result and live stream. |

### Tests

11 test files updated; 31 new tests covering: stderr-on-failure
rendering, skip/cancel events, `on_flow_started` callback, prefix
matching, `--json` on every inspection command, `--follow` exit
semantics, marker stripping (live + result), `live_streamed` compact
rendering, agent-turn rules, and piped-stdin echo (TTY vs non-TTY
branches). All previous tests still pass.

## How was tested

Empirical end-to-end — every command was run against the fully-synced
`uv tool install`'d binary in a throwaway `/tmp/atelier-demo-…/`
working directory, with a real `harness:claude-code` ACP adapter
spawned via `npx`.

### Test 1 — happy path (4-task `demo` conduit)

Conduit:
```yaml
name: demo
description: 4-task demo to evaluate CLI output
max_concurrency: 3
inputs:
  topic: A short topic phrase
tasks:
  - facts:      { task: ..., tool: tool:bash, depends_on: [] }
  - count_tmp:  { task: ..., tool: tool:bash, depends_on: [] }
  - summarize:  { task: ..., tool: harness:claude-code, depends_on: [facts, count_tmp] }
  - finalize:   { task: ..., tool: tool:bash, depends_on: [summarize] }
```

Run:
```bash
$ atelier run demo --input topic="bloom filters"
╭─ ✓ count_tmp [tool:bash] ─...
╭─ ✓ facts [tool:bash] ─...
╭─ ✓ summarize [harness:claude-code] ─...
│ A Bloom filter is a space-efficient probabilistic data structure that ...
╭─ ✓ finalize [tool:bash] ─...
✓4  ·  total 11.5s
flow_id: demo_2a3515d6_20260417T205712Z
```

Confirms: parallel scheduling, no double-render of the harness output
(B1 fix), aggregate footer (M6), `flow_id` printed.

Tableified inspection commands:
```bash
$ atelier list flows --conduit demo
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃ flow_id          ┃ conduit ┃ status    ┃ started          ┃ duration ┃ tasks ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━┩
│ demo_2a3515d6... │ demo    │ completed │ 2026-04-17 15:57 │ 11.4s    │ ✓4    │
└──...
```

```bash
$ atelier status demo_2a35    # ← git-style prefix
flow demo_2a3515d6_…  status=completed  started=2026-04-17 15:57  duration=11.4s
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
┃ task      ┃ status    ┃ reason ┃
…
✓4
```

```bash
$ atelier logs demo_2a35 --task summarize
╭─ ✓ summarize [harness:claude-code] ─...
│ A Bloom filter is a space-efficient probabilistic data structure ...
╰──── 2026-04-17 15:57  ·  exit=0  ·  11.386s ─╯
```

```bash
$ atelier status demo_2a35 --json | jq .duration_seconds
11.437681
```

### Test 2 — failure path (`fail_demo`)

```bash
$ atelier run fail_demo
╭─ ✓ step_one [tool:bash] ─...
╭─ ✗ step_two [tool:bash] ─...
│ stdout:
│ about to fail on stdout
│
│ stderr:
│ this is the stderr message
╰──── exit=7 · 0.014s ─╯
⊘ step_three [tool:bash]  cancelled  (upstream failed)
✓1  ✗1  ⊘1  ·  total 0.03s
flow failed: task 'step_two' failed: exit=7 stderr=this is the stderr message
flow_id: fail_demo_e0970b91_20260417T204456Z
→ atelier status fail_demo_e0970b91_20260417T204456Z
```

Confirms: B2 (stderr now shown alongside stdout in failure panels),
B3 (cancelled task no longer disappears — gets a one-line `⊘ cancelled`
summary), B4 (`flow_id` + next-step hint printed on failure).

### Test 3 — interactive HITL (scripted stdin)

```yaml
# hitl_demo conduit excerpt
- ask_user:
    tool: tool:hitl
    inputs:
      name: Your name
      food: Your favorite food
- greet:
    task: "echo 'Hello {{inputs.name}} — enjoy your {{inputs.food}}!'"
    tool: tool:bash
    depends_on: [ask_user]
```

```bash
$ printf 'luis\ntacos\n' | atelier run hitl_demo
Hi! I need two details before continuing.
[hitl] Task 'ask_user' needs the following inputs:

  name (Your name): luis
  food (Your favorite food): tacos
╭─ ✓ ask_user [tool:hitl] ─...
│ name: luis
│ food: tacos
╭─ ✓ greet [tool:bash] ─...
│ Hello luis — enjoy your tacos!
✓2  ·  total 0.01s
```

Confirms: piped HITL replies are echoed back so prompts no longer smash
(Fix E); answers correctly templated into the downstream task; persisted
to `input.yaml`.

### Test 4 — interactive AI Q&A (multi-turn, scripted reply)

A conduit instructing Claude to ask one clarifying question, wait, then
answer. Reply piped via `echo`:

```bash
$ echo "I am an experienced Python dev with no systems programming background." \
    | atelier run hitl_ai_demo

🤖 agent ───────────────────────────────────────────────────────────────────────
What is your current programming experience — are you a complete beginner, or do you already know languages like C, C++, Python, or similar?
👤 you ─────────────────────────────────────────────────────────────────────────
agent is waiting for your reply:
› I am an experienced Python dev with no systems programming background.

🤖 agent ───────────────────────────────────────────────────────────────────────
Start with the official *Rust Book* (rust-lang.org/book) since it's kept up to date and carefully explains ownership and borrowing — the concepts that trip up most Python devs ...

✓ clarify_then_answer [harness:claude-code]  exit=0 · 16.834s  (streamed live above)
✓1  ·  total 16.8s
```

Confirms: turn boundaries rendered as styled rules (Fix D),
`[ATELIER_DONE]` no longer leaks anywhere (Fix A + A′), final panel is
a compact one-liner instead of duplicating the streamed transcript
(Fix C), piped reply echoes as `› <answer>` so the transcript is
readable end-to-end.

## Test plan (reviewer)

- [x] `uv sync && uv run pytest` (153 passing, no regressions)
- [x] `atelier init && atelier run hello --input name=world` — verify panels + footer + `flow_id`
- [x] `atelier list flows` and `atelier list conduits` — tables, not bullets
- [x] `atelier status <flow-id-prefix>` — prefix matching, header includes started + duration
- [x] `atelier logs <flow-id> --task <task> --show all` — panels include stdout + stderr labels
- [x] `atelier list flows --json | jq` — parseable JSON with `task_counts`
- [x] Failure path: a conduit with a non-zero-exit `tool:bash` task should print stderr in the panel, render cancelled downstream tasks as `⊘ ... cancelled`, print `flow_id` + `→ atelier status` hint on failure
- [x] Interactive HITL: `printf 'a\nb\n' | atelier run <hitl-conduit>` — answers echo on their own lines, downstream `{{inputs.x}}` resolves
- [x] Interactive harness: pipe a reply for a multi-turn conduit — see `🤖 agent` / `👤 you` rules, `› <reply>` echo, no `[ATELIER_DONE]` visible

## Out of scope (deferred)

- `status --follow` (Rich-Live based)
- Wall-clock timestamps in live `_render_task_event` panel subtitles
- Concurrent harness output prefixing (only matters when running >1
  harness in parallel)
- `--input @file.json` for big inputs
- `--quiet` / `--verbose` global flags
- Persisted `logs.json` doesn't yet record turn boundaries / user replies
  for multi-turn interactive sessions (live UI does, only the log is flat)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `logs` command for viewing flow logs with filtering, following, and JSON output options.
  * Added JSON output support (`--json`) to `status`, `list flows`, and `list conduits` commands.
  * Introduced live streaming of task output during interactive execution.
  * Enhanced task status tracking with support for skipped and cancelled tasks.

* **Improvements**
  * Richer table formatting and visual styling for CLI output.
  * Better stderr/stdout handling in task output display.
  * Flow ID prefix resolution for `status` and `logs` commands.
  * Improved input echoing for non-TTY environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->