### PR TITLE
Feature/more harness support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,17 @@
 # JSON array. Empty (default) uses: ["npx","-y","@zed-industries/codex-acp@0.11.1"]
 # ATELIER_CODEX_LAUNCH_CMD=["npx","-y","@zed-industries/codex-acp@0.11.1"]
 
+# Override the argv used to launch the harness:opencode ACP agent.
+# JSON array. Empty (default) uses: ["opencode","acp"]
+# ATELIER_OPENCODE_LAUNCH_CMD=["opencode","acp"]
+
+# Override the argv used to launch the harness:copilot ACP agent.
+# JSON array. Empty (default) uses: ["copilot","--acp"]
+# ATELIER_COPILOT_LAUNCH_CMD=["copilot","--acp"]
+
+# Override the argv used to launch the harness:cursor ACP agent.
+# JSON array. Empty (default) uses: ["npx","-y","@blowmage/cursor-agent-acp@0.7.1"]
+# ATELIER_CURSOR_LAUNCH_CMD=["npx","-y","@blowmage/cursor-agent-acp@0.7.1"]
+
 # Token the harness looks for in interactive mode. Default: [ATELIER_DONE]
 # ATELIER_DONE_MARKER=[ATELIER_DONE]

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ wheels/
 .venv*
 .claude
 .atelier
-
+.devtool
+claude.md
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DAG-based workflows called **conduits**. A single run of a conduit is a
 **flow**. Tasks whose dependencies are satisfied run concurrently via
 `asyncio`, subject to a conduit-level concurrency cap.
 
-Each task is dispatched to one of five executors:
+Each task is dispatched to one of eight executors:
 
 | Tool                  | What it runs                                                     |
 |-----------------------|------------------------------------------------------------------|
