### PR TITLE
fix(harness): coalesce per-token AgentThoughtChunk updates into one step

### DIFF
--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -50,6 +50,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_DONE_MARKER = "[ATELIER_DONE]"
 MAX_INTERACTIVE_TURNS = 20
 
+# Group consecutive AgentThoughtChunk updates into one IntermediateStep
+# until the merged text reaches this many characters or hits a newline.
+# Some agents (notably opencode) emit one thought chunk per token; without
+# grouping the UI shows one rendered line per word.
+THINKING_FLUSH_CHARS = 200
+
 # Mode-id keyword tiers in descending permissiveness. Each ACP agent
 # advertises its own mode ids; we pick the most permissive one available so
 # the agent never has to ask for tool permission. Keyword matched against
@@ -163,6 +169,33 @@ class _BufferingClient:
         self._done_marker = done_marker
         self.buffer: list[str] = []
         self.steps: list[IntermediateStep] = []
+        self._pending_thinking: list[str] = []
+        self._pending_thinking_len: int = 0
+
+    async def _flush_thinking(self) -> None:
+        """Emit any buffered thought chunks as one merged ``thinking`` step.
+
+        No-op when the buffer is empty or contains only whitespace.
+        """
+        if not self._pending_thinking:
+            return
+        text = "".join(self._pending_thinking).strip()
+        self._pending_thinking.clear()
+        self._pending_thinking_len = 0
+        if not text:
+            return
+        step = IntermediateStep(kind=StepKind.thinking, text=text)
+        self.steps.append(step)
+        if self._stream_steps and hasattr(self._sink, "display_step"):
+            await self._sink.display_step(step)
+
+    async def flush_pending(self) -> None:
+        """Flush any partial thought-chunk buffer at a turn boundary.
+
+        Called by the driver after each ``conn.prompt`` round so the last
+        group of thinking does not get stuck pending until the next update.
+        """
+        await self._flush_thinking()
 
     async def session_update(self, session_id: str, update, **kwargs) -> None:
         """Handle a session update notification from the ACP agent.
@@ -173,6 +206,7 @@ class _BufferingClient:
         """
         del session_id, kwargs
         if isinstance(update, AgentMessageChunk):
+            await self._flush_thinking()
             content = update.content
             text = getattr(content, "text", None)
             if text:
@@ -181,11 +215,14 @@ class _BufferingClient:
                     await self._sink.display(text.replace(self._done_marker, ""))
         elif isinstance(update, AgentThoughtChunk):
             text = getattr(update.content, "text", "") or ""
-            step = IntermediateStep(kind=StepKind.thinking, text=text)
-            self.steps.append(step)
-            if self._stream_steps and hasattr(self._sink, "display_step"):
-                await self._sink.display_step(step)
+            if not text:
+                return
+            self._pending_thinking.append(text)
+            self._pending_thinking_len += len(text)
+            if self._pending_thinking_len >= THINKING_FLUSH_CHARS or "\n" in text:
+                await self._flush_thinking()
         elif isinstance(update, ToolCallStart):
+            await self._flush_thinking()
             step = IntermediateStep(
                 kind=StepKind.tool_call,
                 tool_call_id=update.tool_call_id,
@@ -200,6 +237,7 @@ class _BufferingClient:
                 await self._sink.display_step(step)
         elif isinstance(update, ToolCallProgress):
             if update.status in ("completed", "failed"):
+                await self._flush_thinking()
                 step = IntermediateStep(
                     kind=StepKind.tool_result,
                     tool_call_id=update.tool_call_id,
@@ -394,6 +432,7 @@ class AcpHarnessExecutor(ExecutorBase):
                 timeout=context.timeout,
             )
         except TimeoutError:
+            await client.flush_pending()
             return ExecutionResult(
                 exit_code=124,
                 stdout="".join(client.buffer),
@@ -402,6 +441,7 @@ class AcpHarnessExecutor(ExecutorBase):
                 steps=client.steps,
             )
         except Exception as exc:  # noqa: BLE001
+            await client.flush_pending()
             return ExecutionResult(
                 exit_code=1,
                 stdout="".join(client.buffer),
@@ -498,6 +538,7 @@ class AcpHarnessExecutor(ExecutorBase):
             session_id=session_id,
         )
         await self._drain_pending_notifications(client)
+        await client.flush_pending()
         return self._result_for_turn(client, resp.stop_reason)
 
     @staticmethod
@@ -560,6 +601,7 @@ class AcpHarnessExecutor(ExecutorBase):
                 session_id=session_id,
             )
             await self._drain_pending_notifications(client)
