### PR TITLE
Add YAML-driven conduit scheduler with cross-platform daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,71 @@ atelier run <conduit> [--input key=value ...]
 atelier status <flow_id>
 atelier list conduits
 atelier list flows [--conduit <name>]
+
+# scheduler
+atelier schedule add <file.yaml> [--force]
+atelier schedule list [--json]
+atelier schedule remove <name>
+atelier schedule run-now <name>
+atelier scheduler start [--reload-interval 30] [--log-level INFO]
+atelier scheduler status [--json]
 ```
+
+## Scheduler
+
+`atelier scheduler` runs conduits on a wall-clock schedule. Schedules are
+defined as YAML files under `.atelier/schedules/`. The daemon
+(`atelier scheduler start`) is a single foreground asyncio process that
+fires conduits identically on Linux, macOS, and Windows — put it under
+your preferred supervisor (`systemd --user`, `launchd`, NSSM, etc.).
+
+Each schedule's filename stem is its canonical name. Two schedule modes
+are supported: **once** and **recurring**.
+
+```yaml
+# .atelier/schedules/nightly-report.yaml — recurring
+conduit: report                 # required
+working_dir: ./projects/foo     # optional; default = scheduler's cwd
+inputs:
+  date: today
+  region: us-east
+timezone: America/Bogota        # optional; default = system local zone
+schedule:
+  type: recurring
+  days: [mon, tue, wed, thu, fri]   # mon..sun, monday..sunday, 0..6, '*' / 'daily'
+  hours: ["09:00", "17:30"]         # HH:MM (24h); fires once per (day × hour) pair
+```
+
+```yaml
+# .atelier/schedules/backfill-april.yaml — one-shot
+conduit: backfill
+inputs:
+  month: "2026-04"
+schedule:
+  type: once
+  at: 2026-05-01T09:00:00       # ISO 8601; tz-aware suffix optional
+```
+
+Behavior notes:
+
+- **Timezone** defaults to the host's local zone (`tzlocal`); per-schedule
+  `timezone:` overrides it. Naive `at:` values are interpreted in the
+  resolved zone.
+- **Working directory** is where the conduit lives and where its flow
+  artefacts are written (`<working_dir>/.atelier/flows/...`). Relative
+  paths resolve against the daemon's cwd. Conduits resolve via the same
+  project/global scope rules as `atelier run`.
+- **Hot reload**: edits to `.atelier/schedules/*.yaml` are picked up on
+  the next reload tick (`--reload-interval`, default 30s). Broken YAML
+  files are logged but never crash the daemon.
+- **One-shot deduplication**: after a `once` schedule fires, its
+  scheduled timestamp is recorded in `.atelier/schedules/.state.json`
+  so a daemon restart never re-runs it. Edit the YAML to a new `at:`
+  to re-arm.
+- **Concurrency**: each schedule runs at most one instance at a time
+  (`max_instances=1`); missed fires are coalesced.
+- `atelier schedule run-now <name>` dispatches a schedule immediately
+  without going through the daemon and without touching fired-state.
 
 ## Conduit reference
 
@@ -330,6 +394,9 @@ invoked.
 .atelier/
 ├── conduits/
 │   └── <conduit_name>/conduit.yaml
+├── schedules/
+│   ├── <schedule_name>.yaml             # one ScheduleDefinition per file
+│   └── .state.json                      # fired-once markers (managed by the daemon)
 └── flows/
     └── <flow_id>/                       # <conduit>_<uuid8>_<YYYYMMDDTHHMMSSZ>
         ├── input.yaml

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -24,6 +24,21 @@ class AtelierSettings(BaseSettings):
     global_atelier_dir: Path = Field(
         default_factory=lambda: Path.home() / ".atelier",
         description="Global directory holding shared conduits/ (no flows).",
+    )
+    schedules_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Directory holding schedule YAML files. "
+            "Defaults to ``<atelier_dir>/schedules`` when unset."
+        ),
+    )
+    scheduler_state_path: Path | None = Field(
+        default=None,
+        description=(
+            "JSON file recording fired one-shot schedules so they don't "
+            "re-fire across daemon restarts. Defaults to "
+            "``<schedules_dir>/.state.json`` when unset."
+        ),
     )
     default_timeout: int = 3600
     default_max_concurrency: int = 3
@@ -63,3 +78,11 @@ class AtelierSettings(BaseSettings):
         ),
     )
     done_marker: str = "[ATELIER_DONE]"
+
+    @model_validator(mode="after")
+    def _resolve_scheduler_paths(self) -> "AtelierSettings":
+        if self.schedules_dir is None:
+            self.schedules_dir = self.atelier_dir / "schedules"
+        if self.scheduler_state_path is None:
+            self.scheduler_state_path = self.schedules_dir / ".state.json"
+        return self

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from collections import Counter
 from datetime import datetime
@@ -15,9 +16,17 @@ from rich.table import Table
 from rich.text import Text
 
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.schemas.flow import parse_flow_id
 from app.schemas.log import TaskEvent
 from app.schemas.progress import FlowStatus, Progress, TaskStatus
+from app.services.scheduler import (
+    PlannedJob,
+    ScheduleStore,
+    SchedulerDaemon,
+    compute_planned_view,
+    default_local_zone,
+)
 
 HELLO_CONDUIT_YAML = """name: hello
 description: Say hello
@@ -42,6 +51,20 @@ list_app = typer.Typer(
     rich_markup_mode="rich",
 )
 app.add_typer(list_app, name="list")
+
+schedule_app = typer.Typer(
+    help="Manage scheduled conduit runs (YAML files in .atelier/schedules/).",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+app.add_typer(schedule_app, name="schedule")
+
+scheduler_app = typer.Typer(
+    help="Run and inspect the scheduler daemon.",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+app.add_typer(scheduler_app, name="scheduler")
 
 console = Console()
 
@@ -761,6 +784,222 @@ def list_flows_cmd(
             _task_status_summary(progress),
         )
     console.print(table)
+
+
+# ---------------------------------------------------------------- schedule / scheduler
+
+
+def _schedule_store() -> ScheduleStore:
+    settings = AtelierSettings()
+    return ScheduleStore(
+        settings.schedules_dir,
+        state_path=settings.scheduler_state_path,
+    )
+
+
+def _format_next_fire(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    return value.astimezone().strftime("%Y-%m-%d %H:%M %Z").strip()
+
+
+def _render_planned_table(planned: list[PlannedJob]) -> Table:
+    table = Table("name", "conduit", "kind", "next fire", "working_dir")
+    for p in planned:
+        kind_style = "cyan" if p.schedule_kind == "recurring" else "magenta"
+        next_cell = _format_next_fire(p.next_fire_time)
+        if p.next_fire_time is None and p.schedule_kind == "once":
+            next_cell = "[dim](already fired)[/dim]"
+        table.add_row(
+            p.name,
+            p.conduit,
+            f"[{kind_style}]{p.schedule_kind}[/{kind_style}]",
+            next_cell,
+            str(p.working_dir),
+        )
+    return table
+
+
+@schedule_app.command(
+    "add",
+    help="Install a schedule YAML into .atelier/schedules/.",
+)
+def schedule_add_cmd(
+    file: Path = typer.Argument(
+        ..., exists=True, dir_okay=False, readable=True,
+        help="Path to a schedule YAML file."
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f",
+        help="Overwrite if a schedule with this name already exists."
+    ),
+) -> None:
+    """Validate and copy a schedule YAML into ``.atelier/schedules/``."""
+    store = _schedule_store()
+    try:
+        dest = store.install(file, force=force)
+    except FileExistsError as e:
+        console.print(f"[red]{e}[/red]  [dim](use --force to overwrite)[/dim]")
+        raise typer.Exit(code=1)
+    except Exception as e:  # noqa: BLE001
+        console.print(f"[red]invalid schedule:[/red] {e}")
+        raise typer.Exit(code=1)
+    console.print(f"[green]installed[/green] {dest}")
+
+
+@schedule_app.command("list", help="List installed schedules and their next fire times.")
+def schedule_list_cmd(
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of a table."
+    ),
+) -> None:
+    store = _schedule_store()
+    planned, errors = compute_planned_view(
+        store,
+        default_zone=default_local_zone(),
+        default_working_dir=Path.cwd(),
+    )
+
+    if json_mode:
+        payload = {
+            "schedules": [
+                {
+                    "name": p.name,
+                    "conduit": p.conduit,
+                    "kind": p.schedule_kind,
+                    "next_fire_time": (
+                        p.next_fire_time.isoformat() if p.next_fire_time else None
+                    ),
+                    "working_dir": str(p.working_dir),
+                }
+                for p in planned
+            ],
+            "errors": [
+                {"path": str(e.source_path), "error": e.error} for e in errors
+            ],
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    if not planned and not errors:
+        console.print("[yellow]no schedules found[/yellow]")
+        return
+
+    if planned:
+        console.print(_render_planned_table(planned))
+    for err in errors:
+        console.print(
+            f"[red]× {err.source_path.name}:[/red] {err.error}"
+        )
+
+
+@schedule_app.command("remove", help="Delete a schedule YAML from .atelier/schedules/.")
+def schedule_remove_cmd(
+    name: str = typer.Argument(..., help="Schedule name (filename stem)."),
+) -> None:
+    store = _schedule_store()
+    if not store.remove(name):
+        console.print(f"[yellow]schedule not found:[/yellow] {name}")
+        raise typer.Exit(code=1)
+    console.print(f"[green]removed[/green] {name}")
+
+
+@schedule_app.command(
+    "run-now",
+    help="Run a scheduled conduit immediately (bypasses the daemon).",
+)
+def schedule_run_now_cmd(
+    name: str = typer.Argument(..., help="Schedule name to dispatch."),
+) -> None:
+    store = _schedule_store()
+    try:
+        definition = store.read(name)
+    except FileNotFoundError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1)
+    working_dir = Path.cwd()
+    if definition.working_dir is not None:
+        wd = Path(definition.working_dir)
+        working_dir = wd if wd.is_absolute() else (working_dir / wd).resolve()
+
+    atelier = Atelier(base_dir=working_dir / ".atelier")
+    collected_events: list[TaskEvent] = []
+
+    def _on_event(event: TaskEvent) -> None:
+        collected_events.append(event)
+        _render_task_event(event, console)
+
+    captured: dict[str, str | None] = {"id": None}
+
+    def _on_started(fid: str) -> None:
+        captured["id"] = fid
+
+    try:
+        flow_id = asyncio.run(
+            atelier.run_conduit(
+                definition.conduit,
+                dict(definition.inputs),
+                on_task_event=_on_event,
+                on_flow_started=_on_started,
+            )
+        )
+    except Exception as e:  # noqa: BLE001
+        _render_run_footer(collected_events, console)
+        console.print(f"[red]flow failed:[/red] {e}")
+        if captured["id"]:
+            console.print(f"[red]flow_id:[/red] {captured['id']}")
+        raise typer.Exit(code=1)
+    _render_run_footer(collected_events, console)
+    console.print(f"[green]flow_id:[/green] {flow_id}")
+
+
+@scheduler_app.command(
+    "start",
+    help="Run the scheduler daemon in the foreground (Ctrl+C / SIGTERM to stop).",
+)
+def scheduler_start_cmd(
+    reload_interval: float = typer.Option(
+        30.0, "--reload-interval",
+        help="Seconds between YAML directory rescans."
+    ),
+    log_level: str = typer.Option(
+        "INFO", "--log-level",
+        help="Logging level for the daemon (DEBUG, INFO, WARNING, ERROR)."
+    ),
+) -> None:
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)-7s %(name)s — %(message)s",
+    )
+    store = _schedule_store()
+    daemon = SchedulerDaemon(
+        store,
+        default_zone=default_local_zone(),
+        default_working_dir=Path.cwd(),
+        reload_interval_seconds=reload_interval,
+    )
+    console.print(
+        f"[green]scheduler running[/green] "
+        f"(tz={daemon.default_zone}, reload={reload_interval}s, "
+        f"schedules_dir={store.schedules_dir})"
+    )
+    try:
+        asyncio.run(daemon.run_forever())
+    except KeyboardInterrupt:
+        pass
+    console.print("[dim]scheduler stopped[/dim]")
+
+
+@scheduler_app.command(
+    "status",
+    help="Show registered schedules and their next fire times (no daemon required).",
+)
+def scheduler_status_cmd(
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of a table."
+    ),
+) -> None:
+    schedule_list_cmd(json_mode=json_mode)
 
 
 if __name__ == "__main__":

--- a/app/schemas/schedule.py
+++ b/app/schemas/schedule.py
@@ -1,0 +1,160 @@
+"""Schedule definition schemas (YAML-driven scheduler)."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, time
+from pathlib import Path
+from typing import Annotated, Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+
+
+_DAY_ALIASES: dict[str, str] = {
+    "0": "mon", "1": "tue", "2": "wed", "3": "thu",
+    "4": "fri", "5": "sat", "6": "sun",
+    "mon": "mon", "monday": "mon",
+    "tue": "tue", "tues": "tue", "tuesday": "tue",
+    "wed": "wed", "weds": "wed", "wednesday": "wed",
+    "thu": "thu", "thurs": "thu", "thursday": "thu",
+    "fri": "fri", "friday": "fri",
+    "sat": "sat", "saturday": "sat",
+    "sun": "sun", "sunday": "sun",
+    "*": "*", "daily": "*", "all": "*", "any": "*", "everyday": "*",
+}
+
+_HHMM_RE = re.compile(r"^([01]?\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$")
+
+DAY_ORDER = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+
+class _ScheduleBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class OnceSchedule(_ScheduleBase):
+    """Fire exactly once at the given instant."""
+
+    type: Literal["once"]
+    at: datetime
+
+    @field_validator("at", mode="before")
+    @classmethod
+    def _parse_iso(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v.replace("Z", "+00:00"))
+            except ValueError as e:
+                raise ValueError(f"invalid ISO 8601 datetime: {v!r}") from e
+        return v
+
+
+class RecurringSchedule(_ScheduleBase):
+    """Fire on every (day-of-week × time-of-day) cross product."""
+
+    type: Literal["recurring"]
+    days: list[str] = Field(min_length=1)
+    hours: list[time] = Field(min_length=1)
+
+    @field_validator("days", mode="before")
+    @classmethod
+    def _normalize_days(cls, v: Any) -> Any:
+        if not isinstance(v, list):
+            raise ValueError("days must be a list")
+        if not v:
+            raise ValueError("days must contain at least one entry")
+        out: list[str] = []
+        seen: set[str] = set()
+        for item in v:
+            if not isinstance(item, (str, int)):
+                raise ValueError(f"day must be a string or 0-6 int: {item!r}")
+            key = str(item).strip().lower()
+            if key not in _DAY_ALIASES:
+                raise ValueError(
+                    f"unknown day {item!r}; allowed: mon..sun, monday..sunday, 0-6, '*'"
+                )
+            normalized = _DAY_ALIASES[key]
+            if normalized == "*":
+                return DAY_ORDER.copy()
+            if normalized not in seen:
+                seen.add(normalized)
+                out.append(normalized)
+        out.sort(key=DAY_ORDER.index)
+        return out
+
+    @field_validator("hours", mode="before")
+    @classmethod
+    def _parse_hours(cls, v: Any) -> Any:
+        if not isinstance(v, list):
+            raise ValueError("hours must be a list")
+        if not v:
+            raise ValueError("hours must contain at least one entry")
+        out: list[time] = []
+        seen: set[str] = set()
+        for item in v:
+            if isinstance(item, time):
+                t = item
+            elif isinstance(item, str):
+                m = _HHMM_RE.match(item.strip())
+                if not m:
+                    raise ValueError(
+                        f"invalid time-of-day {item!r}; expected 'HH:MM' (00-23:00-59)"
+                    )
+                hour = int(m.group(1))
+                minute = int(m.group(2))
+                second = int(m.group(3)) if m.group(3) is not None else 0
+                t = time(hour, minute, second)
+            else:
+                raise ValueError(f"hour must be a 'HH:MM' string: {item!r}")
+            key = t.isoformat()
+            if key not in seen:
+                seen.add(key)
+                out.append(t)
+        out.sort()
+        return out
+
+    @field_serializer("hours")
+    def _serialize_hours(self, value: list[time]) -> list[str]:
+        return [t.strftime("%H:%M") if t.second == 0 else t.strftime("%H:%M:%S") for t in value]
+
+
+ScheduleSpec = Annotated[
+    OnceSchedule | RecurringSchedule,
+    Field(discriminator="type"),
+]
+
+
+class ScheduleDefinition(BaseModel):
+    """Top-level schedule entry parsed from ``.atelier/schedules/<name>.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    conduit: str
+    working_dir: Path | None = None
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    timezone: str | None = None
+    schedule: ScheduleSpec
+
+    @field_validator("name", "conduit")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("must not be empty")
+        return stripped
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_tz(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        try:
+            ZoneInfo(v)
+        except (ZoneInfoNotFoundError, ValueError) as e:
+            raise ValueError(f"unknown timezone {v!r}: {e}") from e
+        return v
+
+    def resolve_zone(self, default: ZoneInfo) -> ZoneInfo:
+        """Return the IANA zone for this schedule, falling back to ``default``."""
+        return ZoneInfo(self.timezone) if self.timezone else default

--- a/app/services/scheduler/__init__.py
+++ b/app/services/scheduler/__init__.py
@@ -1,0 +1,23 @@
+"""Scheduler subsystem: YAML-driven daemon that fires conduits on schedule."""
+from app.services.scheduler.runner import (
+    PlannedJob,
+    SchedulerDaemon,
+    compute_planned_view,
+)
+from app.services.scheduler.store import (
+    LoadedSchedule,
+    ScheduleLoadError,
+    ScheduleStore,
+)
+from app.services.scheduler.triggers import default_local_zone, to_trigger
+
+__all__ = [
+    "LoadedSchedule",
+    "PlannedJob",
+    "ScheduleLoadError",
+    "ScheduleStore",
+    "SchedulerDaemon",
+    "compute_planned_view",
+    "default_local_zone",
+    "to_trigger",
+]

--- a/app/services/scheduler/runner.py
+++ b/app/services/scheduler/runner.py
@@ -1,0 +1,321 @@
+"""Async scheduler daemon driven by .atelier/schedules YAML."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Awaitable, Callable
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from app.schemas.schedule import OnceSchedule, ScheduleDefinition
+from app.services.scheduler.store import (
+    LoadedSchedule,
+    ScheduleLoadError,
+    ScheduleStore,
+)
+from app.services.scheduler.triggers import default_local_zone, to_trigger
+
+
+logger = logging.getLogger(__name__)
+
+
+# Job ID reserved for the periodic reload job.
+_RELOAD_JOB_ID = "__atelier_sync__"
+
+
+ScheduleExecutor = Callable[[ScheduleDefinition, Path], Awaitable[None]]
+
+
+async def _default_executor(definition: ScheduleDefinition, working_dir: Path) -> None:
+    """Default fire action: instantiate ``Atelier(base_dir=working_dir/.atelier)``
+    and ``await run_conduit(...)``. Imported lazily to keep test-time
+    bootstrapping cheap and to avoid a circular import.
+    """
+    from app.core.atelier import Atelier  # local import: avoids cycle at scheduler import time
+
+    atelier = Atelier(base_dir=working_dir / ".atelier")
+    await atelier.run_conduit(definition.conduit, dict(definition.inputs))
+
+
+@dataclass(frozen=True)
+class PlannedJob:
+    """A schedule that is currently registered with the daemon."""
+
+    name: str
+    conduit: str
+    next_fire_time: datetime | None
+    working_dir: Path
+    schedule_kind: str  # "once" | "recurring"
+
+
+class SchedulerDaemon:
+    """YAML-driven async scheduler.
+
+    Holds an :class:`AsyncIOScheduler`, syncs the live job set against
+    the contents of ``store.schedules_dir`` on startup and on a fixed
+    reload interval, and dispatches each fire by calling the configured
+    executor with a fresh :class:`Atelier`.
+
+    The daemon is a thin coordinator — it never blocks on a running flow
+    (APScheduler runs each fire as its own task), and it never owns flow
+    state. All persistence is the existing filesystem store under each
+    schedule's ``working_dir``.
+    """
+
+    def __init__(
+        self,
+        store: ScheduleStore,
+        *,
+        executor: ScheduleExecutor | None = None,
+        default_zone: ZoneInfo | None = None,
+        default_working_dir: Path | None = None,
+        reload_interval_seconds: float = 30.0,
+    ) -> None:
+        self.store = store
+        self.executor: ScheduleExecutor = executor or _default_executor
+        self.default_zone = default_zone or default_local_zone()
+        self.default_working_dir = (default_working_dir or Path.cwd()).resolve()
+        self.reload_interval_seconds = reload_interval_seconds
+        self._scheduler: AsyncIOScheduler | None = None
+        self._known_mtimes: dict[str, float] = {}
+        # Cached after each sync; the CLI's `scheduler status` reads this
+        # to render a table without re-parsing every YAML file.
+        self._planned: dict[str, PlannedJob] = {}
+        self._load_errors: list[ScheduleLoadError] = []
+
+    # ------------------------------------------------------------------ lifecycle
+
+    async def start(self) -> None:
+        if self._scheduler is not None:
+            return
+        self._scheduler = AsyncIOScheduler(timezone=self.default_zone)
+        self._scheduler.add_job(
+            self._sync_from_disk,
+            trigger=IntervalTrigger(seconds=self.reload_interval_seconds),
+            id=_RELOAD_JOB_ID,
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+        )
+        await self._sync_from_disk()
+        self._scheduler.start()
+        logger.info(
+            "scheduler started: %d schedule(s), tz=%s, reload=%.1fs",
+            len(self._planned),
+            self.default_zone,
+            self.reload_interval_seconds,
+        )
+
+    async def stop(self) -> None:
+        if self._scheduler is None:
+            return
+        self._scheduler.shutdown(wait=False)
+        self._scheduler = None
+        logger.info("scheduler stopped")
+
+    async def run_forever(self) -> None:
+        """Start the daemon and block until SIGINT/SIGTERM (or Ctrl+C)."""
+        await self.start()
+        stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        installed: list[int] = []
+        if sys.platform != "win32":
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                try:
+                    loop.add_signal_handler(sig, stop_event.set)
+                    installed.append(sig)
+                except (NotImplementedError, RuntimeError):
+                    pass
+        try:
+            await stop_event.wait()
+        finally:
+            for sig in installed:
+                try:
+                    loop.remove_signal_handler(sig)
+                except Exception:  # noqa: BLE001
+                    pass
+            await self.stop()
+
+    # ------------------------------------------------------------------ sync
+
+    async def _sync_from_disk(self) -> None:
+        """Diff live jobs against on-disk YAML; add/update/remove as needed."""
+        if self._scheduler is None:
+            # Initial sync runs *before* scheduler.start() so
+            # self._scheduler is set; the early-return only matters if a
+            # caller manually invokes sync after stop().
+            return
+        loaded, errors = self.store.list_definitions_with_errors()
+        self._load_errors = errors
+        for err in errors:
+            logger.warning("skipping unparseable schedule %s: %s", err.source_path, err.error)
+
+        on_disk: dict[str, LoadedSchedule] = {ls.definition.name: ls for ls in loaded}
+        live_ids = {
+            job.id
+            for job in self._scheduler.get_jobs()
+            if job.id != _RELOAD_JOB_ID
+        }
+
+        # Remove jobs whose YAML has been deleted.
+        for stale in live_ids - on_disk.keys():
+            self._scheduler.remove_job(stale)
+            self._known_mtimes.pop(stale, None)
+            self._planned.pop(stale, None)
+            logger.info("removed schedule %s (yaml deleted)", stale)
+
+        # Add or update jobs from YAML.
+        for name, ls in on_disk.items():
+            prior_mtime = self._known_mtimes.get(name)
+            if name in live_ids and prior_mtime == ls.mtime:
+                continue
+            self._register(ls)
+
+    def _register(self, ls: LoadedSchedule) -> None:
+        assert self._scheduler is not None
+        definition = ls.definition
+
+        # Skip already-fired one-shots so a daemon restart doesn't re-run them.
+        if isinstance(definition.schedule, OnceSchedule):
+            already = self.store.fired_at(definition.name)
+            if already and already == definition.schedule.at.isoformat():
+                logger.info(
+                    "skipping one-shot %s: already fired for at=%s",
+                    definition.name,
+                    already,
+                )
+                if definition.name in {j.id for j in self._scheduler.get_jobs()}:
+                    self._scheduler.remove_job(definition.name)
+                self._known_mtimes[definition.name] = ls.mtime
+                self._planned.pop(definition.name, None)
+                return
+
+        trigger = to_trigger(definition, default_zone=self.default_zone)
+        working_dir = self._resolve_working_dir(definition)
+        self._scheduler.add_job(
+            self._fire,
+            trigger=trigger,
+            id=definition.name,
+            args=[definition.name],
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+        )
+        self._known_mtimes[definition.name] = ls.mtime
+        # Compute next fire time from the trigger directly: APScheduler
+        # only populates Job.next_run_time *after* scheduler.start(), and
+        # the initial sync runs before that.
+        now = datetime.now(tz=self.default_zone)
+        next_fire = trigger.get_next_fire_time(None, now)
+        self._planned[definition.name] = PlannedJob(
+            name=definition.name,
+            conduit=definition.conduit,
+            next_fire_time=next_fire,
+            working_dir=working_dir,
+            schedule_kind=definition.schedule.type,
+        )
+        logger.info(
+            "registered schedule %s (%s): next fire %s",
+            definition.name,
+            definition.schedule.type,
+            next_fire,
+        )
+
+    def _resolve_working_dir(self, definition: ScheduleDefinition) -> Path:
+        if definition.working_dir is None:
+            return self.default_working_dir
+        wd = Path(definition.working_dir)
+        if not wd.is_absolute():
+            wd = (self.default_working_dir / wd).resolve()
+        return wd
+
+    # ------------------------------------------------------------------ fire
+
+    async def _fire(self, name: str) -> None:
+        """Job function: re-read the latest definition and dispatch it."""
+        try:
+            definition = self.store.read(name)
+        except FileNotFoundError:
+            logger.warning("schedule %s vanished before firing; skipping", name)
+            return
+        working_dir = self._resolve_working_dir(definition)
+        scheduled_at = (
+            definition.schedule.at.isoformat()
+            if isinstance(definition.schedule, OnceSchedule)
+            else None
+        )
+        logger.info("firing schedule %s → %s in %s", name, definition.conduit, working_dir)
+        try:
+            await self.executor(definition, working_dir)
+        except Exception:  # noqa: BLE001 — daemon must survive a single failed fire
+            logger.exception("schedule %s failed", name)
+            return
+        if scheduled_at is not None:
+            self.store.mark_fired(name, scheduled_at)
+
+    # ------------------------------------------------------------------ introspection
+
+    def list_planned(self) -> list[PlannedJob]:
+        """Return the schedules currently registered with the daemon."""
+        return sorted(self._planned.values(), key=lambda p: p.name)
+
+    @property
+    def load_errors(self) -> list[ScheduleLoadError]:
+        return list(self._load_errors)
+
+
+def compute_planned_view(
+    store: ScheduleStore,
+    *,
+    default_zone: ZoneInfo,
+    default_working_dir: Path,
+) -> tuple[list[PlannedJob], list[ScheduleLoadError]]:
+    """Compute next-fire-time for every schedule on disk.
+
+    Used by ``atelier schedule list`` and ``atelier scheduler status`` so
+    they work whether or not a daemon is running. Already-fired one-shots
+    are surfaced with ``next_fire_time=None``.
+    """
+    loaded, errors = store.list_definitions_with_errors()
+    now = datetime.now(tz=default_zone)
+    base = default_working_dir.resolve()
+    planned: list[PlannedJob] = []
+    for ls in loaded:
+        d = ls.definition
+        wd = d.working_dir
+        working_dir = base if wd is None else (
+            Path(wd) if Path(wd).is_absolute() else (base / wd).resolve()
+        )
+        if isinstance(d.schedule, OnceSchedule):
+            already = store.fired_at(d.name)
+            if already and already == d.schedule.at.isoformat():
+                planned.append(
+                    PlannedJob(
+                        name=d.name,
+                        conduit=d.conduit,
+                        next_fire_time=None,
+                        working_dir=working_dir,
+                        schedule_kind="once",
+                    )
+                )
+                continue
+        trigger = to_trigger(d, default_zone=default_zone)
+        next_fire = trigger.get_next_fire_time(None, now)
+        planned.append(
+            PlannedJob(
+                name=d.name,
+                conduit=d.conduit,
+                next_fire_time=next_fire,
+                working_dir=working_dir,
+                schedule_kind=d.schedule.type,
+            )
+        )
+    planned.sort(key=lambda p: p.name)
+    return planned, errors

--- a/app/services/scheduler/store.py
+++ b/app/services/scheduler/store.py
@@ -1,0 +1,213 @@
+"""On-disk CRUD for schedules and fired-state tracking.
+
+Layout::
+
+    <schedules_dir>/
+    ├── <name>.yaml          # one ScheduleDefinition per file
+    └── .state.json          # one-shot fired markers, not user-editable
+
+The store treats YAML as the source of truth — there is no DB. Fired-state
+is a small JSON map so a daemon restart does not re-run a one-shot whose
+``at`` has already passed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.schedule import ScheduleDefinition
+
+
+@dataclass(frozen=True)
+class LoadedSchedule:
+    """A successfully parsed schedule with disk metadata."""
+
+    definition: ScheduleDefinition
+    source_path: Path
+    mtime: float
+
+
+@dataclass(frozen=True)
+class ScheduleLoadError:
+    """A YAML file that failed to parse, kept so the CLI/daemon can surface it."""
+
+    source_path: Path
+    error: str
+
+
+class ScheduleStore:
+    """Project-local schedule directory + fired-state JSON."""
+
+    def __init__(
+        self,
+        schedules_dir: Path | str,
+        state_path: Path | str | None = None,
+    ) -> None:
+        self.schedules_dir = Path(schedules_dir)
+        self.schedules_dir.mkdir(parents=True, exist_ok=True)
+        self.state_path = (
+            Path(state_path)
+            if state_path is not None
+            else self.schedules_dir / ".state.json"
+        )
+
+    # ------------------------------------------------------------------ paths
+
+    def path_for(self, name: str) -> Path:
+        return self.schedules_dir / f"{name}.yaml"
+
+    # ------------------------------------------------------------------ load
+
+    def _yaml_files(self) -> list[Path]:
+        if not self.schedules_dir.exists():
+            return []
+        return sorted(
+            p for p in self.schedules_dir.iterdir()
+            if p.is_file() and p.suffix in (".yaml", ".yml") and not p.name.startswith(".")
+        )
+
+    def list_definitions(self) -> list[LoadedSchedule]:
+        loaded, _errors = self.list_definitions_with_errors()
+        return loaded
+
+    def list_definitions_with_errors(
+        self,
+    ) -> tuple[list[LoadedSchedule], list[ScheduleLoadError]]:
+        loaded: list[LoadedSchedule] = []
+        errors: list[ScheduleLoadError] = []
+        for path in self._yaml_files():
+            try:
+                definition = self._parse(path)
+            except (ValidationError, ValueError, yaml.YAMLError, OSError) as e:
+                errors.append(ScheduleLoadError(source_path=path, error=str(e)))
+                continue
+            loaded.append(
+                LoadedSchedule(
+                    definition=definition,
+                    source_path=path,
+                    mtime=path.stat().st_mtime,
+                )
+            )
+        return loaded, errors
+
+    def read(self, name: str) -> ScheduleDefinition:
+        path = self.path_for(name)
+        if not path.exists():
+            raise FileNotFoundError(f"schedule not found: {name} ({path})")
+        return self._parse(path)
+
+    def _parse(self, path: Path) -> ScheduleDefinition:
+        raw = yaml.safe_load(path.read_text()) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"{path}: top-level YAML must be a mapping")
+        # Filename stem is the canonical schedule name; allow YAML to omit
+        # `name:` and patch it in. If both are present they must match.
+        stem = path.stem
+        if "name" not in raw:
+            raw["name"] = stem
+        elif raw["name"] != stem:
+            raise ValueError(
+                f"{path}: schedule name {raw['name']!r} != filename stem {stem!r}"
+            )
+        return ScheduleDefinition.model_validate(raw)
+
+    # ------------------------------------------------------------------ write
+
+    def write(
+        self,
+        definition: ScheduleDefinition,
+        *,
+        force: bool = False,
+    ) -> Path:
+        path = self.path_for(definition.name)
+        if path.exists() and not force:
+            raise FileExistsError(f"schedule already exists: {definition.name} ({path})")
+        payload = definition.model_dump(mode="json", exclude_none=True)
+        # Drop the name field when writing — it's implied by the filename
+        # and the loader will patch it back in. Avoids the accidental
+        # mismatch class of bugs.
+        payload.pop("name", None)
+        path.write_text(yaml.safe_dump(payload, sort_keys=False))
+        return path
+
+    def install(self, source_path: Path | str, *, force: bool = False) -> Path:
+        """Copy a user-supplied YAML file into ``schedules_dir``.
+
+        Validates the YAML before installing so we never persist a broken
+        schedule. The destination filename is ``<definition.name>.yaml``,
+        which may differ from the source filename.
+        """
+        source = Path(source_path)
+        if not source.exists():
+            raise FileNotFoundError(f"file not found: {source}")
+        raw = yaml.safe_load(source.read_text()) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"{source}: top-level YAML must be a mapping")
+        if "name" not in raw:
+            raw["name"] = source.stem
+        definition = ScheduleDefinition.model_validate(raw)
+        dest = self.path_for(definition.name)
+        if dest.exists() and not force:
+            raise FileExistsError(
+                f"schedule already exists: {definition.name} ({dest})"
+            )
+        if source.resolve() == dest.resolve():
+            return dest
+        shutil.copyfile(source, dest)
+        # Re-parse to confirm the copy round-trips.
+        self._parse(dest)
+        return dest
+
+    def remove(self, name: str) -> bool:
+        path = self.path_for(name)
+        existed = path.exists()
+        if existed:
+            path.unlink()
+        self.clear_fired(name)
+        return existed
+
+    # ------------------------------------------------------------------ fired-state
+
+    def _load_state(self) -> dict[str, Any]:
+        if not self.state_path.exists():
+            return {"schedules": {}}
+        try:
+            data = json.loads(self.state_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {"schedules": {}}
+        if not isinstance(data, dict) or "schedules" not in data:
+            return {"schedules": {}}
+        return data
+
+    def _save_state(self, data: dict[str, Any]) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.state_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+        os.replace(tmp, self.state_path)
+
+    def fired_at(self, name: str) -> str | None:
+        """Return ISO timestamp of the scheduled-at of the last fire, or None."""
+        data = self._load_state()
+        entry = data["schedules"].get(name)
+        if not isinstance(entry, dict):
+            return None
+        value = entry.get("fired_at_scheduled_iso")
+        return value if isinstance(value, str) else None
+
+    def mark_fired(self, name: str, scheduled_at_iso: str) -> None:
+        data = self._load_state()
+        data["schedules"][name] = {"fired_at_scheduled_iso": scheduled_at_iso}
+        self._save_state(data)
+
+    def clear_fired(self, name: str) -> None:
+        data = self._load_state()
+        if name in data["schedules"]:
+            del data["schedules"][name]
+            self._save_state(data)

--- a/app/services/scheduler/triggers.py
+++ b/app/services/scheduler/triggers.py
@@ -1,0 +1,76 @@
+"""Convert schedule specs into APScheduler triggers."""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from apscheduler.triggers.base import BaseTrigger
+from apscheduler.triggers.combining import OrTrigger
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from app.schemas.schedule import (
+    OnceSchedule,
+    RecurringSchedule,
+    ScheduleDefinition,
+)
+
+
+def default_local_zone() -> ZoneInfo:
+    """Resolve the host's local IANA timezone, with a UTC fallback.
+
+    Tries ``tzlocal.get_localzone()`` first because it normalizes Windows
+    "Pacific Standard Time"-style names to ``America/Los_Angeles``. Falls
+    back to whatever ``datetime.now().astimezone()`` gives us if tzlocal
+    is unavailable or returns a non-IANA zone.
+    """
+    try:
+        import tzlocal  # local import: optional perf cost only on first call
+    except ImportError:  # pragma: no cover — declared as a dep
+        tzlocal = None
+    if tzlocal is not None:
+        try:
+            zone = tzlocal.get_localzone()
+            if isinstance(zone, ZoneInfo):
+                return zone
+            name = getattr(zone, "key", None) or str(zone)
+            return ZoneInfo(name)
+        except Exception:  # noqa: BLE001 — fall through to system clock zone
+            pass
+    fallback = datetime.now().astimezone().tzinfo
+    name = getattr(fallback, "key", None) or "UTC"
+    try:
+        return ZoneInfo(name)
+    except Exception:  # noqa: BLE001
+        return ZoneInfo("UTC")
+
+
+def to_trigger(definition: ScheduleDefinition, default_zone: ZoneInfo) -> BaseTrigger:
+    """Build an APScheduler trigger from a parsed schedule definition.
+
+    :param definition: validated schedule
+    :param default_zone: timezone used when the schedule omits ``timezone:``
+    :returns: ``DateTrigger`` for ``once``, ``CronTrigger`` (or
+        ``OrTrigger`` of crons) for ``recurring``
+    """
+    zone = definition.resolve_zone(default_zone)
+    spec = definition.schedule
+    if isinstance(spec, OnceSchedule):
+        run_date = spec.at if spec.at.tzinfo is not None else spec.at.replace(tzinfo=zone)
+        return DateTrigger(run_date=run_date, timezone=zone)
+    if isinstance(spec, RecurringSchedule):
+        day_of_week = ",".join(spec.days)
+        crons = [
+            CronTrigger(
+                day_of_week=day_of_week,
+                hour=t.hour,
+                minute=t.minute,
+                second=t.second,
+                timezone=zone,
+            )
+            for t in spec.hours
+        ]
+        if len(crons) == 1:
+            return crons[0]
+        return OrTrigger(crons)
+    raise TypeError(f"unsupported schedule spec: {spec!r}")  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "pydantic-settings>=2.4",
     "rich>=13.7",
     "agent-client-protocol>=0.9.0",
+    "apscheduler>=3.10,<4",
+    "tzdata>=2024.1",
+    "tzlocal>=5.2",
 ]
 
 [project.scripts]

--- a/tests/schemas/test_schedule_schema.py
+++ b/tests/schemas/test_schedule_schema.py
@@ -1,0 +1,220 @@
+"""Schedule schema validation tests."""
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.schedule import (
+    DAY_ORDER,
+    OnceSchedule,
+    RecurringSchedule,
+    ScheduleDefinition,
+)
+
+
+def _recurring_payload(**overrides):
+    base = {
+        "name": "nightly",
+        "conduit": "report",
+        "schedule": {
+            "type": "recurring",
+            "days": ["mon", "wed", "fri"],
+            "hours": ["09:00", "17:30"],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _once_payload(**overrides):
+    base = {
+        "name": "backfill",
+        "conduit": "backfill",
+        "schedule": {"type": "once", "at": "2026-05-01T09:00:00"},
+    }
+    base.update(overrides)
+    return base
+
+
+# -------------------------------------------------------------- happy paths
+
+
+def test_recurring_basic():
+    sd = ScheduleDefinition.model_validate(_recurring_payload())
+    assert isinstance(sd.schedule, RecurringSchedule)
+    assert sd.schedule.days == ["mon", "wed", "fri"]
+    assert sd.schedule.hours == [time(9, 0), time(17, 30)]
+
+
+def test_once_basic():
+    sd = ScheduleDefinition.model_validate(_once_payload())
+    assert isinstance(sd.schedule, OnceSchedule)
+    assert sd.schedule.at == datetime(2026, 5, 1, 9, 0)
+
+
+def test_once_z_suffix_parses_as_utc():
+    sd = ScheduleDefinition.model_validate(
+        _once_payload(schedule={"type": "once", "at": "2026-05-01T09:00:00Z"})
+    )
+    assert sd.schedule.at == datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+
+# -------------------------------------------------------------- day normalization
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (["MON", "Wed"], ["mon", "wed"]),
+        (["monday", "Tuesday"], ["mon", "tue"]),
+        (["fri", "fri", "tue"], ["tue", "fri"]),
+        (["0", 6], ["mon", "sun"]),
+        (["*"], DAY_ORDER),
+        (["daily"], DAY_ORDER),
+        (["any", "mon"], DAY_ORDER),
+    ],
+)
+def test_day_normalization(raw, expected):
+    sd = ScheduleDefinition.model_validate(
+        _recurring_payload(schedule={"type": "recurring", "days": raw, "hours": ["08:00"]})
+    )
+    assert sd.schedule.days == expected
+
+
+def test_day_unknown_rejected():
+    with pytest.raises(ValidationError) as exc:
+        ScheduleDefinition.model_validate(
+            _recurring_payload(
+                schedule={"type": "recurring", "days": ["funday"], "hours": ["08:00"]}
+            )
+        )
+    assert "unknown day" in str(exc.value)
+
+
+# -------------------------------------------------------------- hour parsing
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (["08:00"], [time(8, 0)]),
+        (["8:00"], [time(8, 0)]),
+        (["23:59"], [time(23, 59)]),
+        (["09:30", "09:30", "08:00"], [time(8, 0), time(9, 30)]),
+    ],
+)
+def test_hour_parsing(raw, expected):
+    sd = ScheduleDefinition.model_validate(
+        _recurring_payload(schedule={"type": "recurring", "days": ["mon"], "hours": raw})
+    )
+    assert sd.schedule.hours == expected
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["24:00", "9", "9:0", "noon", "9:60", "-1:00"],
+)
+def test_hour_invalid_rejected(bad):
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(
+            _recurring_payload(
+                schedule={"type": "recurring", "days": ["mon"], "hours": [bad]}
+            )
+        )
+
+
+def test_hours_must_not_be_empty():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(
+            _recurring_payload(
+                schedule={"type": "recurring", "days": ["mon"], "hours": []}
+            )
+        )
+
+
+def test_days_must_not_be_empty():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(
+            _recurring_payload(
+                schedule={"type": "recurring", "days": [], "hours": ["08:00"]}
+            )
+        )
+
+
+# -------------------------------------------------------------- timezone
+
+
+def test_timezone_valid():
+    sd = ScheduleDefinition.model_validate(
+        _recurring_payload(timezone="America/Bogota")
+    )
+    assert sd.timezone == "America/Bogota"
+    assert sd.resolve_zone(ZoneInfo("UTC")) == ZoneInfo("America/Bogota")
+
+
+def test_timezone_unknown_rejected():
+    with pytest.raises(ValidationError) as exc:
+        ScheduleDefinition.model_validate(_recurring_payload(timezone="Mars/Olympus"))
+    assert "unknown timezone" in str(exc.value)
+
+
+def test_timezone_default_resolution_uses_fallback():
+    sd = ScheduleDefinition.model_validate(_recurring_payload())
+    assert sd.timezone is None
+    assert sd.resolve_zone(ZoneInfo("UTC")) == ZoneInfo("UTC")
+
+
+# -------------------------------------------------------------- discriminator
+
+
+def test_unknown_schedule_type_rejected():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(
+            _once_payload(schedule={"type": "weekly", "at": "2026-01-01T00:00:00"})
+        )
+
+
+def test_extra_fields_rejected():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(_recurring_payload(extra="nope"))
+
+
+def test_once_extra_fields_rejected():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(
+            _once_payload(
+                schedule={
+                    "type": "once",
+                    "at": "2026-05-01T09:00:00",
+                    "days": ["mon"],
+                }
+            )
+        )
+
+
+# -------------------------------------------------------------- name/conduit
+
+
+def test_name_strips_whitespace():
+    sd = ScheduleDefinition.model_validate(_recurring_payload(name="  nightly  "))
+    assert sd.name == "nightly"
+
+
+def test_empty_name_rejected():
+    with pytest.raises(ValidationError):
+        ScheduleDefinition.model_validate(_recurring_payload(name="   "))
+
+
+def test_inputs_default_empty_dict():
+    sd = ScheduleDefinition.model_validate(_recurring_payload())
+    assert sd.inputs == {}
+
+
+def test_inputs_arbitrary_values():
+    sd = ScheduleDefinition.model_validate(
+        _recurring_payload(inputs={"date": "today", "n": 3, "flag": True})
+    )
+    assert sd.inputs == {"date": "today", "n": 3, "flag": True}

--- a/tests/services/scheduler/test_runner.py
+++ b/tests/services/scheduler/test_runner.py
@@ -1,0 +1,276 @@
+"""SchedulerDaemon: sync, fire, and one-shot fired-state tests."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.schemas.schedule import ScheduleDefinition
+from app.services.scheduler.runner import SchedulerDaemon, _RELOAD_JOB_ID
+from app.services.scheduler.store import ScheduleStore
+
+
+UTC = ZoneInfo("UTC")
+
+
+RECURRING_FAR_FUTURE = """
+conduit: report
+schedule:
+  type: recurring
+  days: [mon]
+  hours: ["09:00"]
+"""
+
+ONCE_FAR_FUTURE = """
+conduit: backfill
+schedule:
+  type: once
+  at: "2099-05-01T09:00:00"
+"""
+
+ONCE_OTHER_TIME = """
+conduit: backfill
+schedule:
+  type: once
+  at: "2099-06-01T09:00:00"
+"""
+
+
+def _write(store: ScheduleStore, name: str, body: str) -> Path:
+    path = store.path_for(name)
+    path.write_text(body)
+    return path
+
+
+@pytest.fixture
+def store(tmp_path) -> ScheduleStore:
+    return ScheduleStore(tmp_path / "schedules")
+
+
+class _RecordingExecutor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[ScheduleDefinition, Path]] = []
+        self.raise_on_next = False
+
+    async def __call__(
+        self, definition: ScheduleDefinition, working_dir: Path
+    ) -> None:
+        self.calls.append((definition, working_dir))
+        if self.raise_on_next:
+            self.raise_on_next = False
+            raise RuntimeError("forced failure for test")
+
+
+@pytest.fixture
+def executor() -> _RecordingExecutor:
+    return _RecordingExecutor()
+
+
+@pytest.fixture
+async def daemon(tmp_path, store, executor):
+    d = SchedulerDaemon(
+        store,
+        executor=executor,
+        default_zone=UTC,
+        default_working_dir=tmp_path,
+        reload_interval_seconds=3600,  # never auto-reloads during tests
+    )
+    yield d
+    await d.stop()
+
+
+# -------------------------------------------------------------- start / stop
+
+
+async def test_start_registers_existing_schedules(daemon, store):
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    _write(store, "once", ONCE_FAR_FUTURE)
+    await daemon.start()
+    planned = {p.name for p in daemon.list_planned()}
+    assert planned == {"weekly", "once"}
+
+
+async def test_start_is_idempotent(daemon, store):
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    await daemon.start()
+    assert {p.name for p in daemon.list_planned()} == {"weekly"}
+
+
+async def test_start_with_no_schedules(daemon):
+    await daemon.start()
+    assert daemon.list_planned() == []
+
+
+async def test_load_errors_are_surfaced_not_fatal(daemon, store):
+    _write(store, "good", RECURRING_FAR_FUTURE)
+    _write(store, "broken", "name: broken\nconduit: c\nschedule:\n  type: bogus\n")
+    await daemon.start()
+    assert {p.name for p in daemon.list_planned()} == {"good"}
+    assert len(daemon.load_errors) == 1
+    assert daemon.load_errors[0].source_path.name == "broken.yaml"
+
+
+# -------------------------------------------------------------- sync / hot reload
+
+
+async def test_sync_picks_up_added_schedules(daemon, store):
+    await daemon.start()
+    assert daemon.list_planned() == []
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon._sync_from_disk()
+    assert [p.name for p in daemon.list_planned()] == ["weekly"]
+
+
+async def test_sync_drops_removed_schedules(daemon, store):
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    store.remove("weekly")
+    await daemon._sync_from_disk()
+    assert daemon.list_planned() == []
+
+
+async def test_sync_updates_on_mtime_change(daemon, store):
+    path = _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    job_before = daemon._scheduler.get_job("weekly")
+    next_before = job_before.next_run_time
+    # Rewrite with a different hour and bump mtime.
+    path.write_text(
+        RECURRING_FAR_FUTURE.replace('"09:00"', '"17:30"')
+    )
+    import os, time
+    future = path.stat().st_mtime + 5
+    os.utime(path, (future, future))
+    await daemon._sync_from_disk()
+    next_after = daemon._scheduler.get_job("weekly").next_run_time
+    assert next_after.hour == 17 and next_after.minute == 30
+    assert next_after != next_before
+
+
+async def test_sync_reload_job_is_preserved(daemon, store):
+    await daemon.start()
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon._sync_from_disk()
+    job_ids = {j.id for j in daemon._scheduler.get_jobs()}
+    assert _RELOAD_JOB_ID in job_ids
+    assert "weekly" in job_ids
+
+
+# -------------------------------------------------------------- fire
+
+
+async def test_fire_invokes_executor_with_resolved_working_dir(
+    daemon, store, executor, tmp_path
+):
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    await daemon._fire("weekly")
+    assert len(executor.calls) == 1
+    definition, working_dir = executor.calls[0]
+    assert definition.name == "weekly"
+    assert definition.conduit == "report"
+    assert working_dir == tmp_path.resolve()
+
+
+async def test_fire_uses_relative_working_dir(daemon, store, executor, tmp_path):
+    proj = tmp_path / "projects" / "foo"
+    proj.mkdir(parents=True)
+    body = (
+        "conduit: report\n"
+        "working_dir: projects/foo\n"
+        "schedule:\n  type: recurring\n  days: [mon]\n  hours: ['09:00']\n"
+    )
+    _write(store, "scoped", body)
+    await daemon.start()
+    await daemon._fire("scoped")
+    _, working_dir = executor.calls[0]
+    assert working_dir == proj.resolve()
+
+
+async def test_fire_passes_inputs(daemon, store, executor):
+    body = (
+        "conduit: report\n"
+        "inputs:\n  date: today\n  region: us\n"
+        "schedule:\n  type: recurring\n  days: [mon]\n  hours: ['09:00']\n"
+    )
+    _write(store, "with_inputs", body)
+    await daemon.start()
+    await daemon._fire("with_inputs")
+    definition, _ = executor.calls[0]
+    assert definition.inputs == {"date": "today", "region": "us"}
+
+
+async def test_fire_marks_one_shot_fired_state(daemon, store, executor):
+    _write(store, "once", ONCE_FAR_FUTURE)
+    await daemon.start()
+    await daemon._fire("once")
+    assert store.fired_at("once") == "2099-05-01T09:00:00"
+
+
+async def test_fire_does_not_mark_state_for_recurring(daemon, store, executor):
+    _write(store, "weekly", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    await daemon._fire("weekly")
+    assert store.fired_at("weekly") is None
+
+
+async def test_fire_failure_does_not_mark_state(daemon, store, executor):
+    _write(store, "once", ONCE_FAR_FUTURE)
+    await daemon.start()
+    executor.raise_on_next = True
+    await daemon._fire("once")  # must NOT raise
+    assert store.fired_at("once") is None
+
+
+async def test_fire_skips_when_yaml_disappears(daemon, store, executor):
+    _write(store, "ghost", RECURRING_FAR_FUTURE)
+    await daemon.start()
+    store.remove("ghost")
+    # No executor call, no exception.
+    await daemon._fire("ghost")
+    assert executor.calls == []
+
+
+# -------------------------------------------------------------- one-shot fired-state skipping
+
+
+async def test_already_fired_one_shot_is_not_re_registered(
+    daemon, store, executor
+):
+    _write(store, "once", ONCE_FAR_FUTURE)
+    store.mark_fired("once", "2099-05-01T09:00:00")
+    await daemon.start()
+    assert daemon._scheduler.get_job("once") is None
+    assert "once" not in {p.name for p in daemon.list_planned()}
+
+
+async def test_changing_one_shot_at_re_arms_after_fire(daemon, store, executor):
+    _write(store, "once", ONCE_FAR_FUTURE)
+    store.mark_fired("once", "2099-05-01T09:00:00")
+    await daemon.start()
+    assert daemon._scheduler.get_job("once") is None
+    # User edits the YAML to a new datetime.
+    path = store.path_for("once")
+    path.write_text(ONCE_OTHER_TIME)
+    import os
+    future = path.stat().st_mtime + 5
+    os.utime(path, (future, future))
+    await daemon._sync_from_disk()
+    assert daemon._scheduler.get_job("once") is not None
+
+
+# -------------------------------------------------------------- fire concurrency
+
+
+async def test_fire_runs_concurrently_for_distinct_schedules(
+    daemon, store, executor
+):
+    _write(store, "a", RECURRING_FAR_FUTURE)
+    _write(store, "b", RECURRING_FAR_FUTURE.replace("report", "report2"))
+    await daemon.start()
+    await asyncio.gather(daemon._fire("a"), daemon._fire("b"))
+    names = {c[0].name for c in executor.calls}
+    assert names == {"a", "b"}

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -1,0 +1,235 @@
+"""Tests for ScheduleStore: YAML CRUD and fired-state persistence."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.schemas.schedule import ScheduleDefinition
+from app.services.scheduler.store import ScheduleStore
+
+
+RECURRING_YAML = """
+conduit: report
+inputs:
+  date: today
+schedule:
+  type: recurring
+  days: [mon, fri]
+  hours: ["09:00"]
+"""
+
+ONCE_YAML = """
+conduit: backfill
+schedule:
+  type: once
+  at: "2026-05-01T09:00:00"
+"""
+
+
+@pytest.fixture
+def store(tmp_path) -> ScheduleStore:
+    return ScheduleStore(tmp_path / "schedules")
+
+
+def _write(store: ScheduleStore, name: str, body: str) -> Path:
+    p = store.path_for(name)
+    p.write_text(body)
+    return p
+
+
+# -------------------------------------------------------------- list / read
+
+
+def test_list_empty(store):
+    assert store.list_definitions() == []
+
+
+def test_list_picks_up_yaml_and_yml(store):
+    _write(store, "a", RECURRING_YAML)
+    (store.schedules_dir / "b.yml").write_text(ONCE_YAML)
+    loaded = store.list_definitions()
+    names = [ls.definition.name for ls in loaded]
+    assert names == ["a", "b"]
+
+
+def test_list_skips_dotfiles(store):
+    _write(store, "a", RECURRING_YAML)
+    (store.schedules_dir / ".state.json").write_text("{}")
+    (store.schedules_dir / ".hidden.yaml").write_text(RECURRING_YAML)
+    names = [ls.definition.name for ls in store.list_definitions()]
+    assert names == ["a"]
+
+
+def test_list_records_errors_for_broken_yaml(store):
+    _write(store, "good", RECURRING_YAML)
+    _write(store, "broken", "name: broken\n  bad: indentation")
+    loaded, errors = store.list_definitions_with_errors()
+    assert [ls.definition.name for ls in loaded] == ["good"]
+    assert len(errors) == 1
+    assert errors[0].source_path.name == "broken.yaml"
+
+
+def test_list_records_errors_for_invalid_schema(store):
+    _write(store, "bad", textwrap.dedent("""
+        conduit: x
+        schedule:
+          type: recurring
+          days: [funday]
+          hours: ["09:00"]
+    """))
+    loaded, errors = store.list_definitions_with_errors()
+    assert loaded == []
+    assert len(errors) == 1
+
+
+def test_read_unknown(store):
+    with pytest.raises(FileNotFoundError):
+        store.read("missing")
+
+
+def test_read_patches_name_from_filename(store):
+    _write(store, "weekly", RECURRING_YAML)
+    sd = store.read("weekly")
+    assert sd.name == "weekly"
+
+
+def test_read_rejects_filename_name_mismatch(store):
+    _write(store, "weekly", "name: other\n" + RECURRING_YAML)
+    with pytest.raises(ValueError) as exc:
+        store.read("weekly")
+    assert "filename stem" in str(exc.value)
+
+
+# -------------------------------------------------------------- write
+
+
+def test_write_creates_file_and_omits_name_field(store):
+    sd = ScheduleDefinition.model_validate({
+        "name": "nightly",
+        "conduit": "report",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    path = store.write(sd)
+    assert path.exists()
+    raw = yaml.safe_load(path.read_text())
+    assert "name" not in raw
+    assert raw["conduit"] == "report"
+    # Round-trip via read.
+    parsed = store.read("nightly")
+    assert parsed.name == "nightly"
+    assert parsed.conduit == "report"
+
+
+def test_write_collision_without_force(store):
+    sd = ScheduleDefinition.model_validate({
+        "name": "n",
+        "conduit": "c",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    store.write(sd)
+    with pytest.raises(FileExistsError):
+        store.write(sd)
+
+
+def test_write_force_overwrites(store):
+    sd = ScheduleDefinition.model_validate({
+        "name": "n",
+        "conduit": "old",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    store.write(sd)
+    sd2 = ScheduleDefinition.model_validate({
+        "name": "n",
+        "conduit": "new",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    store.write(sd2, force=True)
+    assert store.read("n").conduit == "new"
+
+
+# -------------------------------------------------------------- install
+
+
+def test_install_copies_file(tmp_path, store):
+    src = tmp_path / "scratch.yaml"
+    src.write_text("name: copied\n" + RECURRING_YAML)
+    dest = store.install(src)
+    assert dest == store.path_for("copied")
+    assert store.read("copied").conduit == "report"
+
+
+def test_install_uses_filename_when_no_name_field(tmp_path, store):
+    src = tmp_path / "from-stem.yaml"
+    src.write_text(RECURRING_YAML)
+    dest = store.install(src)
+    assert dest.name == "from-stem.yaml"
+
+
+def test_install_rejects_collision(tmp_path, store):
+    src = tmp_path / "scratch.yaml"
+    src.write_text("name: dup\n" + RECURRING_YAML)
+    store.install(src)
+    with pytest.raises(FileExistsError):
+        store.install(src)
+
+
+def test_install_force_overwrites(tmp_path, store):
+    src = tmp_path / "scratch.yaml"
+    src.write_text("name: dup\n" + RECURRING_YAML)
+    store.install(src)
+    src.write_text("name: dup\nconduit: changed\nschedule:\n  type: once\n  at: '2026-01-01T00:00:00'\n")
+    store.install(src, force=True)
+    assert store.read("dup").conduit == "changed"
+
+
+def test_install_validates_before_writing(tmp_path, store):
+    src = tmp_path / "bad.yaml"
+    src.write_text("name: bad\nconduit: c\nschedule:\n  type: bogus\n")
+    with pytest.raises(Exception):  # ValidationError surfaces as ValueError-like
+        store.install(src)
+    assert not store.path_for("bad").exists()
+
+
+# -------------------------------------------------------------- remove
+
+
+def test_remove_returns_true_when_existed(store):
+    _write(store, "x", RECURRING_YAML)
+    store.mark_fired("x", "2026-05-01T09:00:00")
+    assert store.remove("x") is True
+    assert not store.path_for("x").exists()
+    assert store.fired_at("x") is None
+
+
+def test_remove_returns_false_when_missing(store):
+    assert store.remove("ghost") is False
+
+
+# -------------------------------------------------------------- fired-state
+
+
+def test_fired_state_round_trip(store):
+    assert store.fired_at("once") is None
+    store.mark_fired("once", "2026-05-01T09:00:00")
+    assert store.fired_at("once") == "2026-05-01T09:00:00"
+    store.mark_fired("once", "2026-06-01T09:00:00")
+    assert store.fired_at("once") == "2026-06-01T09:00:00"
+
+
+def test_fired_state_clear(store):
+    store.mark_fired("a", "2026-05-01T09:00:00")
+    store.mark_fired("b", "2026-05-02T09:00:00")
+    store.clear_fired("a")
+    assert store.fired_at("a") is None
+    assert store.fired_at("b") == "2026-05-02T09:00:00"
+
+
+def test_fired_state_resilient_to_corrupt_file(store):
+    store.state_path.parent.mkdir(parents=True, exist_ok=True)
+    store.state_path.write_text("{not json")
+    assert store.fired_at("x") is None
+    store.mark_fired("x", "2026-05-01T09:00:00")
+    assert store.fired_at("x") == "2026-05-01T09:00:00"

--- a/tests/services/scheduler/test_triggers.py
+++ b/tests/services/scheduler/test_triggers.py
@@ -1,0 +1,154 @@
+"""Tests for trigger construction (APScheduler integration)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from apscheduler.triggers.combining import OrTrigger
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from app.schemas.schedule import ScheduleDefinition
+from app.services.scheduler.triggers import default_local_zone, to_trigger
+
+
+UTC = ZoneInfo("UTC")
+NYC = ZoneInfo("America/New_York")
+
+
+def _def(payload: dict) -> ScheduleDefinition:
+    return ScheduleDefinition.model_validate(payload)
+
+
+# -------------------------------------------------------------- once
+
+
+def test_once_naive_uses_default_zone():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {"type": "once", "at": "2026-05-01T09:00:00"},
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    assert isinstance(trig, DateTrigger)
+    fire = trig.get_next_fire_time(None, datetime(2026, 4, 1, tzinfo=UTC))
+    assert fire == datetime(2026, 5, 1, 9, 0, tzinfo=UTC)
+
+
+def test_once_naive_uses_per_schedule_timezone_override():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "timezone": "America/New_York",
+        "schedule": {"type": "once", "at": "2026-05-01T09:00:00"},
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    fire = trig.get_next_fire_time(None, datetime(2026, 4, 1, tzinfo=UTC))
+    assert fire.astimezone(NYC) == datetime(2026, 5, 1, 9, 0, tzinfo=NYC)
+
+
+def test_once_aware_at_keeps_its_tz():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {"type": "once", "at": "2026-05-01T09:00:00Z"},
+    })
+    trig = to_trigger(sd, default_zone=NYC)
+    fire = trig.get_next_fire_time(None, datetime(2026, 4, 1, tzinfo=UTC))
+    assert fire == datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+
+# -------------------------------------------------------------- recurring
+
+
+def test_recurring_single_hour_returns_cron():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    assert isinstance(trig, CronTrigger)
+    # 2026-04-25 is a Saturday → next Monday is 2026-04-27 09:00 UTC.
+    fire = trig.get_next_fire_time(None, datetime(2026, 4, 25, tzinfo=UTC))
+    assert fire == datetime(2026, 4, 27, 9, 0, tzinfo=UTC)
+
+
+def test_recurring_multiple_hours_uses_or_trigger():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {
+            "type": "recurring",
+            "days": ["mon"],
+            "hours": ["09:00", "17:30"],
+        },
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    assert isinstance(trig, OrTrigger)
+    after_morning = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)  # Mon afternoon
+    fire = trig.get_next_fire_time(None, after_morning)
+    assert fire == datetime(2026, 4, 27, 17, 30, tzinfo=UTC)
+
+
+def test_recurring_does_not_collapse_cross_product():
+    """09:30 + 17:00 must NOT fire 09:00, 17:30 — that was the cron pitfall
+    the OrTrigger composition exists to avoid."""
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {
+            "type": "recurring",
+            "days": ["mon"],
+            "hours": ["09:30", "17:00"],
+        },
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    base = datetime(2026, 4, 27, 0, 0, tzinfo=UTC)
+    fires: list[datetime] = []
+    cur = base
+    for _ in range(4):
+        cur = trig.get_next_fire_time(None, cur)
+        if cur is None:
+            break
+        fires.append(cur)
+        cur = cur.replace(minute=cur.minute + 1)
+    assert fires[0] == datetime(2026, 4, 27, 9, 30, tzinfo=UTC)
+    assert fires[1] == datetime(2026, 4, 27, 17, 0, tzinfo=UTC)
+    # No spurious 09:00 or 17:30 fires.
+    bad_minutes = {(d.hour, d.minute) for d in fires} & {(9, 0), (17, 30)}
+    assert not bad_minutes
+
+
+def test_recurring_per_schedule_timezone():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "timezone": "America/New_York",
+        "schedule": {"type": "recurring", "days": ["mon"], "hours": ["09:00"]},
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    fire = trig.get_next_fire_time(None, datetime(2026, 4, 25, tzinfo=UTC))
+    # 09:00 NYC on the next Monday = 13:00 UTC (EDT, -4)
+    assert fire.astimezone(NYC) == datetime(2026, 4, 27, 9, 0, tzinfo=NYC)
+
+
+def test_recurring_daily():
+    sd = _def({
+        "name": "x",
+        "conduit": "c",
+        "schedule": {"type": "recurring", "days": ["*"], "hours": ["00:00"]},
+    })
+    trig = to_trigger(sd, default_zone=UTC)
+    fire = trig.get_next_fire_time(
+        None, datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    )
+    assert fire == datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
+
+
+# -------------------------------------------------------------- default zone
+
+
+def test_default_local_zone_returns_zoneinfo():
+    z = default_local_zone()
+    assert isinstance(z, ZoneInfo)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -363,6 +363,153 @@ tasks:
 """
 
 
+# ---------------------------------------------------------------- schedule cmds
+
+
+SCHEDULE_RECURRING_YAML = """
+name: nightly
+conduit: hello
+inputs:
+  name: world
+schedule:
+  type: recurring
+  days: [mon, fri]
+  hours: ["09:00"]
+"""
+
+SCHEDULE_ONCE_YAML = """
+name: backfill
+conduit: hello
+inputs:
+  name: once
+schedule:
+  type: once
+  at: "2099-05-01T09:00:00"
+"""
+
+
+def test_schedule_add_and_list(workdir, tmp_path):
+    src = tmp_path / "nightly.yaml"
+    src.write_text(SCHEDULE_RECURRING_YAML)
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "add", str(src)])
+    assert result.exit_code == 0, result.output
+    assert "installed" in result.output
+    assert (workdir / ".atelier" / "schedules" / "nightly.yaml").exists()
+
+    listing = runner.invoke(app, ["schedule", "list"])
+    assert listing.exit_code == 0, listing.output
+    assert "nightly" in listing.output
+    assert "hello" in listing.output
+    assert "recurring" in listing.output
+
+
+def test_schedule_add_collision_requires_force(workdir, tmp_path):
+    src = tmp_path / "nightly.yaml"
+    src.write_text(SCHEDULE_RECURRING_YAML)
+    runner = CliRunner()
+    runner.invoke(app, ["schedule", "add", str(src)])
+    again = runner.invoke(app, ["schedule", "add", str(src)])
+    assert again.exit_code != 0
+    assert "already exists" in again.output
+
+    forced = runner.invoke(app, ["schedule", "add", str(src), "--force"])
+    assert forced.exit_code == 0, forced.output
+
+
+def test_schedule_add_rejects_invalid_yaml(workdir, tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("name: bad\nconduit: c\nschedule:\n  type: weekly\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "add", str(bad)])
+    assert result.exit_code != 0
+    assert "invalid schedule" in result.output
+
+
+def test_schedule_remove(workdir, tmp_path):
+    src = tmp_path / "nightly.yaml"
+    src.write_text(SCHEDULE_RECURRING_YAML)
+    runner = CliRunner()
+    runner.invoke(app, ["schedule", "add", str(src)])
+
+    result = runner.invoke(app, ["schedule", "remove", "nightly"])
+    assert result.exit_code == 0, result.output
+    assert "removed" in result.output
+    assert not (workdir / ".atelier" / "schedules" / "nightly.yaml").exists()
+
+
+def test_schedule_remove_unknown(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "remove", "ghost"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_schedule_list_empty(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "list"])
+    assert result.exit_code == 0
+    assert "no schedules" in result.output
+
+
+def test_schedule_list_json_includes_one_shot(workdir, tmp_path):
+    src = tmp_path / "backfill.yaml"
+    src.write_text(SCHEDULE_ONCE_YAML)
+    runner = CliRunner()
+    runner.invoke(app, ["schedule", "add", str(src)])
+
+    result = runner.invoke(app, ["schedule", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+    assert "schedules" in payload and "errors" in payload
+    assert len(payload["schedules"]) == 1
+    entry = payload["schedules"][0]
+    assert entry["name"] == "backfill"
+    assert entry["kind"] == "once"
+    assert entry["next_fire_time"].startswith("2099-05-01")
+
+
+def test_schedule_list_surfaces_load_errors(workdir):
+    schedules_dir = workdir / ".atelier" / "schedules"
+    schedules_dir.mkdir(parents=True, exist_ok=True)
+    (schedules_dir / "broken.yaml").write_text(
+        "conduit: c\nschedule:\n  type: bogus\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "list"])
+    assert result.exit_code == 0  # broken schedules don't fail the listing
+    assert "broken.yaml" in result.output
+
+
+def test_schedule_run_now(workdir, tmp_path):
+    src = tmp_path / "nightly.yaml"
+    src.write_text(SCHEDULE_RECURRING_YAML)
+    runner = CliRunner()
+    runner.invoke(app, ["schedule", "add", str(src)])
+
+    result = runner.invoke(app, ["schedule", "run-now", "nightly"])
+    assert result.exit_code == 0, result.output
+    assert "flow_id" in result.output
+    assert "greet" in result.output  # task from the hello conduit
+
+
+def test_schedule_run_now_unknown(workdir):
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "run-now", "ghost"])
+    assert result.exit_code != 0
+    assert "schedule not found" in result.output
+
+
+def test_scheduler_status_alias(workdir, tmp_path):
+    src = tmp_path / "nightly.yaml"
+    src.write_text(SCHEDULE_RECURRING_YAML)
+    runner = CliRunner()
+    runner.invoke(app, ["schedule", "add", str(src)])
+    result = runner.invoke(app, ["scheduler", "status"])
+    assert result.exit_code == 0, result.output
+    assert "nightly" in result.output
+
+
 def test_run_failure_prints_flow_id_and_status_hint(tmp_path, monkeypatch):
     """Failure output must include the flow_id and a next-step hint so
     the user can inspect what happened. Previously the flow_id was only

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -59,11 +71,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
+    { name = "apscheduler" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
+    { name = "tzdata" },
+    { name = "tzlocal" },
 ]
 
 [package.dev-dependencies]
@@ -76,11 +91,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.9.0" },
+    { name = "apscheduler", specifier = ">=3.10,<4" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "tzdata", specifier = ">=2024.1" },
+    { name = "tzlocal", specifier = ">=5.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -370,4 +388,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]


### PR DESCRIPTION
## What

Adds a scheduler subsystem to flow-atelier that runs conduits on a wall-clock
schedule. Schedules are YAML files under `.atelier/schedules/`; a single
foreground asyncio daemon (`atelier scheduler start`) fires them
identically on Linux, macOS, and Windows.

Two schedule modes:

- **`once`** — fire a single time at a given ISO 8601 instant.
- **`recurring`** — fire on every (day-of-week × time-of-day) cross product.
  Days accept `mon..sun`, `monday..sunday`, integers `0..6`, or `*` /
  `daily` for every day. Times are `HH:MM` (24h).

New CLI surface:

```
atelier schedule add <file.yaml> [--force]
atelier schedule list [--json]
atelier schedule remove <name>
atelier schedule run-now <name>
atelier scheduler start [--reload-interval 30] [--log-level INFO]
atelier scheduler status [--json]
```

Example schedule:

```yaml
# .atelier/schedules/nightly-report.yaml
conduit: report
working_dir: ./projects/foo
inputs:
  date: today
timezone: America/Bogota          # optional; default = system local zone
schedule:
  type: recurring
  days: [mon, tue, wed, thu, fri]
  hours: ["09:00", "17:30"]
```

## Why

The engine today only runs ad-hoc — `atelier run <conduit>` blocks until the
DAG completes, then exits. There was no way to trigger a conduit on a
schedule, leaving recurring/scheduled work (nightly reports, periodic
backfills, weekly deploys) outside the tool. This change adds first-class
scheduling without forcing users to wire up cron / launchd / Task Scheduler
themselves and without losing the cross-platform parity the rest of the CLI
already provides.

## How

Three-layer service module under `app/services/scheduler/`, called by two
new Typer sub-apps. The runner is a thin caller of the existing
`Atelier.run_conduit` facade — no engine, executor, or store changes were
needed.

### Library choice

**APScheduler 3.11** (pure Python, cross-platform) with `AsyncIOScheduler`
+ `CronTrigger` / `DateTrigger` / `OrTrigger`. Plus `tzdata` (so Windows
hosts have a timezone DB) and `tzlocal` (to resolve the system zone to an
IANA name on Windows, where `datetime.now().astimezone()` yields a fixed
offset).

### Architecture

- **`app/schemas/schedule.py`** — `ScheduleDefinition` pydantic model with
  a discriminated `OnceSchedule | RecurringSchedule` union. Validates day
  aliases, `HH:MM(:SS)?`, ISO 8601 timestamps, and IANA timezones via
  `zoneinfo.ZoneInfo`.
- **`app/services/scheduler/store.py`** — YAML CRUD for
  `.atelier/schedules/*.yaml` plus a `.state.json` recording fired-at
  timestamps for `once` schedules so a daemon restart never re-runs them.
- **`app/services/scheduler/triggers.py`** — pure conversion of a
  `ScheduleDefinition` into an APScheduler trigger. Recurring schedules
  build one `CronTrigger` per `HH:MM` and combine them via `OrTrigger`,
  which avoids the cron cross-product pitfall (a naive `hour="9,17",
  minute="0,30"` would fire 09:00, 09:30, 17:00, **and** 17:30; we want
  exactly 09:30 and 17:00 in that example).
- **`app/services/scheduler/runner.py`** — `SchedulerDaemon` owns the
  `AsyncIOScheduler`, hot-reloads YAML on an mtime-based diff (default
  every 30s, configurable), dispatches each fire by constructing
  `Atelier(base_dir=working_dir / ".atelier")` and awaiting
  `run_conduit`, and survives a single failed fire without crashing the
  loop. SIGINT / SIGTERM exit cleanly on Unix; Windows uses Ctrl+C +
  `KeyboardInterrupt`.

### Behavioural decisions

- **Foreground daemon only.** No `--detach`, no PID file, no service
  install. Users plug it into their preferred supervisor (`systemd
  --user`, `launchd`, NSSM). This keeps the implementation a single
  asyncio entrypoint with no platform-specific code paths.
- **YAML is the source of truth.** APScheduler runs with the in-memory
  job store; jobs are rebuilt from YAML on startup and on every reload
  tick. Avoids the "DB and YAML drift" failure mode and keeps the tool
  inspectable with `cat`.
- **Default timezone = system local**, per-schedule `timezone:` overrides.
  Naive `at:` values are interpreted in the resolved zone.
- **One-shot deduplication** via `.atelier/schedules/.state.json` keyed
  by `name + scheduled_at`. Editing the YAML to a new `at:` re-arms.
- **`max_instances=1` + `coalesce=True`** per job — no overlapping
  instances of the same schedule, missed fires collapse to one.
- **`schedule run-now`** dispatches a schedule immediately *without* going
  through the daemon and *without* touching fired-state, useful for
  testing a schedule's inputs.

### Settings

`AtelierSettings` gains two env-overridable paths (`ATELIER_SCHEDULES_DIR`,
`ATELIER_SCHEDULER_STATE_PATH`), both defaulting under the existing
`atelier_dir`.

### Folder layout

```
.atelier/
├── conduits/
│   └── <conduit_name>/conduit.yaml
├── schedules/
│   ├── <schedule_name>.yaml             # one ScheduleDefinition per file
│   └── .state.json                      # fired-once markers (managed by the daemon)
└── flows/
    └── <flow_id>/...
```

## Test plan

- [x] `uv run pytest` — full suite green (318 tests, 87 new)
  - Schema: 33 tests covering day/time/tz normalization, discriminator,
    extra-field rejection
  - Store: 21 tests covering YAML CRUD, install-from-source,
    fired-state round-trip, corrupt-state resilience
  - Triggers: 9 tests including the cron cross-product regression and
    cross-zone next-fire computation
  - Runner: 18 tests covering startup/sync/fire/one-shot-dedup, with
    a recording executor so no real conduits run
  - CLI: 11 new smoke tests via `typer.testing.CliRunner` covering
    add / list / remove / run-now / status, plus the JSON modes
- [ ] Manual smoke (Linux, macOS, Windows):
  ```
  atelier init
  echo 'conduit: hello
  inputs: {name: world}
  schedule: {type: recurring, days: ["*"], hours: ["09:00"]}' \
    > /tmp/daily.yaml
  atelier schedule add /tmp/daily.yaml
  atelier schedule list           # should show next fire time
  atelier scheduler start         # foreground; fires at 09:00 local
  ```
- [ ] Confirm `timezone: America/Bogota` override works on Windows once
  `tzdata` is installed (no system tz DB on stock Windows).

## Out of scope

Deferred to follow-ups: OS-native install (cron / launchd / `schtasks`),
detached daemon / Windows service wrapper, global-scope schedules under
`~/.atelier/schedules/`, retry-on-failure policies, holiday calendars.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGZmTobw8hTaUREJXqLcnm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schedule management CLI commands: create, list, remove, and immediately execute schedules
  * Introduced scheduler daemon for running conduits on wall-clock schedules
  * Supports YAML-based schedule definitions with recurring and one-shot modes
  * Added per-schedule timezone and working directory configuration
  * Daemon automatically reloads schedule changes without restart
  * Tracks one-shot schedule execution across daemon restarts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->