@@ -14,13 +14,15 @@ Each task is dispatched to one of five executors:
 | `tool:conduit`        | another conduit, as a nested flow                                |
 | `harness:claude-code` | Claude Code via the [ACP](https://agentclientprotocol.com) adapter |
 | `harness:codex`       | OpenAI Codex via the ACP adapter                                 |
+| `harness:opencode`    | [opencode](https://opencode.ai) via native `opencode acp`        |
+| `harness:copilot`     | GitHub Copilot CLI via native `copilot --acp`                    |
+| `harness:cursor`      | Cursor CLI via the `@blowmage/cursor-agent-acp` adapter          |
 
 Harnesses speak the **Agent Client Protocol** (ACP) over stdio, so they
 get real bidirectional interaction: the agent can ask for permission, ask
 the user a free-form question mid-turn, or run a multi-turn conversation.
-Both harnesses reuse your existing local CLI configuration — project-level
-`.claude/settings.json`, skills, subagents, hooks, MCP servers, CLAUDE.md
-(for claude) and `~/.codex/config.toml`, auth, AGENTS.md (for codex).
+Each harness reuses the host CLI's own local configuration and auth —
+flow-atelier does not read, write, or proxy any of it.
 
 In `interactive: true` mode, flow-atelier keeps the session open across
 turns: if the agent ends a turn without emitting the `[ATELIER_DONE]`
@@ -59,22 +61,38 @@ also works.
 
 ### Harness prerequisites
 
-`harness:claude-code` and `harness:codex` launch ACP adapters published
-by Zed via `npx`, so you need:
+You only need the prerequisites for the harness(es) you actually plan
+to use. A user who only wants `harness:opencode` does not need `claude`,
+`codex`, `copilot`, or `cursor-agent` installed, and so on.
 
-- **Node.js / `npx`** on your PATH.
-- An authenticated Claude Code and/or Codex setup on this machine (the
-  adapters reuse your `~/.claude` and `~/.codex` configuration, including
-  auth, settings, skills, MCP servers, CLAUDE.md, and AGENTS.md).
+- **`harness:claude-code`** — Node.js / `npx` on PATH, plus an
+  authenticated `claude` setup (`~/.claude`, skills, subagents, hooks,
+  MCP servers, CLAUDE.md). On first use `npx` downloads
+  `@zed-industries/claude-code-acp`.
+- **`harness:codex`** — Node.js / `npx` on PATH, plus an authenticated
+  `codex` setup (`~/.codex/config.toml`, auth, AGENTS.md). On first use
+  `npx` downloads `@zed-industries/codex-acp`.
+- **`harness:opencode`** — the `opencode` binary on PATH; ACP is
+  native. As an alternative, an npm-published adapter like
+  `josephschmitt/opencode-acp` can be swapped in via
+  `ATELIER_OPENCODE_LAUNCH_CMD` if you prefer an `npx`-launched flow
+  without a local `opencode` install.
+- **`harness:copilot`** — the `copilot` binary on PATH, from the
+  `@github/copilot` npm package (public preview as of Jan 2026). ACP
+  is native via `copilot --acp`.
+- **`harness:cursor`** — Node.js / `npx` on PATH, plus the
+  `cursor-agent` binary on PATH (the community npm adapter
+  `@blowmage/cursor-agent-acp` is pinned exactly at `0.7.1` and shells
+  out to `cursor-agent`).
 
-On first use `npx` will download and cache the adapter packages:
-
-- `@zed-industries/claude-code-acp`
-- `@zed-industries/codex-acp`
+Each harness reuses its host CLI's own config and auth — flow-atelier
+does not hard-code paths to, or proxy, any of that state.
 
 To pin a custom version or point at a locally installed adapter, set
-`ATELIER_CLAUDE_LAUNCH_CMD` / `ATELIER_CODEX_LAUNCH_CMD` to a JSON array
-of argv (see `.env.example`).
+the matching `ATELIER_*_LAUNCH_CMD` env var to a JSON array of argv:
+`ATELIER_CLAUDE_LAUNCH_CMD`, `ATELIER_CODEX_LAUNCH_CMD`,
+`ATELIER_OPENCODE_LAUNCH_CMD`, `ATELIER_COPILOT_LAUNCH_CMD`, or
+`ATELIER_CURSOR_LAUNCH_CMD` (see `.env.example`).
 
 ## Quick start
 

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -9,7 +9,13 @@ from app.modules.engine import Engine, FlowStartedCallback, TaskEventCallback
 from app.schemas.progress import Progress
 from app.services.executor.bash import BashExecutor
 from app.services.executor.conduit import ConduitExecutor
-from app.services.executor.harness import ClaudeHarness, CodexHarness
+from app.services.executor.harness import (
+    ClaudeHarness,
+    CodexHarness,
+    CopilotHarness,
+    CursorHarness,
+    OpencodeHarness,
+)
 from app.services.executor.hitl import HitlExecutor
 from app.services.executor.prompt_sink import PromptSink, TerminalPromptSink
 from app.services.store.filesystem import FilesystemStore
@@ -49,6 +55,9 @@ class Atelier:
             self.settings.claude_launch_cmd or None
         )
         codex_launch = self.settings.codex_launch_cmd or None
+        opencode_launch = self.settings.opencode_launch_cmd or None
+        copilot_launch = self.settings.copilot_launch_cmd or None
+        cursor_launch = self.settings.cursor_launch_cmd or None
         self.executors = {
             "tool:bash": BashExecutor(),
             "tool:hitl": HitlExecutor(),
@@ -61,6 +70,21 @@ class Atelier:
             "harness:codex": CodexHarness(
                 sink=sink,
                 launch_cmd=codex_launch,
+                done_marker=self.settings.done_marker,
+            ),
+            "harness:opencode": OpencodeHarness(
+                sink=sink,
+                launch_cmd=opencode_launch,
+                done_marker=self.settings.done_marker,
+            ),
+            "harness:copilot": CopilotHarness(
+                sink=sink,
+                launch_cmd=copilot_launch,
+                done_marker=self.settings.done_marker,
+            ),
+            "harness:cursor": CursorHarness(
+                sink=sink,
+                launch_cmd=cursor_launch,
                 done_marker=self.settings.done_marker,
             ),
         }

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -41,4 +41,25 @@ class AtelierSettings(BaseSettings):
             "Empty = use the bundled default (@zed-industries/codex-acp)."
         ),
     )
+    opencode_launch_cmd: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Override argv for the harness:opencode ACP agent. "
+            "Empty = use the bundled default (opencode acp)."
+        ),
+    )
+    copilot_launch_cmd: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Override argv for the harness:copilot ACP agent. "
+            "Empty = use the bundled default (copilot --acp)."
+        ),
+    )
+    cursor_launch_cmd: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Override argv for the harness:cursor ACP agent. "
+            "Empty = use the bundled default (@blowmage/cursor-agent-acp)."
+        ),
+    )
     done_marker: str = "[ATELIER_DONE]"

--- a/app/schemas/conduit.py
+++ b/app/schemas/conduit.py
@@ -13,6 +13,9 @@ class ToolType(str, Enum):
     conduit = "tool:conduit"
     claude = "harness:claude-code"
     codex = "harness:codex"