+            await client.flush_pending()
             last_stop = resp.stop_reason
             buffer_text = "".join(client.buffer)
             if self.done_marker in buffer_text:

--- a/tests/cli/test_render_steps.py
+++ b/tests/cli/test_render_steps.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import io
+import re
 
 from rich.console import Console
 from rich.text import Text
@@ -242,13 +243,28 @@ class TestRenderLogEntrySteps:
         assert "completed" in output
 
     def test_show_steps_uses_short_timestamps(self) -> None:
-        """Verify the steps view renders short timestamps, not full dates."""
+        """Verify the steps view renders short timestamps inside the panel
+        body. The panel subtitle uses the full clock by design — and is
+        rendered on the bottom border, not the body — so it is excluded.
+
+        Scoping the assertion to body lines also keeps this test
+        timezone-independent: a UTC CI runner formats the fixture's
+        ``2026-01-01T00:00:00Z`` subtitle as ``2026-01-01 00:00`` (date
+        preserved), while a runner in any negative-offset zone shifts it
+        to ``2025-12-31`` — the assertion must only care about step rows.
+        """
         entry = self._entry_with_steps()
         c, buf = _console()
         _render_log_entry(entry, "steps", c)
         output = buf.getvalue()
-        # Should NOT contain full date format, only HH:MM
-        assert "2026-01-01" not in output
+        body_lines = [
+            line for line in output.splitlines()
+            if line.lstrip().startswith("│")
+        ]
+        assert body_lines, f"expected body lines in panel output: {output!r}"
+        for line in body_lines:
+            # Step rows must use HH:MM only, never YYYY-MM-DD.
+            assert not re.search(r"\d{4}-\d{2}-\d{2}", line), line
 
     def test_show_steps_tool_result_indented(self) -> None:
         """Tool results should be indented under their tool call (no timestamp)."""

--- a/tests/services/executor/test_harness_steps.py
+++ b/tests/services/executor/test_harness_steps.py
@@ -35,13 +35,14 @@ class RecordingSink:
 
         :param label: turn label (ignored).
         """
-        pass
+        del label
 
     async def request_input(self, prompt: str) -> str:
         """Refuse input by raising EOFError.
 
         :param prompt: prompt text (ignored).
         """
+        del prompt
         raise EOFError
 
     async def request_permission(
@@ -52,6 +53,7 @@ class RecordingSink:
         :param summary: permission request summary (ignored).
         :param options: available permission options.
         """
+        del summary
         return options[0].id
 
     async def display_step(self, step: IntermediateStep) -> None:
@@ -64,7 +66,8 @@ class RecordingSink:
 
 class TestBufferingClientSteps:
     async def test_thinking_chunk_captured(self) -> None:
-        """Verify agent thought chunks become thinking steps."""
+        """Verify a single thought chunk yields one merged thinking step
+        once the driver flushes at the turn boundary."""
         sink = RecordingSink()
         client = _BufferingClient(sink, stream_steps=False)
         update = AgentThoughtChunk(
@@ -72,9 +75,113 @@ class TestBufferingClientSteps:
             content=TextContentBlock(type="text", text="Let me think about this"),
         )
         await client.session_update("s1", update)
+        # Short chunks sit pending until flush — emulate end-of-turn.
+        await client.flush_pending()
         assert len(client.steps) == 1
         assert client.steps[0].kind == StepKind.thinking
         assert client.steps[0].text == "Let me think about this"
