### PR TITLE
Chore/ci tooling and ruff cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install 3.13
+      - run: uv sync --dev
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install 3.13
+      - run: uv sync --dev
+      - name: Tests (excluding live harness)
+        run: uv run pytest --ignore=tests/test_live_harness.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pyver=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          test "$tag" = "$pyver" || { echo "tag $tag != pyproject $pyver"; exit 1; }
+
+  build-wheel:
+    needs: verify-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install 3.13
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  build-binary:
+    needs: verify-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: atelier-linux-x86_64
+            bin: atelier
+          - os: macos-latest
+            asset: atelier-macos-arm64
+            bin: atelier
+          - os: windows-latest
+            asset: atelier-windows-x86_64.exe
+            bin: atelier.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install 3.13
+      - run: uv sync --dev
+      - name: Build binary
+        shell: bash
+        run: |
+          uv run pyinstaller scripts/atelier_entry.py \
+            --onefile --name atelier --clean --noconfirm \
+            --collect-all uvicorn \
+            --collect-all apscheduler \
+            --collect-all tzdata \
+            --collect-all agent_client_protocol
+      - name: Smoke test the binary
+        shell: bash
+        run: ./dist/${{ matrix.bin }} --help
+      - name: Rename for upload
+        shell: bash
+        run: mv dist/${{ matrix.bin }} dist/${{ matrix.asset }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bin-${{ matrix.os }}
+          path: dist/${{ matrix.asset }}
+
+  publish-pypi:
+    needs: [build-wheel, build-binary]
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Flatten artifacts
+        run: mkdir -p release && find artifacts -type f -exec cp {} release/ \;
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 wheels/
 *.egg-info
+*.spec
 
 # Virtual environments
 .venv*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest (excluding live harness)
+        entry: uv run pytest --ignore=tests/test_live_harness.py
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -34,21 +34,14 @@ marker appears in the agent's output.
 
 ## Install
 
-Requires Python 3.13+ and [uv](https://docs.astral.sh/uv/).
+### From PyPI
 
-Install `atelier` globally on your PATH so it runs from any directory
-(similar to how `claude` and `codex` run anywhere):
-
-```bash
-git clone <this-repo> flow-atelier
-cd flow-atelier
-uv tool install .
-```
-
-You can also install directly from a remote:
+Requires Python 3.13+. Install with [uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/):
 
 ```bash
-uv tool install git+<repo-url>
+uv tool install flow-atelier
+# or
+pipx install flow-atelier
 ```
 
 To upgrade or uninstall later:
@@ -56,6 +49,36 @@ To upgrade or uninstall later:
 ```bash
 uv tool upgrade flow-atelier
 uv tool uninstall flow-atelier
+```
+
+### Standalone binary (no Python required)
+
+Download the appropriate file from the
+[latest release](https://github.com/LGuillermoAngaritaG/flow-atelier/releases/latest):
+
+- `atelier-linux-x86_64`
+- `atelier-macos-arm64`
+- `atelier-windows-x86_64.exe`
+
+Make it executable (Linux/macOS) and put it on your `PATH`:
+
+```bash
+chmod +x atelier-linux-x86_64
+sudo mv atelier-linux-x86_64 /usr/local/bin/atelier
+```
+
+### From source
+
+```bash
+git clone <this-repo> flow-atelier
+cd flow-atelier
+uv tool install .
+```
+
+Or directly from a remote:
+
+```bash
+uv tool install git+<repo-url>
 ```
 
 For local development inside the repo, a plain `uv sync` + `uv run atelier`

--- a/app/cli/commands/run.py
+++ b/app/cli/commands/run.py
@@ -8,7 +8,11 @@ import typer
 
 from app.cli._shared import _parse_inputs, console
 from app.cli.main import app
-from app.cli.rendering.render import _render_orchestration_msg, _render_run_footer, _render_task_event
+from app.cli.rendering.render import (
+    _render_orchestration_msg,
+    _render_run_footer,
+    _render_task_event,
+)
 from app.core.atelier import Atelier
 from app.schemas.log import TaskEvent
 

--- a/app/cli/commands/scheduler.py
+++ b/app/cli/commands/scheduler.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import typer
 
 from app.cli._shared import _schedule_store, console
-from app.cli.main import scheduler_app
 from app.cli.commands.schedule import schedule_list_cmd
+from app.cli.main import scheduler_app
 from app.services.scheduler import SchedulerDaemon, default_local_zone
 
 

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -36,11 +36,11 @@ app.add_typer(scheduler_app, name="scheduler")
 # decoration order in app/main.py so --help layout stays byte-identical.
 from app.cli.commands import (  # noqa: E402, F401
     init,
-    run,
-    status,
     logs,
-    list as _list,
+    run,
     schedule,
     scheduler,
     serve,
+    status,
 )
+from app.cli.commands import list as _list  # noqa: E402, F401

--- a/app/cli/rendering/render.py
+++ b/app/cli/rendering/render.py
@@ -8,7 +8,12 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from app.cli._shared import _format_clock, _format_clock_short, _format_duration_seconds, _format_next_fire
+from app.cli._shared import (
+    _format_clock,
+    _format_clock_short,
+    _format_duration_seconds,
+    _format_next_fire,
+)
 from app.schemas.log import IntermediateStep, StepKind, TaskEvent
 from app.schemas.progress import FlowStatus, Progress, TaskStatus
 from app.services.scheduler import PlannedJob
@@ -324,10 +329,7 @@ def _render_log_entry(entry, show: str, console: Console) -> None:
 
     if show == "steps":
         steps = getattr(entry, "steps", [])
-        if steps:
-            body = _render_steps_timeline(steps)
-        else:
-            body = Text("(no steps)")
+        body = _render_steps_timeline(steps) if steps else Text("(no steps)")
     elif show == "all":
         body = Text()
         steps = getattr(entry, "steps", [])

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -22,7 +22,6 @@ from app.schemas.conduit import Conduit
 from app.schemas.flow import parse_flow_id
 from app.schemas.log import LogEntry
 from app.schemas.progress import Progress
-from app.services.scheduler.store import ScheduleStore
 from app.services.executor.bash import BashExecutor
 from app.services.executor.conduit import ConduitExecutor
 from app.services.executor.harness import (
@@ -34,8 +33,8 @@ from app.services.executor.harness import (
 )
 from app.services.executor.hitl import HitlExecutor
 from app.services.executor.prompt_sink import PromptSink, TerminalPromptSink
+from app.services.scheduler.store import ScheduleStore
 from app.services.store.filesystem import FilesystemStore
-
 
 logger = logging.getLogger(__name__)
 

--- a/app/modules/conditions.py
+++ b/app/modules/conditions.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Literal, Union
+from typing import Literal
 
 from app.schemas.progress import TaskStatus
 
@@ -45,7 +45,7 @@ class ConditionalDependency:
         return self._compiled
 
 
-Dependency = Union[PlainDependency, ConditionalDependency]
+Dependency = PlainDependency | ConditionalDependency
 
 
 class DependencyParseError(ValueError):

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 import asyncio
 import sys
 import traceback
-from datetime import datetime, timezone
-from typing import Any, Callable
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
 
 from app.modules.conditions import (
     DependencyParseError,
@@ -48,7 +49,7 @@ def _now() -> str:
 
     :returns: ISO-8601 timestamp ending with ``Z``.
     """
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _validate_dag(conduit: Conduit) -> dict[str, list]:
@@ -405,13 +406,13 @@ class Engine:
                     for iteration in range(1, t.repeat + 1):
                         mark_running(t.name, iteration)
                         started = _now()
-                        start_ts = datetime.now(timezone.utc)
+                        start_ts = datetime.now(UTC)
                         try:
                             result = await asyncio.wait_for(
                                 executor.execute(t, resolved, ctx),
                                 timeout=conduit.timeout,
                             )
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             result = ExecutionResult(
                                 exit_code=124,
                                 stderr=f"engine timeout after {conduit.timeout}s",
@@ -422,7 +423,7 @@ class Engine:
                             )
                         finished = _now()
                         duration = (
-                            datetime.now(timezone.utc) - start_ts
+                            datetime.now(UTC) - start_ts
                         ).total_seconds()
                         await self.store.append_log(
                             flow_id,

--- a/app/routes/conduits.py
+++ b/app/routes/conduits.py
@@ -15,7 +15,6 @@ from app.schemas.api import (
 )
 from app.services.api.base import get_atelier
 
-
 router = APIRouter(prefix="/conduits", tags=["conduits"])
 
 

--- a/app/routes/flows.py
+++ b/app/routes/flows.py
@@ -7,7 +7,6 @@ from fastapi.responses import JSONResponse
 from app.core.atelier import Atelier
 from app.services.api.base import get_atelier
 
-
 router = APIRouter(prefix="/flows", tags=["flows"])
 
 

--- a/app/routes/schedules.py
+++ b/app/routes/schedules.py
@@ -8,7 +8,6 @@ from app.core.atelier import Atelier
 from app.schemas.api import CreateScheduleInput
 from app.services.api.base import get_atelier
 
-
 router = APIRouter(prefix="/schedules", tags=["schedules"])
 
 

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -7,7 +7,6 @@ from app.core.atelier import Atelier
 from app.schemas.api import RunTaskInput, RunTaskOutput
 from app.services.api.base import get_atelier
 
-
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -22,7 +22,6 @@ from app.services.api.base import get_atelier
 from app.services.api.ws_hitl import WsHitlExecutor
 from app.services.api.ws_manager import WebSocketBroker
 
-
 logger = logging.getLogger(__name__)
 router = APIRouter()
 _client_message_adapter = TypeAdapter(ClientMessage)

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -129,7 +129,7 @@ class ScheduleConfig(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _check_mode_fields(self) -> "ScheduleConfig":
+    def _check_mode_fields(self) -> ScheduleConfig:
         """Ensure required fields are present for the selected ``mode``.
 
         :returns: the validated ``ScheduleConfig`` instance.

--- a/app/schemas/conduit.py
+++ b/app/schemas/conduit.py
@@ -54,7 +54,7 @@ class TaskDefinition(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _validate_loop_predicates(self) -> "TaskDefinition":
+    def _validate_loop_predicates(self) -> TaskDefinition:
         """Validate ``until``/``while`` mutual exclusion and predicate syntax.
 
         :returns: the validated ``TaskDefinition`` instance.
@@ -118,7 +118,7 @@ class Conduit(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _validate_unique_task_names(self) -> "Conduit":
+    def _validate_unique_task_names(self) -> Conduit:
         """Ensure no two tasks in the conduit share the same ``name``.
 
         :returns: the validated ``Conduit`` instance.

--- a/app/schemas/flow.py
+++ b/app/schemas/flow.py
@@ -3,34 +3,34 @@ from __future__ import annotations
 
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
 
-FLOW_ID_RE = re.compile(r"^(?P<conduit>.+)_(?P<uuid>[0-9a-f]{8})_(?P<ts>\d{8}T\d{6}Z)$")
+FLOW_ID_RE = re.compile(r"^(?P<date>\d{8})_(?P<uuid>[0-9a-f]{8})_(?P<conduit>.+)$")
 
 
 def new_flow_id(conduit_name: str) -> str:
-    """Build a filesystem-safe flow id: <conduit>_<uuid8>_<YYYYMMDDTHHMMSSZ>.
+    """Build a filesystem-safe flow id: <YYYYMMDD>_<uuid8>_<conduit>.
 
     :param conduit_name: name of the conduit this flow belongs to.
-    :returns: a new flow id string composed of conduit, short uuid, and UTC timestamp.
+    :returns: a new flow id string composed of UTC date, short uuid, and conduit name.
     """
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return f"{conduit_name}_{uuid.uuid4().hex[:8]}_{ts}"
+    date = datetime.now(UTC).strftime("%Y%m%d")
+    return f"{date}_{uuid.uuid4().hex[:8]}_{conduit_name}"
 
 
 def parse_flow_id(flow_id: str) -> tuple[str, str, str]:
-    """Return (conduit_name, uuid8, timestamp) — raises ValueError if invalid.
+    """Return (conduit_name, uuid8, date) — raises ValueError if invalid.
 
     :param flow_id: a flow id previously built by :func:`new_flow_id`.
-    :returns: a tuple of ``(conduit_name, uuid8, timestamp)`` parsed from the id.
+    :returns: a tuple of ``(conduit_name, uuid8, date)`` parsed from the id.
     """
     m = FLOW_ID_RE.match(flow_id)
     if not m:
         raise ValueError(f"Invalid flow id: {flow_id!r}")
-    return m.group("conduit"), m.group("uuid"), m.group("ts")
+    return m.group("conduit"), m.group("uuid"), m.group("date")
 
 
 class Flow(BaseModel):

--- a/app/schemas/log.py
+++ b/app/schemas/log.py
@@ -1,7 +1,7 @@
 """Log and execution result schemas."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -21,7 +21,7 @@ def _now_iso() -> str:
 
     :returns: current UTC timestamp formatted as ISO 8601 with ``Z`` suffix.
     """
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 class IntermediateStep(BaseModel):

--- a/app/schemas/progress.py
+++ b/app/schemas/progress.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -26,12 +25,12 @@ class TaskProgress(BaseModel):
     status: TaskStatus = TaskStatus.pending
     iteration: int = 1
     of: int = 1
-    reason: Optional[str] = None
+    reason: str | None = None
 
 
 class Progress(BaseModel):
     status: FlowStatus = FlowStatus.running
     current_tasks: list[str] = Field(default_factory=list)
     tasks: dict[str, TaskProgress] = Field(default_factory=dict)
-    started_at: Optional[str] = None
-    finished_at: Optional[str] = None
+    started_at: str | None = None
+    finished_at: str | None = None

--- a/app/services/api/ws_manager.py
+++ b/app/services/api/ws_manager.py
@@ -11,7 +11,6 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-
 SendCallable = Callable[[dict[str, Any]], Awaitable[None]]
 
 

--- a/app/services/executor/base.py
+++ b/app/services/executor/base.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from app.schemas.conduit import TaskDefinition
 from app.schemas.log import ExecutionResult

--- a/app/services/executor/bash.py
+++ b/app/services/executor/bash.py
@@ -33,7 +33,7 @@ class BashExecutor(ExecutorBase):
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
                 proc.communicate(), timeout=context.timeout
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             proc.kill()
             await proc.wait()
             return ExecutionResult(

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -44,7 +44,6 @@ from app.services.executor.prompt_sink import (
     TerminalPromptSink,
 )
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -394,7 +393,7 @@ class AcpHarnessExecutor(ExecutorBase):
                 self._drive_session(client, prompt_text, task.interactive, cwd),
                 timeout=context.timeout,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return ExecutionResult(
                 exit_code=124,
                 stdout="".join(client.buffer),

--- a/app/services/scheduler/runner.py
+++ b/app/services/scheduler/runner.py
@@ -5,10 +5,10 @@ import asyncio
 import logging
 import signal
 import sys
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Awaitable, Callable
 from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -17,7 +17,6 @@ from apscheduler.triggers.interval import IntervalTrigger
 from app.schemas.api import ScheduledJob
 from app.services.scheduler.store import ScheduleStore
 from app.services.scheduler.triggers import default_local_zone, to_trigger
-
 
 logger = logging.getLogger(__name__)
 
@@ -167,14 +166,13 @@ class SchedulerDaemon:
             logger.info("removed schedule %s (not active)", stale)
 
         for sid, job in active.items():
-            if job.schedule.mode == "once":
+            if job.schedule.mode == "once" and self.store.fired_at(sid):
                 # Skip already-fired one-shots (regardless of whether the
                 # daemon was previously running).
-                if self.store.fired_at(sid):
-                    if sid in live_ids:
-                        self._scheduler.remove_job(sid)
-                    self._planned.pop(sid, None)
-                    continue
+                if sid in live_ids:
+                    self._scheduler.remove_job(sid)
+                self._planned.pop(sid, None)
+                continue
             self._register(job)
 
     def _register(self, job: ScheduledJob) -> None:

--- a/app/services/scheduler/store.py
+++ b/app/services/scheduler/store.py
@@ -16,13 +16,13 @@ import os
 import re
 import time
 import uuid
+from datetime import UTC
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from app.schemas.api import CreateScheduleInput, ScheduledJob
-
 
 _SLUG_RE = re.compile(r"[^a-z0-9._-]+")
 
@@ -234,10 +234,10 @@ class ScheduleStore:
         :param scheduled_at_iso: optional ISO timestamp; defaults to now
         """
         if scheduled_at_iso is None:
-            from datetime import datetime, timezone
+            from datetime import datetime
 
             scheduled_at_iso = (
-                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+                datetime.now(UTC).isoformat().replace("+00:00", "Z")
             )
         data = self._read_state()
         data["schedules"][schedule_id] = {"fired_at_iso": scheduled_at_iso}

--- a/app/services/scheduler/triggers.py
+++ b/app/services/scheduler/triggers.py
@@ -11,7 +11,6 @@ from apscheduler.triggers.date import DateTrigger
 
 from app.schemas.api import ScheduledJob
 
-
 # ISO 8601 day-of-week (1=Mon..7=Sun) → APScheduler cron day_of_week names.
 _ISO_DAY_TO_CRON = {
     1: "mon",

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -19,14 +19,14 @@ import asyncio
 import json
 import os
 import shutil
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from app.schemas.conduit import Conduit
-from app.schemas.flow import new_flow_id
+from app.schemas.flow import new_flow_id, parse_flow_id
 from app.schemas.log import LogEntry
 from app.schemas.progress import Progress
 from app.services.store.base import ConduitSource, StoreBase
@@ -208,7 +208,7 @@ class FilesystemStore(StoreBase):
                     "status": "running",
                     "current_tasks": [],
                     "tasks": {},
-                    "started_at": datetime.now(timezone.utc)
+                    "started_at": datetime.now(UTC)
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "finished_at": None,
@@ -219,18 +219,27 @@ class FilesystemStore(StoreBase):
         return flow_id
 
     def list_flows(self, conduit_name: str | None = None) -> list[str]:
-        """List top-level flow ids, optionally filtered by conduit prefix.
+        """List top-level flow ids, optionally filtered by conduit name.
 
-        :param conduit_name: when set, only flows starting with ``<name>_`` are returned
+        :param conduit_name: when set, only flows whose parsed conduit equals
+            ``conduit_name`` are returned.
         """
         root = self.base_dir / "flows"
         if not root.exists():
             return []
         ids: list[str] = []
         for p in root.iterdir():
-            if p.is_dir():
-                if conduit_name is None or p.name.startswith(conduit_name + "_"):
-                    ids.append(p.name)
+            if not p.is_dir():
+                continue
+            if conduit_name is None:
+                ids.append(p.name)
+                continue
+            try:
+                flow_conduit, _, _ = parse_flow_id(p.name)
+            except ValueError:
+                continue
+            if flow_conduit == conduit_name:
+                ids.append(p.name)
         return sorted(ids)
 
     # ------------------------------------------------------------------ logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,33 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-timeout>=2.3",
     "websockets>=16.0",
+    "ruff>=0.6",
+    "pre-commit>=3.8",
+    "pyinstaller>=6.10",
 ]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = 300
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM"]
+ignore = [
+    "B008",
+    "B904",
+    "E402",
+    "E741",
+    "SIM105",
+    "UP042",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B", "SIM", "E501"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]

--- a/scripts/atelier_entry.py
+++ b/scripts/atelier_entry.py
@@ -1,0 +1,5 @@
+"""PyInstaller entry — produces the standalone `atelier` binary."""
+from app.main import app
+
+if __name__ == "__main__":
+    app()

--- a/tests/cli/test_multiline_input.py
+++ b/tests/cli/test_multiline_input.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import builtins
 import sys
 
-import pytest
-
 
 class TestMultilineInputNonTTY:
     """Non-TTY fallback delegates to builtins.input()."""

--- a/tests/cli/test_render_steps.py
+++ b/tests/cli/test_render_steps.py
@@ -6,9 +6,13 @@ import io
 from rich.console import Console
 from rich.text import Text
 
-from app.cli.rendering.render import _render_log_entry, _render_orchestration_msg, _render_step, _render_task_event
+from app.cli.rendering.render import (
+    _render_log_entry,
+    _render_orchestration_msg,
+    _render_step,
+    _render_task_event,
+)
 from app.schemas.log import IntermediateStep, LogEntry, StepKind, TaskEvent
-from app.schemas.progress import TaskStatus
 
 
 def _console() -> tuple[Console, io.StringIO]:

--- a/tests/core/test_atelier_conduit_crud.py
+++ b/tests/core/test_atelier_conduit_crud.py
@@ -1,7 +1,6 @@
 """Atelier facade: conduit CRUD + open-path."""
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import patch
 

--- a/tests/fixtures/fake_acp_agent.py
+++ b/tests/fixtures/fake_acp_agent.py
@@ -49,7 +49,6 @@ from acp.schema import (
     Implementation,
     InitializeResponse,
     NewSessionResponse,
-    PermissionOption as AcpPermissionOption,
     PromptCapabilities,
     PromptResponse,
     SessionMode,
@@ -57,6 +56,9 @@ from acp.schema import (
     SetSessionModeResponse,
     TextContentBlock,
     ToolCallUpdate,
+)
+from acp.schema import (
+    PermissionOption as AcpPermissionOption,
 )
 
 

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -6,10 +6,10 @@ import pytest
 import yaml
 
 from app.modules.engine import ConduitValidationError, Engine
-from app.schemas.conduit import Conduit, TaskDefinition, ToolType
+from app.schemas.conduit import Conduit
 from app.schemas.log import ExecutionResult
 from app.schemas.progress import FlowStatus, TaskStatus
-from app.services.executor.base import ExecutorBase, FlowContext
+from app.services.executor.base import ExecutorBase
 from app.services.store.filesystem import FilesystemStore
 
 
@@ -222,7 +222,7 @@ async def test_fail_fast_cancels_siblings(store):
     engine = Engine({"tool:bash": fake}, store)
     with pytest.raises(RuntimeError):
         await engine.run(conduit, {})
-    p = store.read_progress(fake_flow := store.list_flows()[0])
+    p = store.read_progress(store.list_flows()[0])
     assert p.status == FlowStatus.failed
     assert p.tasks["fail"].status == TaskStatus.failed
     assert p.tasks["slow"].status in (TaskStatus.cancelled, TaskStatus.failed)

--- a/tests/modules/test_engine_steps.py
+++ b/tests/modules/test_engine_steps.py
@@ -8,7 +8,7 @@ import pytest
 from app.modules.engine import Engine
 from app.schemas.conduit import Conduit
 from app.schemas.log import ExecutionResult, IntermediateStep, StepKind, TaskEvent
-from app.services.executor.base import ExecutorBase, FlowContext
+from app.services.executor.base import ExecutorBase
 from app.services.store.filesystem import FilesystemStore
 
 

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -5,9 +5,8 @@ import pytest
 import yaml
 
 from app.schemas.conduit import Conduit, ToolType
-from app.schemas.flow import new_flow_id, parse_flow_id, FLOW_ID_RE
+from app.schemas.flow import FLOW_ID_RE, new_flow_id, parse_flow_id
 from app.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
-
 
 SAMPLE_YAML = """
 name: deploy_pipeline
@@ -289,10 +288,10 @@ def test_flow_id_roundtrip():
     """Verify a generated flow id parses back into its components."""
     fid = new_flow_id("deploy_pipeline")
     assert FLOW_ID_RE.match(fid)
-    conduit, uuid8, ts = parse_flow_id(fid)
+    conduit, uuid8, date = parse_flow_id(fid)
     assert conduit == "deploy_pipeline"
     assert len(uuid8) == 8
-    assert re.match(r"^\d{8}T\d{6}Z$", ts)
+    assert re.match(r"^\d{8}$", date)
 
 
 def test_parse_flow_id_rejects_invalid():

--- a/tests/services/executor/test_bash.py
+++ b/tests/services/executor/test_bash.py
@@ -1,5 +1,4 @@
 """BashExecutor tests."""
-import pytest
 
 from app.schemas.conduit import TaskDefinition, ToolType
 from app.services.executor.base import FlowContext

--- a/tests/services/executor/test_conduit.py
+++ b/tests/services/executor/test_conduit.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from app.schemas.conduit import TaskDefinition, ToolType
 from app.schemas.log import ExecutionResult, LogEntry
-from app.schemas.progress import FlowStatus, Progress, TaskStatus
+from app.schemas.progress import FlowStatus, Progress
 from app.services.executor.base import FlowContext
 from app.services.executor.conduit import ConduitExecutor
 

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -6,8 +6,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from app.schemas.conduit import TaskDefinition, ToolType
 from app.services.executor.base import FlowContext
 from app.services.executor.harness import (
@@ -21,7 +19,6 @@ from app.services.executor.harness import (
     build_interactive_suffix,
 )
 from app.services.executor.prompt_sink import PermissionOption
-
 
 FAKE_AGENT = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_agent.py"
 

--- a/tests/services/executor/test_prompt_sink.py
+++ b/tests/services/executor/test_prompt_sink.py
@@ -118,6 +118,7 @@ class TestTerminalPromptSink:
         :param monkeypatch: pytest monkeypatch fixture.
         """
         import sys as _sys
+
         import app.cli.rendering.multiline_input as _ml
 
         stream = io.StringIO()

--- a/tests/services/scheduler/test_runner.py
+++ b/tests/services/scheduler/test_runner.py
@@ -8,9 +8,8 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from app.schemas.api import CreateScheduleInput, ScheduledJob
-from app.services.scheduler.runner import SchedulerDaemon, _RELOAD_JOB_ID
+from app.services.scheduler.runner import _RELOAD_JOB_ID, SchedulerDaemon
 from app.services.scheduler.store import ScheduleStore
-
 
 UTC = ZoneInfo("UTC")
 

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -7,7 +7,6 @@ import yaml
 from app.schemas.api import CreateScheduleInput
 from app.services.scheduler.store import ScheduleStore
 
-
 # ----------------------------------------------------------- fixtures / helpers
 
 

--- a/tests/services/scheduler/test_triggers.py
+++ b/tests/services/scheduler/test_triggers.py
@@ -1,7 +1,8 @@
 """Tests for trigger construction (APScheduler integration, JSON store)."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC as _STDLIB_UTC
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from apscheduler.triggers.combining import OrTrigger
@@ -10,7 +11,6 @@ from apscheduler.triggers.date import DateTrigger
 
 from app.schemas.api import ScheduledJob
 from app.services.scheduler.triggers import default_local_zone, to_trigger
-
 
 UTC = ZoneInfo("UTC")
 NYC = ZoneInfo("America/New_York")
@@ -45,7 +45,7 @@ def test_once_aware_run_at_uses_explicit_tz():
     trig = to_trigger(job, default_zone=NYC)
     assert isinstance(trig, DateTrigger)
     fire = trig.get_next_fire_time(None, datetime(2026, 4, 1, tzinfo=UTC))
-    assert fire == datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc)
+    assert fire == datetime(2026, 5, 1, 9, 0, tzinfo=_STDLIB_UTC)
 
 
 def test_once_naive_run_at_uses_default_zone():

--- a/tests/services/store/test_filesystem.py
+++ b/tests/services/store/test_filesystem.py
@@ -8,7 +8,6 @@ from app.schemas.log import LogEntry
 from app.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
 from app.services.store.filesystem import FilesystemStore
 
-
 CONDUIT_YAML = """
 name: hello
 description: Say hello

--- a/tests/test_api/test_ws_run_conduit.py
+++ b/tests/test_api/test_ws_run_conduit.py
@@ -1,7 +1,6 @@
 """/ws/run-conduit end-to-end tests."""
 from __future__ import annotations
 
-import asyncio
 import json
 
 import pytest
@@ -9,7 +8,6 @@ from starlette.testclient import TestClient
 
 from app.core.atelier import Atelier
 from app.services.api.app import FastApiServer
-
 
 HELLO_YAML = """name: hello
 description: Say hello

--- a/tests/test_api/test_ws_step_messages.py
+++ b/tests/test_api/test_ws_step_messages.py
@@ -1,12 +1,6 @@
 """Test that WebSocket emits StepMessage when tasks have steps."""
 from __future__ import annotations
 
-import asyncio
-from typing import Any
-from unittest.mock import AsyncMock
-
-import pytest
-
 from app.schemas.log import IntermediateStep, StepKind, TaskEvent
 from app.schemas.progress import TaskStatus
 

--- a/tests/test_live_harness.py
+++ b/tests/test_live_harness.py
@@ -11,7 +11,6 @@ import pytest
 
 from app.core.atelier import Atelier
 
-
 pytestmark = pytest.mark.timeout(300)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """CLI smoke tests via Typer's CliRunner."""
 import io
 import os
+from datetime import UTC, datetime
 
 import pytest
 from rich.console import Console
@@ -131,7 +132,7 @@ def test_list_flows(workdir):
     runner.invoke(app, ["run", "hello", "--input", "name=a"])
     result = runner.invoke(app, ["list", "flows"])
     assert result.exit_code == 0
-    assert "hello_" in result.output
+    assert "_hello" in result.output
     # New table-based output includes per-flow status and conduit columns.
     assert "status" in result.output
     assert "completed" in result.output
@@ -315,10 +316,11 @@ def test_status_ambiguous_prefix(workdir):
     """
     _write_multi(workdir)
     runner = CliRunner()
-    # Two flows from the same conduit → "multi_" is ambiguous.
+    # Two flows on the same UTC date → the date prefix is ambiguous.
     _run_and_id(runner, "multi")
     _run_and_id(runner, "multi")
-    result = runner.invoke(app, ["status", "multi_"])
+    today = datetime.now(UTC).strftime("%Y%m%d")
+    result = runner.invoke(app, ["status", today])
     assert result.exit_code != 0
     assert "ambiguous" in result.output.lower()
 
@@ -660,8 +662,8 @@ def test_run_failure_prints_flow_id_and_status_hint(tmp_path, monkeypatch):
     assert "flow_id" in result.output
     # Hint should point the user at how to investigate.
     assert "atelier status" in result.output
-    # The id should match the failing_<...> shape.
-    assert "failing_" in result.output
+    # The id should match the <date>_<uid>_failing shape.
+    assert "_failing" in result.output
 
 
 # ---------------------------------------------------------------- renderer

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -66,6 +75,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -87,6 +105,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -100,6 +127,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -124,9 +160,12 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pre-commit" },
+    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
     { name = "websockets" },
 ]
 
@@ -149,9 +188,12 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pre-commit", specifier = ">=3.8" },
+    { name = "pyinstaller", specifier = ">=6.10" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-timeout", specifier = ">=2.3" },
+    { name = "ruff", specifier = ">=0.6" },
     { name = "websockets", specifier = ">=16.0" },
 ]
 
@@ -215,6 +257,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -230,6 +281,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -254,6 +317,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -263,12 +335,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -375,6 +481,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/60/d03d52e6690d4e9caf333dcd14550cde634ce6c118b3bc8fa3112c3186fd/pyinstaller-6.20.0.tar.gz", hash = "sha256:95c5c7e03d5d61e9dfb8ef259c699cf492bb1041beb6dbe83696608cec07347a", size = 4048728, upload-time = "2026-04-22T20:59:36.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/e4/e228d6d1bbb7fd62dc660a8fb202a583b023d3a3624ca95d1a9290ee4d6a/pyinstaller-6.20.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:bf3be4e1284ee78ddccba5e29f99443a12a7b4673168288ffc4c9d38c6f7b90e", size = 1047642, upload-time = "2026-04-22T20:58:32.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/afb631bcb3f9040efebd4f6d067f0828b51710818f69fb41a2d4b7787f52/pyinstaller-6.20.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:72ae9c1fdea134afa791f58bdc9a1934d5c7609753c111e0026bfc272b32b712", size = 742494, upload-time = "2026-04-22T20:58:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/76/08/0729a5bac14754150e5d83b39d87d842eb42b0bffcaa03dbad6252e23a39/pyinstaller-6.20.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1031bcc307f3fbeffd4e162723e64d46dbf591c82dd0997413afb2a07328b941", size = 754191, upload-time = "2026-04-22T20:58:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/82/bc0ee4c7b97db1958eb651e0da9fb1e672e5ae53ca8867fd97701de52906/pyinstaller-6.20.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8df3b3f347659fa2562d8d193a98ad4600133b8b8d07c268df89e4154376750e", size = 751902, upload-time = "2026-04-22T20:58:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/770002d6aaa54173881cb2c49bb195ba67b97bf39bac1cdf320f28401629/pyinstaller-6.20.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:b0d3cc9dd8120d448459bd3880a12e2f9774c51443af49047801446377999a59", size = 748634, upload-time = "2026-04-22T20:58:48.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/db/68ba1fccb71278b2124fb90b37b7c8c0bc4c1173fba45b94466df3d9cb7f/pyinstaller-6.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:03696bb6350177c6bc23bcaf78e71a33c4a89b6754dd90d1be2f318e978c918b", size = 748490, upload-time = "2026-04-22T20:58:52.749Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0f/ac77ffa996a56be3d5c8f85734a007f8347240691657f9704e7de2527fa3/pyinstaller-6.20.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:6357f1699f6af84f37e7367f031d4f68abdba65543b83990c9e8f5a4cebed0b7", size = 747650, upload-time = "2026-04-22T20:58:57.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/1ee91c3a2bc10ca1f36da10a6fd55ff7efc4dec367171eb25992a827874f/pyinstaller-6.20.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0ab39c690abad26ba148e8f664f0478acc82a733997f4f22e757774832802da9", size = 747413, upload-time = "2026-04-22T20:59:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/55/ae264339996953c4cdf9d89d916a0a8fa26a83cf917a742fff8b9d5f3fe8/pyinstaller-6.20.0-py3-none-win32.whl", hash = "sha256:9a7637e8e44b4387b13667fdcaac86ab6b29c446c16d34d8401539b81838759c", size = 1331584, upload-time = "2026-04-22T20:59:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/300f57578882cce259bfb5ae56fda3b69caa3fe9df40a176c719920ea6e2/pyinstaller-6.20.0-py3-none-win_amd64.whl", hash = "sha256:d588844e890ee80c4365867f98146636e1849bbca8e4284bbf0c809aff0f161a", size = 1391851, upload-time = "2026-04-22T20:59:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/b2f8e1642aecda78c0b75c7321f708e49e10bb3c00dd4f148c40761a1527/pyinstaller-6.20.0-py3-none-win_arm64.whl", hash = "sha256:bd53282c0a73e5c95573e1ddc8e5d564d4932bec91efbaed4dc5fdff9c2ae7f2", size = 1332259, upload-time = "2026-04-22T20:59:20.509Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/67/f4452d68793fb15beba4f19ef39a38a8822f0da7452b503c400d5a21f5c1/pyinstaller_hooks_contrib-2026.5.tar.gz", hash = "sha256:f066dfca8f7c45ff6336c9cf9fe25b4e48bfeb322a1aa24faaedfb8a8d1b0b08", size = 173689, upload-time = "2026-05-04T22:36:55.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/5c/fd465d11da4d12b50d7eb5d2ee2ceb780d8d049dbb489f3828d131e387af/pyinstaller_hooks_contrib-2026.5-py3-none-any.whl", hash = "sha256:ea1535783fbdac4626351709e83f3ea80b681d3a4745763ebb407b5e27342eb9", size = 457314, upload-time = "2026-05-04T22:36:53.598Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -415,12 +562,34 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -470,6 +639,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -598,6 +801,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/e1/665267cea4767debd19f584667a9197c2098b5e7f67a502da9f3a086ab37/virtualenv-21.3.2.tar.gz", hash = "sha256:3ecda97894a6fc1c53106356f488690e5c86278c1f693f3fc0805ac85a513686", size = 7613810, upload-time = "2026-05-12T14:44:18.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/5b/885f479093f6627669d39b57bc3d4e674da532e1a4b247d473a61d8d2118/virtualenv-21.3.2-py3-none-any.whl", hash = "sha256:c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764", size = 7594558, upload-time = "2026-05-12T14:44:15.193Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# CI tooling, release pipeline, flow id reshape, and ruff cleanup

This branch sets up the automation we were missing, reshapes flow ids so the
filesystem layout is usable by hand, and cleans the codebase up to satisfy the
new linter.

## What changed

### Continuous integration and release pipeline
- GitHub Actions runs ruff and the pytest suite (excluding the live harness)
  on Linux, macOS, and Windows for every PR.
- A tag-triggered release workflow verifies the tag matches the version in
  `pyproject.toml`, builds a wheel with `uv build`, builds standalone
  PyInstaller binaries for the three platforms, publishes the wheel to PyPI
  via trusted publishing, and attaches the binaries to a GitHub release.
- `scripts/atelier_entry.py` is the PyInstaller entry point.
- Pre-commit runs ruff on every commit and pytest on pre-push.
- `pyproject.toml` adds `ruff`, `pre-commit`, and `pyinstaller` to the `dev`
  group, plus a ruff config (line-length 100, `py313` target, rule set
  `E/F/I/B/UP/SIM` with a relaxed `tests/*` profile). `.gitignore` ignores
  PyInstaller `.spec` artifacts.

### Install documentation
- README now documents three install paths: PyPI (via `uv tool install` or
  `pipx`), prebuilt binaries from the latest GitHub release, and from-source
  for development. The three binary asset names are listed explicitly.

### Flow id format
- Flow ids change from `<conduit>_<uuid8>_<YYYYMMDDTHHMMSSZ>` to
  `<YYYYMMDD>_<uuid8>_<conduit>`. `parse_flow_id` and `FLOW_ID_RE` are
  updated; the third tuple element is now a `date` instead of a full
  timestamp.
- `FilesystemStore.list_flows(conduit_name=...)` no longer uses
  `startswith(name + "_")` — it parses each directory name and compares the
  parsed conduit field.

### Lint cleanup
- Typing modernization across the app and tests: `Union[A, B]` → `A | B`,
  `Optional[X]` → `X | None`, string forward refs → bare class refs in
  modules that already opt into PEP 563.
- `datetime.timezone.utc` → `datetime.UTC`, `asyncio.TimeoutError` → builtin
  `TimeoutError`, `typing.Awaitable/Callable` → `collections.abc`.
- Sorted imports, removed unused imports, collapsed one nested-if in the
  scheduler reload path, trimmed stray blank lines flagged by ruff.

## Why

- We had no automated quality gate. Shipping a fix meant running ruff and
  pytest locally on one OS and hoping the matrix held. CI on three platforms
  makes that automatic and catches Windows-only path/encoding issues we'd
  otherwise miss.
- Two distribution paths matter: `uv tool install` for Python users, and a
  single-file binary for anyone who doesn't want to install Python at all.
  The release workflow covers both from one tag, and the README points users
  at the right one.
- The old flow id put the conduit name first and the timestamp last, so
  listing `.atelier/flows/` sorted alphabetically by conduit name instead of
  chronologically. Putting the date first means a plain `ls` shows newest
  flows next to each other, which is how anyone debugging actually reads the
  directory.
- The old `list_flows` prefix filter was a latent bug: a conduit named `foo`
  matched flows from any conduit whose name happened to start with `foo_`.
  Parsing the id and comparing the structured conduit field eliminates that
  whole class of mis-match.
- The lint pass exists because the ruff config has to pass the moment CI
  starts running. Keeping it together (rather than mixed into the substantive
  changes) makes the diff easy to skim: it's all mechanical.

## Verification

- `uv run pytest --ignore=tests/test_live_harness.py`: 451 passed.
- `uv run ruff check .` clean (enforced by both pre-commit and CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI/CD workflows for automated testing and release pipelines.
  * Introduced standalone binary distribution for multiple platforms.
  * Expanded installation options: PyPI, standalone binaries, and source installations.

* **Chores**
  * Modernized codebase with PEP 604 type hints.
  * Updated development tooling with linting and pre-commit hooks.
  * Improved timeout error handling across modules.
  * Reorganized flow ID format for better date-based identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->