+    opencode = "harness:opencode"
+    copilot = "harness:copilot"
+    cursor = "harness:cursor"
 
 
 class HitlInput(BaseModel):

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -1,10 +1,13 @@
-"""Harness executors — harness:claude-code and harness:codex over ACP.
+"""Harness executors — five ACP-speaking coding agents.
 
-Both harnesses speak the Agent Client Protocol (ACP) via Zed's adapter
-binaries, launched through ``npx`` by default:
+Each harness is a thin :class:`AcpHarnessExecutor` subclass differing only
+in its ``launch_cmd``. Each reuses the host CLI's own config and auth.
 
-- ``harness:claude-code`` → ``@zed-industries/claude-code-acp``
-- ``harness:codex``       → ``@zed-industries/codex-acp``
+- ``harness:claude-code`` → ``@zed-industries/claude-code-acp`` via ``npx``
+- ``harness:codex``       → ``@zed-industries/codex-acp`` via ``npx``
+- ``harness:opencode``    → ``opencode acp`` (native ACP)
+- ``harness:copilot``     → ``copilot --acp`` (GitHub Copilot CLI, native ACP)
+- ``harness:cursor``      → ``@blowmage/cursor-agent-acp`` via ``npx``
 
 Non-interactive mode sends one prompt turn and returns whatever the agent
 streams before ``stop_reason``. Interactive mode keeps the session open

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -51,6 +51,13 @@ CODEX_ACP_LAUNCH = [
     "-y",
     "@zed-industries/codex-acp@0.11.1",
 ]
+OPENCODE_ACP_LAUNCH = ["opencode", "acp"]
+COPILOT_ACP_LAUNCH = ["copilot", "--acp"]
+CURSOR_ACP_LAUNCH = [
+    "npx",
+    "-y",
+    "@blowmage/cursor-agent-acp@0.7.1",
+]
 
 
 def build_interactive_suffix(marker: str) -> str:
@@ -405,6 +412,54 @@ class CodexHarness(AcpHarnessExecutor):
     ) -> None:
         super().__init__(
             launch_cmd=launch_cmd or list(CODEX_ACP_LAUNCH),
+            sink=sink,
+            done_marker=done_marker,
+        )
+
+
+class OpencodeHarness(AcpHarnessExecutor):
+    """`harness:opencode` — drives ``opencode acp`` (native ACP)."""
+
+    def __init__(
+        self,
+        sink: PromptSink | None = None,
+        launch_cmd: list[str] | None = None,
+        done_marker: str | None = None,
+    ) -> None:
+        super().__init__(
+            launch_cmd=launch_cmd or list(OPENCODE_ACP_LAUNCH),
+            sink=sink,
+            done_marker=done_marker,
+        )
+
+
+class CopilotHarness(AcpHarnessExecutor):
+    """`harness:copilot` — drives ``copilot --acp`` (GitHub Copilot CLI)."""
+
+    def __init__(
+        self,
+        sink: PromptSink | None = None,
+        launch_cmd: list[str] | None = None,
+        done_marker: str | None = None,
+    ) -> None:
+        super().__init__(
+            launch_cmd=launch_cmd or list(COPILOT_ACP_LAUNCH),
+            sink=sink,
+            done_marker=done_marker,
+        )
+
+
+class CursorHarness(AcpHarnessExecutor):
+    """`harness:cursor` — drives the ``@blowmage/cursor-agent-acp`` adapter via npx."""
+
+    def __init__(
+        self,
+        sink: PromptSink | None = None,
+        launch_cmd: list[str] | None = None,
+        done_marker: str | None = None,
+    ) -> None:
+        super().__init__(
+            launch_cmd=launch_cmd or list(CURSOR_ACP_LAUNCH),
             sink=sink,
             done_marker=done_marker,
         )

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -102,6 +102,30 @@ def test_duplicate_task_names_rejected():
         )
 
 