+
+    async def test_thinking_chunks_grouped_until_flush(self) -> None:
+        """Word-per-chunk streams (e.g. opencode) coalesce into one step
+        per turn boundary instead of one step per token."""
+        sink = RecordingSink()
+        client = _BufferingClient(sink, stream_steps=True)
+        tokens = ["Let", " me", " think", " about", " this", "."]
+        for tok in tokens:
+            await client.session_update(
+                "s1",
+                AgentThoughtChunk(
+                    sessionUpdate="agent_thought_chunk",
+                    content=TextContentBlock(type="text", text=tok),
+                ),
+            )
+        # Below the length threshold and no newlines — nothing emitted yet.
+        assert client.steps == []
+        assert sink.step_log == []
+        await client.flush_pending()
+        assert len(client.steps) == 1
+        assert client.steps[0].text == "Let me think about this."
+        assert len(sink.step_log) == 1
+
+    async def test_thinking_flushes_on_length(self) -> None:
+        """Once the buffered thought text reaches the threshold the client
+        emits a step without waiting for a turn boundary; remaining text
+        continues to accumulate in a fresh group."""
+        sink = RecordingSink()
+        client = _BufferingClient(sink, stream_steps=False)
+        chunk = "x" * 50
+        for _ in range(5):  # 250 chars total > 200 threshold
+            await client.session_update(
+                "s1",
+                AgentThoughtChunk(
+                    sessionUpdate="agent_thought_chunk",
+                    content=TextContentBlock(type="text", text=chunk),
+                ),
+            )
+        # First flush fires when the buffer reaches 200; the trailing 50
+        # chars stay pending until the next flush.
+        assert len(client.steps) == 1
+        assert client.steps[0].text == "x" * 200
+        await client.flush_pending()
+        assert len(client.steps) == 2
+        assert client.steps[1].text == "x" * 50
+
+    async def test_thinking_flushes_on_newline(self) -> None:
+        """A chunk containing a newline closes the current thought group."""
+        sink = RecordingSink()
+        client = _BufferingClient(sink, stream_steps=False)
+        await client.session_update(
+            "s1",
+            AgentThoughtChunk(
+                sessionUpdate="agent_thought_chunk",
+                content=TextContentBlock(type="text", text="first thought"),
+            ),
+        )
+        await client.session_update(
+            "s1",
+            AgentThoughtChunk(
+                sessionUpdate="agent_thought_chunk",
+                content=TextContentBlock(type="text", text="\n"),
+            ),
+        )
+        await client.session_update(
+            "s1",
+            AgentThoughtChunk(
+                sessionUpdate="agent_thought_chunk",
+                content=TextContentBlock(type="text", text="second thought"),
+            ),
+        )
+        await client.flush_pending()
+        assert [s.text for s in client.steps] == [
+            "first thought",
+            "second thought",
+        ]
+
+    async def test_message_chunk_flushes_pending_thinking(self) -> None:
+        """When prose arrives, any partial thought group is emitted first
+        so the recorded order matches what the agent actually said."""
+        sink = RecordingSink()
+        client = _BufferingClient(
+            sink, stream_messages=False, stream_steps=False
+        )
+        await client.session_update(
+            "s1",
+            AgentThoughtChunk(
+                sessionUpdate="agent_thought_chunk",
+                content=TextContentBlock(type="text", text="brief plan"),
+            ),
+        )
+        await client.session_update(
+            "s1",
+            AgentMessageChunk(
+                sessionUpdate="agent_message_chunk",
+                content=TextContentBlock(type="text", text="answer"),
+            ),
+        )
+        assert len(client.steps) == 1
+        assert client.steps[0].kind == StepKind.thinking
+        assert client.steps[0].text == "brief plan"
+        assert "".join(client.buffer) == "answer"
 
     async def test_tool_call_start_captured(self) -> None:
         """Verify ToolCallStart updates become tool_call steps with metadata."""
@@ -150,6 +257,7 @@ class TestBufferingClientSteps:
             content=TextContentBlock(type="text", text="thinking"),
         )
         await client.session_update("s1", update)
+        await client.flush_pending()
         assert len(sink.step_log) == 1
         assert sink.step_log[0].kind == StepKind.thinking
 
@@ -162,6 +270,7 @@ class TestBufferingClientSteps:
             content=TextContentBlock(type="text", text="thinking"),
         )
         await client.session_update("s1", update)
+        await client.flush_pending()
         # Steps captured, but not sent to sink
         assert len(client.steps) == 1
         assert len(sink.step_log) == 0


### PR DESCRIPTION
# fix(harness): coalesce per-token AgentThoughtChunk updates into one step

## What

Buffer consecutive `AgentThoughtChunk` updates inside `_BufferingClient`
(`app/services/executor/harness.py`) and emit them as a single
`IntermediateStep` instead of one step per chunk.

A new flush is triggered when:

- the buffered text reaches `THINKING_FLUSH_CHARS` (200 chars),
- an incoming chunk contains a newline,
- any non-thought update arrives (`AgentMessageChunk`, `ToolCallStart`,
  `ToolCallProgress`) — flushes before recording the next step so the
  persisted `steps` list preserves event order,
- or the driver calls the new public `flush_pending()` at a turn
  boundary.

`flush_pending()` is wired into every driver exit path:

- `_run_single_turn` — after `_drain_pending_notifications`
- `_run_interactive` — after each prompt round
- `execute()` — in the `TimeoutError` and generic `Exception` branches

so no exit path can leak a partial thought buffer.

## Why

Some ACP agents (notably **opencode**) emit one `AgentThoughtChunk` per
token. Before this change, each token became its own `IntermediateStep`
because the buffering client minted a step for every update. The
downstream effects were:

- **Live render**: the CLI printed one `💭` line per word — a single
  reasoning paragraph from opencode produced hundreds of lines and
  drowned out the rest of the run output.
- **Persisted log**: `atelier logs <flow> --show steps` showed the same
  per-token explosion, and the panel summary printed
  `thinking(278)` for what was really 1–2 paragraphs of reasoning.

Claude-code and Codex are unaffected by the underlying problem (claude
doesn't emit thought chunks in non-interactive mode at all; codex emits
larger chunks), but the fix is harness-agnostic and benefits any agent
that streams thoughts at fine granularity.

## Before / after

Same conduit (`opencode-fanout`), same input:

| | before | after |
|---|---|---|
| live `💭` lines for the `synthesize` task | ~278 | 2 |
| recorded `thinking(N)` summary | `thinking(278)` | `thinking(2)` |
| log readability (`atelier logs … --show steps`) | one token per line | grouped paragraphs |

The grouped lines map to natural boundaries in the agent's reasoning
(paragraph breaks land as newlines in the stream; mid-paragraph groups
fall on the 200-char length cap).

## Verification

- 51 harness unit tests pass; full suite passes (455 tests).
- New tests in `tests/services/executor/test_harness_steps.py` cover:
  - `test_thinking_chunks_grouped_until_flush` — token-by-token stream
    coalesces into one step at `flush_pending()`.
  - `test_thinking_flushes_on_length` — buffer at the 200-char threshold
    flushes immediately; trailing remainder accumulates in a new group.
  - `test_thinking_flushes_on_newline` — a chunk containing `\n` closes
    the current group.
  - `test_message_chunk_flushes_pending_thinking` — `AgentMessageChunk`
    forces a thinking flush first so persisted ordering matches what
    the agent actually said.
- Existing single-chunk thinking tests updated to call
  `flush_pending()` explicitly, matching the new turn-boundary
  contract.
- Manual end-to-end rerun of `opencode-fanout` with two parallel
  opencode tasks plus a fan-in synthesizer confirmed grouped live
  output and grouped persisted-log output.

## Cleanups bundled in

- Replaced an O(N²) accumulator
  (`sum(len(t) for t in self._pending_thinking)` recomputed on every
  chunk) with a running `_pending_thinking_len` counter, incremented on
  append and reset on flush.
- Silenced three pre-existing Pylance "argument not accessed" warnings
  in `RecordingSink` (`label`, `prompt`, `summary`) using the harness
  module's established `del param` convention.

## Out of scope / follow-ups

- `_drain_pending_notifications` waits on `client.buffer` length
  stability only; it does not account for in-flight thought-chunk
  notifications. A late thought chunk arriving between `drain` and
  `flush_pending()` is still captured, but a chunk arriving after
  `flush_pending()` would be lost. This is pre-existing behavior and
  has not been observed in practice — worth a follow-up to track total
  update count rather than buffer length.
- The renderer still truncates each step at 120 chars for the live
  display (`step.text[:120] + "..."`). The full text is preserved in
  the step record and shown by `atelier logs … --show steps`, but the
  live display ellipsizes mid-sentence. Out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated and ordered intermediate "thinking" steps so buffered thought content is consistently captured and emitted before turn end or non-thought updates.
  * Ensured pending thought buffers are flushed at turn boundaries and on exit paths to prevent incomplete or misordered steps.

* **Tests**
  * Updated tests to explicitly flush and verify buffered steps and improved step-rendering test robustness across timezones.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LGuillermoAngaritaG/flow-atelier/pull/19)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->