+@pytest.mark.parametrize(
+    "tool_str",
+    ["harness:opencode", "harness:copilot", "harness:cursor"],
+)
+def test_new_harness_tool_strings_validate(tool_str):
+    c = Conduit.model_validate(
+        {
+            "name": "x",
+            "description": "d",
+            "tasks": [
+                {
+                    "t": {
+                        "description": "d",
+                        "task": "hi",
+                        "tool": tool_str,
+                        "depends_on": [],
+                    }
+                }
+            ],
+        }
+    )
+    assert c.tasks[0].tool.value == tool_str
+
+
 def test_repeat_must_be_positive():
     with pytest.raises(Exception):
         Conduit.model_validate(

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -14,6 +14,10 @@ from app.services.executor.harness import (
     DEFAULT_DONE_MARKER,
     AcpHarnessExecutor,
     ClaudeHarness,
+    CodexHarness,
+    CopilotHarness,
+    CursorHarness,
+    OpencodeHarness,
     build_interactive_suffix,
 )
 from app.services.executor.prompt_sink import PermissionOption
@@ -345,6 +349,85 @@ class TestPreset:
     def test_claude_harness_override_launch_cmd(self) -> None:
         h = ClaudeHarness(sink=RecordingSink(), launch_cmd=["foo", "bar"])
         assert h.launch_cmd == ["foo", "bar"]
+
+    def test_codex_harness_default_launch_cmd(self) -> None:
+        h = CodexHarness(sink=RecordingSink())
+        assert "codex-acp" in " ".join(h.launch_cmd)
+
+    def test_opencode_harness_default_launch_cmd(self) -> None:
+        h = OpencodeHarness(sink=RecordingSink())
+        assert h.launch_cmd == ["opencode", "acp"]
+
+    def test_opencode_harness_override_launch_cmd(self) -> None:
+        h = OpencodeHarness(sink=RecordingSink(), launch_cmd=["foo", "bar"])
+        assert h.launch_cmd == ["foo", "bar"]
+
+    def test_copilot_harness_default_launch_cmd(self) -> None:
+        h = CopilotHarness(sink=RecordingSink())
+        assert h.launch_cmd == ["copilot", "--acp"]
+
+    def test_copilot_harness_override_launch_cmd(self) -> None:
+        h = CopilotHarness(sink=RecordingSink(), launch_cmd=["foo", "bar"])
+        assert h.launch_cmd == ["foo", "bar"]
+
+    def test_cursor_harness_default_launch_cmd(self) -> None:
+        h = CursorHarness(sink=RecordingSink())
+        assert h.launch_cmd == [
+            "npx",
+            "-y",
+            "@blowmage/cursor-agent-acp@0.7.1",
+        ]
+
+    def test_cursor_harness_override_launch_cmd(self) -> None:
+        h = CursorHarness(sink=RecordingSink(), launch_cmd=["foo", "bar"])
+        assert h.launch_cmd == ["foo", "bar"]
+
+
+class TestAtelierHarnessWiring:
+    def test_atelier_exposes_all_five_harness_keys(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        from app.core.atelier import Atelier
+
+        a = Atelier()
+        assert sorted(a.executors) == [
+            "harness:claude-code",
+            "harness:codex",
+            "harness:copilot",
+            "harness:cursor",
+            "harness:opencode",
+            "tool:bash",
+            "tool:conduit",
+            "tool:hitl",
+        ]
+        assert isinstance(a.executors["harness:opencode"], OpencodeHarness)
+        assert isinstance(a.executors["harness:copilot"], CopilotHarness)
+        assert isinstance(a.executors["harness:cursor"], CursorHarness)
+
+    def test_opencode_launch_cmd_env_override(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ATELIER_OPENCODE_LAUNCH_CMD", '["x","y"]')
+        from app.core.atelier import Atelier
+
+        a = Atelier()
+        assert a.executors["harness:opencode"].launch_cmd == ["x", "y"]
+
+    def test_copilot_launch_cmd_env_override(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ATELIER_COPILOT_LAUNCH_CMD", '["x","y"]')
+        from app.core.atelier import Atelier
+
+        a = Atelier()
+        assert a.executors["harness:copilot"].launch_cmd == ["x", "y"]
+
+    def test_cursor_launch_cmd_env_override(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ATELIER_CURSOR_LAUNCH_CMD", '["x","y"]')
+        from app.core.atelier import Atelier
+
+        a = Atelier()
+        assert a.executors["harness:cursor"].launch_cmd == ["x", "y"]
 
 
 def test_default_marker_constant() -> None:


### PR DESCRIPTION
# Add `harness:opencode`, `harness:copilot`, `harness:cursor`

## What

Three new ACP-speaking harnesses, alongside the existing `harness:claude-code`
and `harness:codex`:

| Tool key            | Backing agent / adapter                                          |
|---------------------|------------------------------------------------------------------|
| `harness:opencode`  | [opencode](https://opencode.ai) — native `opencode acp`          |
| `harness:copilot`   | GitHub Copilot CLI — native `copilot --acp` (public preview)     |
| `harness:cursor`    | Cursor CLI (`cursor-agent`) via `@blowmage/cursor-agent-acp@0.7.1` (pinned) |

Touched in this branch:

- `app/services/executor/harness.py` — three new `AcpHarnessExecutor` subclasses
  (`OpencodeHarness`, `CopilotHarness`, `CursorHarness`) plus their
  `*_ACP_LAUNCH` default launch constants. Module docstring refreshed to
  describe the five-backend lineup.
- `app/schemas/conduit.py` — `ToolType` gains `opencode`, `copilot`, `cursor`
  members so conduit YAML using `tool: harness:<new>` validates.
- `app/core/settings.py` — three new `*_launch_cmd` fields with the same
  JSON-array env-var parsing as the existing two.
- `app/core/atelier.py` — registers the three new executors in
  `Atelier.executors`.
- `.env.example` — documents `ATELIER_OPENCODE_LAUNCH_CMD`,
  `ATELIER_COPILOT_LAUNCH_CMD`, `ATELIER_CURSOR_LAUNCH_CMD`.
- `README.md` — tool table, prerequisites split per-harness, env-override
  paragraph names all five variables.
- `tests/services/executor/test_harness.py` and
  `tests/schemas/test_schemas.py` — default/override launch-cmd assertions,
  five-harness executor-map membership, env-override propagation, and YAML
  validation for each new tool string.
- `.gitignore` — adds `.devtool`, `claude.md`, `.pytest_cache` (incidental dev
  hygiene; not part of the feature).

## Why

flow-atelier already multiplexes ACP-speaking coding agents. Each new harness
is essentially a different `launch_cmd` for the existing `AcpHarnessExecutor` —
no protocol work, no architectural change. Adding these three unlocks
opencode's plan/agent modes, GitHub Copilot's CLI agent, and Cursor's CLI
agent for users who already have those tools installed locally, while keeping
each tool's own config, auth, and tool-permission flow intact.

Slight shift from the existing two harnesses: claude-code and codex use Zed's
`npx`-launched adapters that bundle their SDKs, so users only need the
relevant `~/.claude` / `~/.codex` config dir. opencode and copilot use the
host CLI's *own* native ACP mode, so the binary must be on PATH. Cursor is
similar to the existing pattern but via a community adapter, pinned to
`@blowmage/cursor-agent-acp@0.7.1` (no caret/tilde/latest) for reproducibility.
The README spells out per-harness prerequisites so users with only one of
the three new tools installed aren't confused by missing binaries for the
others.

## How

Each new harness is a thin subclass of `AcpHarnessExecutor` — ~15 lines —
following the exact shape of `ClaudeHarness` / `CodexHarness`:

```python
OPENCODE_ACP_LAUNCH = ["opencode", "acp"]
COPILOT_ACP_LAUNCH  = ["copilot", "--acp"]
CURSOR_ACP_LAUNCH   = ["npx", "-y", "@blowmage/cursor-agent-acp@0.7.1"]


class OpencodeHarness(AcpHarnessExecutor):
    def __init__(self, sink=None, launch_cmd=None, done_marker=None):
        super().__init__(
            launch_cmd=launch_cmd or list(OPENCODE_ACP_LAUNCH),
            sink=sink,
            done_marker=done_marker,
        )
# CopilotHarness, CursorHarness follow the same pattern.
```

No edits to `AcpHarnessExecutor` itself, no registry, no factory. Settings,
atelier wiring, and tests follow the same per-harness pattern that already
exists for claude-code and codex, just extended from two to five entries.

`ToolType` enum is extended in `app/schemas/conduit.py` so pydantic accepts
`tool: harness:opencode` (and the other two) in conduit YAML — without this,
a valid launch command would still fail validation at parse time.

### Verification

- `uv run pytest` — full suite green.
- `uv run pytest tests/services/executor/test_harness.py -v` — per-harness
  default + override + env-override coverage.
- Live smoke (manual, not part of CI) — invoke each new tool key against a
  trivial conduit when the corresponding binary is on PATH.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new code execution providers: Opencode, Copilot, and Cursor, available alongside existing options.
  * New environment variables enable customization of launch commands for all harnesses.

* **Documentation**
  * Updated documentation with expanded executor options and per-provider setup instructions.

* **Chores**
  * Updated example configuration and development tool settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->