### PR TITLE
feature: route API endpoints to global ~/.atelier and thread working_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ wheels/
 .devtool
 claude.md
 .pytest_cache
+.opencode
+AGENTS.md

--- a/app/cli/commands/serve.py
+++ b/app/cli/commands/serve.py
@@ -13,6 +13,8 @@ from app.cli.main import app
 from app.core.atelier import Atelier
 from app.services.api.app import FastApiServer
 from app.services.scheduler import SchedulerDaemon, default_local_zone
+from app.schemas.api import ScheduledJob
+from app.services.scheduler.store import ScheduleStore
 
 
 @app.command(
@@ -53,8 +55,20 @@ def serve_cmd(
     )
 
     atelier = Atelier()
+    # API endpoints use the global schedule store so schedules persist in
+    # ~/.atelier/ rather than the project-level .atelier/. The daemon also
+    # reads from this store so it can fire API-created schedules.
+    global_schedule_store = ScheduleStore(atelier.settings.global_atelier_dir)
+    atelier.schedule_store = global_schedule_store
+
+    async def _api_executor(job: "ScheduledJob", working_dir: Path) -> None:
+        """Custom executor: store flows globally, run tasks in working_dir."""
+        a = Atelier(base_dir=atelier.settings.global_atelier_dir)
+        await a.run_conduit(job.conduit_name, dict(job.inputs), working_dir=working_dir)
+
     daemon = SchedulerDaemon(
-        atelier.schedule_store,
+        global_schedule_store,
+        executor=_api_executor,
         default_zone=default_local_zone(),
         default_working_dir=Path.cwd(),
         reload_interval_seconds=reload_interval,

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -126,6 +126,7 @@ class Atelier:
         on_flow_started: FlowStartedCallback | None = None,
         on_task_starting: TaskStartingCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | str | None = None,
     ) -> str:
         """Start a new flow for the named conduit.
 
@@ -144,8 +145,11 @@ class Atelier:
             tool calls, tool results) to the executor's prompt sink as
             they happen. Defaults to ``True``; the CLI exposes
             ``--hide-steps`` to opt out.
+        :param working_dir: working directory for task execution. When
+            ``None``, executors use the process cwd.
         :returns: the newly created flow id
         """
+        wd = Path(working_dir) if working_dir is not None else None
         conduit = self.store.read_conduit(name)
         return await self.engine.run(
             conduit,
@@ -154,6 +158,7 @@ class Atelier:
             on_flow_started=on_flow_started,
             on_task_starting=on_task_starting,
             show_steps=show_steps,
+            working_dir=wd,
         )
 
     def get_status(self, flow_id: str) -> Progress:
@@ -182,17 +187,21 @@ class Atelier:
     # ------------------------------------------------------------------ CRUD
 
     def create_conduit(self, payload: CreateConduitInput) -> Conduit:
-        """Persist a new conduit; raise if one with that name already exists.
+        """Persist a new conduit to the global store.
+
+        Raises if a conduit with that name already exists in project or global.
 
         :param payload: validated :class:`CreateConduitInput`
         :returns: the persisted :class:`Conduit`
-        :raises FileExistsError: if a project conduit with that name exists
+        :raises FileExistsError: if a conduit with that name already exists
         """
-        existing = self.store.base_dir / "conduits" / payload.name
-        if existing.exists():
+        try:
+            self.store.conduit_source(payload.name)
             raise FileExistsError(f"conduit already exists: {payload.name}")
+        except FileNotFoundError:
+            pass
         conduit = Conduit.model_validate(payload.model_dump())
-        self.store.write_conduit(conduit)
+        self.store.write_conduit_global(conduit)
         return conduit
 
     def update_conduit(
@@ -200,29 +209,44 @@ class Atelier:
     ) -> Conduit:
         """Apply a partial update to an existing conduit.
 
+        Routes the write to the same store (project or global) where the
+        conduit currently lives.
+
         :param name: conduit to modify
         :param payload: subset of fields to overwrite
         :returns: the updated :class:`Conduit`
         :raises FileNotFoundError: if the conduit doesn't exist
         """
+        source = self.store.conduit_source(name)
         existing = self.store.read_conduit(name)
         merged = existing.model_dump()
         for key, value in payload.model_dump(exclude_none=True).items():
             merged[key] = value
         merged["name"] = merged.get("name") or name
         updated = Conduit.model_validate(merged)
-        self.store.write_conduit(updated)
+        if source == "global":
+            self.store.write_conduit_global(updated)
+        else:
+            self.store.write_conduit(updated)
         if updated.name != name:
-            # Rename: drop the old folder.
-            self.store.delete_conduit(name)
+            if source == "global":
+                self.store.delete_conduit_global(name)
+            else:
+                self.store.delete_conduit(name)
         return updated
 
     def delete_conduit(self, name: str) -> bool:
-        """Remove a project-level conduit.
+        """Remove a conduit from whichever store it lives in.
 
         :param name: conduit name
         :returns: True if it existed and was deleted, False otherwise
         """
+        try:
+            source = self.store.conduit_source(name)
+        except FileNotFoundError:
+            return False
+        if source == "global":
+            return self.store.delete_conduit_global(name)
         return self.store.delete_conduit(name)
 
     async def run_single_task(self, payload: RunTaskInput) -> RunTaskOutput:

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -19,6 +19,7 @@ import sys
 import traceback
 from collections.abc import Callable
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from app.modules.conditions import (
@@ -133,6 +134,7 @@ class Engine:
         on_flow_started: FlowStartedCallback | None = None,
         on_task_starting: TaskStartingCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | None = None,
     ) -> str:
         """Execute a conduit to completion, returning the flow id.
 
@@ -382,8 +384,9 @@ class Engine:
                     task_outputs=outputs,
                     timeout=conduit.timeout,
                     show_steps=show_steps,
+                    working_dir=working_dir,
                     run_nested_conduit=self._make_nested_runner(
-                        on_task_event, show_steps=show_steps
+                        on_task_event, show_steps=show_steps, working_dir=working_dir
                     ),
                 )
 
@@ -590,11 +593,13 @@ class Engine:
         self,
         on_task_event: TaskEventCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | None = None,
     ):
         """Build the nested-conduit runner passed to executors via FlowContext.
 
         :param on_task_event: optional task-event callback forwarded to the child run.
         :param show_steps: whether the nested run should surface per-step progress.
+        :param working_dir: working directory forwarded to nested runs.
         :returns: an async callable ``(conduit_name, child_inputs, parent_flow_id)``
             that loads and runs the named child conduit.
         """
@@ -612,6 +617,7 @@ class Engine:
                 parent_flow_id,
                 on_task_event=on_task_event,
                 show_steps=show_steps,
+                working_dir=working_dir,
             )
 
         return _run_nested

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, WebSocket
@@ -117,7 +118,7 @@ async def _spawn_run(
     """
     # Per-connection Atelier instance keeps executor swaps from leaking
     # across sockets (SPEC §10 / risk table).
-    atelier = Atelier(base_dir=base_atelier.settings.atelier_dir)
+    atelier = Atelier(base_dir=base_atelier.settings.global_atelier_dir)
     broker.register_flow(message.flow_id)
     atelier.executors["tool:hitl"] = WsHitlExecutor(
         broker=broker, flow_id=message.flow_id
@@ -177,6 +178,7 @@ async def _spawn_run(
                     conduit,
                     dict(message.inputs),
                     on_task_event=_on_task_event_sync,
+                    working_dir=Path(message.run_path) if message.run_path else None,
                 )
             except asyncio.CancelledError:
                 await broker.send(

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -97,8 +97,11 @@ async def run_conduit_ws(websocket: WebSocket) -> None:
             elif isinstance(message, CancelMessage):
                 broker.cancel(message.flow_id)
     finally:
-        if websocket.application_state == WebSocketState.CONNECTED:
-            await websocket.close()
+        try:
+            if websocket.application_state == WebSocketState.CONNECTED:
+                await websocket.close()
+        except RuntimeError:
+            pass
 
 
 async def _spawn_run(

--- a/app/services/executor/base.py
+++ b/app/services/executor/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from app.schemas.conduit import TaskDefinition
@@ -27,6 +28,9 @@ class FlowContext:
     """Stream intermediate steps (thinking, tool calls, tool results) to the
     executor's :class:`PromptSink` as they happen. Independent of
     ``task.interactive`` (which gates raw message-chunk streaming)."""
+    working_dir: Path | None = None
+    """Working directory for subprocess / agent execution. When ``None``,
+    executors use the process cwd."""
     run_nested_conduit: Callable[[str, dict[str, Any], str], Awaitable[str]] | None = None
     """Callback: (conduit_name, inputs, parent_flow_id) -> child flow_id."""
 

--- a/app/services/executor/bash.py
+++ b/app/services/executor/bash.py
@@ -28,6 +28,7 @@ class BashExecutor(ExecutorBase):
             resolved_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=str(context.working_dir) if context.working_dir else None,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -19,7 +19,11 @@ when the marker appears or when :attr:`MAX_INTERACTIVE_TURNS` is reached.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import os
+import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +49,26 @@ from app.services.executor.prompt_sink import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_cmd(cmd: str) -> str:
+    """On Windows, resolve .cmd/.bat wrappers that ``create_subprocess_exec`` can't find."""
+    if os.name == "nt":
+        resolved = shutil.which(cmd)
+        if resolved is not None:
+            return resolved
+    return cmd
+
+
+def _close_proc_transports(proc: asyncio.subprocess.Process) -> None:
+    """Explicitly close pipe transports on Windows to prevent ``__del__`` errors."""
+    for stream in (proc.stdout, proc.stderr):
+        if stream is None:
+            continue
+        transport = getattr(stream, "_transport", None)
+        if transport is not None:
+            with contextlib.suppress(OSError, ValueError):
+                transport.close()
 
 
 DEFAULT_DONE_MARKER = "[ATELIER_DONE]"
@@ -467,6 +491,7 @@ class AcpHarnessExecutor(ExecutorBase):
         :returns: :class:`ExecutionResult` from single-turn or interactive run.
         """
         cmd, *args = self.launch_cmd
+        cmd = _resolve_cmd(cmd)
         # Raise the per-line StreamReader limit well above asyncio's 64 KiB
         # default; Codex and similar harnesses emit large JSON-RPC frames
         # (tool results, planning output) that routinely exceed it.
@@ -478,19 +503,23 @@ class AcpHarnessExecutor(ExecutorBase):
             transport_kwargs={"limit": 8 * 1024 * 1024},
         ) as (
             conn,
-            _proc,
+            proc,
         ):
             await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
             sess = await conn.new_session(cwd=cwd)
             await self._maybe_switch_to_permissive_mode(conn, sess)
 
-            if not interactive:
-                return await self._run_single_turn(
+            try:
+                if not interactive:
+                    return await self._run_single_turn(
+                        conn, sess.session_id, initial_prompt, client
+                    )
+                return await self._run_interactive(
                     conn, sess.session_id, initial_prompt, client
                 )
-            return await self._run_interactive(
-                conn, sess.session_id, initial_prompt, client
-            )
+            finally:
+                if sys.platform == "win32":
+                    _close_proc_transports(proc)
 
     @staticmethod
     async def _maybe_switch_to_permissive_mode(conn, sess) -> None:

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -442,7 +442,7 @@ class AcpHarnessExecutor(ExecutorBase):
         if task.interactive:
             prompt_text = prompt_text + build_interactive_suffix(self.done_marker)
 
-        cwd = str(Path.cwd())
+        cwd = str(context.working_dir) if context.working_dir else str(Path.cwd())
         client = _BufferingClient(
             self.sink,
             stream_messages=task.interactive,

--- a/app/services/store/base.py
+++ b/app/services/store/base.py
@@ -42,6 +42,33 @@ class StoreBase(ABC):
         ...
 
     @abstractmethod
+    def write_conduit_global(self, conduit: Conduit) -> None:
+        """Persist ``conduit`` to the global (user-level) store.
+
+        :param conduit: validated conduit to persist
+        :raises RuntimeError: if no global directory is available
+        """
+        ...
+
+    @abstractmethod
+    def conduit_source(self, name: str) -> ConduitSource:
+        """Return whether ``name`` lives in the project or global store.
+
+        :param name: conduit name
+        :raises FileNotFoundError: if not found in either store
+        """
+        ...
+
+    @abstractmethod
+    def delete_conduit_global(self, name: str) -> bool:
+        """Delete a global conduit. Returns False if it didn't exist.
+
+        :param name: conduit name
+        :returns: True if deleted, False if it didn't exist
+        """
+        ...
+
+    @abstractmethod
     def delete_conduit(self, name: str) -> bool:
         """Delete a project-level conduit. Returns False if it didn't exist.
 

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -19,6 +19,7 @@ import asyncio
 import json
 import os
 import shutil
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,20 @@ from app.schemas.flow import new_flow_id, parse_flow_id
 from app.schemas.log import LogEntry
 from app.schemas.progress import Progress
 from app.services.store.base import ConduitSource, StoreBase
+
+if os.name == "nt":
+    def _atomic_replace(src: str | Path, dst: str | Path) -> None:
+        for attempt in range(5):
+            try:
+                os.replace(src, dst)
+                return
+            except PermissionError:
+                if attempt == 4:
+                    raise
+                time.sleep(0.05 * (attempt + 1))
+else:
+    def _atomic_replace(src: str | Path, dst: str | Path) -> None:
+        os.replace(src, dst)
 
 
 class FilesystemStore(StoreBase):
@@ -72,14 +87,22 @@ class FilesystemStore(StoreBase):
         """
         return self._conduit_dir(name) / "conduit.yaml"
 
-    def _global_conduit_yaml(self, name: str) -> Path | None:
-        """Return the global ``conduit.yaml`` path for ``name`` or ``None``.
+    def _global_conduit_dir(self, name: str) -> Path | None:
+        """Return the global directory for conduit ``name`` or ``None``.
 
         :param name: conduit name
         """
         if self.global_dir is None:
             return None
-        return self.global_dir / "conduits" / name / "conduit.yaml"
+        return self.global_dir / "conduits" / name
+
+    def _global_conduit_yaml(self, name: str) -> Path | None:
+        """Return the global ``conduit.yaml`` path for ``name`` or ``None``.
+
+        :param name: conduit name
+        """
+        conduit_dir = self._global_conduit_dir(name)
+        return conduit_dir / "conduit.yaml" if conduit_dir is not None else None
 
     def _flow_dir(self, flow_id: str) -> Path:
         """Resolve and cache the directory for ``flow_id``.
@@ -160,7 +183,51 @@ class FilesystemStore(StoreBase):
         path = self._conduit_yaml(conduit.name)
         tmp = path.with_suffix(".yaml.tmp")
         tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
+
+    def write_conduit_global(self, conduit: Conduit) -> None:
+        """Persist ``conduit`` under the global ``~/.atelier/conduits/<name>/``.
+
+        :param conduit: validated conduit to persist.
+        :raises RuntimeError: if no global directory is available.
+        """
+        conduit_dir = self._global_conduit_dir(conduit.name)
+        if conduit_dir is None:
+            raise RuntimeError(
+                "global conduit directory is not available "
+                "(home directory may be read-only)"
+            )
+        conduit_dir.mkdir(parents=True, exist_ok=True)
+        path = conduit_dir / "conduit.yaml"
+        payload = conduit.model_dump(mode="json", by_alias=True, exclude_none=True)
+        tmp = path.with_suffix(".yaml.tmp")
+        tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
+        _atomic_replace(tmp, path)
+
+    def conduit_source(self, name: str) -> ConduitSource:
+        """Return whether ``name`` lives in the project or global store.
+
+        :param name: conduit name
+        :raises FileNotFoundError: if not found in either store
+        """
+        if self._conduit_yaml(name).exists():
+            return "project"
+        global_yaml = self._global_conduit_yaml(name)
+        if global_yaml is not None and global_yaml.exists():
+            return "global"
+        raise FileNotFoundError(f"conduit not found: {name}")
+
+    def delete_conduit_global(self, name: str) -> bool:
+        """Remove a global conduit by name.
+
+        :param name: conduit name
+        :returns: True if deleted, False if it didn't exist
+        """
+        conduit_dir = self._global_conduit_dir(name)
+        if conduit_dir is None or not conduit_dir.exists():
+            return False
+        shutil.rmtree(conduit_dir)
+        return True
 
     def delete_conduit(self, name: str) -> bool:
         """Remove ``conduits/<name>/`` if present (project store only).
@@ -270,7 +337,7 @@ class FilesystemStore(StoreBase):
             existing.append(entry.model_dump())
             tmp = path.with_suffix(".json.tmp")
             tmp.write_text(json.dumps(existing, indent=2))
-            os.replace(tmp, path)
+            _atomic_replace(tmp, path)
 
     def read_logs(self, flow_id: str) -> list[LogEntry]:
         """Return all log entries for ``flow_id`` in append order.
@@ -296,7 +363,7 @@ class FilesystemStore(StoreBase):
         path = self._flow_dir(flow_id) / "progress.json"
         tmp = path.with_suffix(".json.tmp")
         tmp.write_text(progress.model_dump_json(indent=2))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
 
     def read_progress(self, flow_id: str) -> Progress:
         """Load and return the ``Progress`` snapshot for ``flow_id``.

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -385,7 +385,7 @@ class FilesystemStore(StoreBase):
         path = self._flow_dir(flow_id) / "outputs.yaml"
         tmp = path.with_suffix(".yaml.tmp")
         tmp.write_text(yaml.safe_dump(outputs, sort_keys=False))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
 
     # ------------------------------------------------------------------ input.yaml
 

--- a/tests/core/test_atelier_conduit_crud.py
+++ b/tests/core/test_atelier_conduit_crud.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.schemas.api import CreateConduitInput, UpdateConduitInput
 
 
@@ -34,14 +36,20 @@ def _payload(name: str = "release_notes", description: str = "Release notes"):
 
 
 @pytest.fixture
-def atelier(tmp_path, monkeypatch):
-    """Construct an Atelier instance rooted under tmp_path.
+def atelier(tmp_path, _isolate_global_atelier_dir):
+    """Construct an Atelier instance rooted under tmp_path with an isolated global dir.
 
     :param tmp_path: pytest temp directory fixture.
-    :param monkeypatch: pytest monkeypatch fixture.
+    :param _isolate_global_atelier_dir: isolated global atelier dir fixture.
     """
-    monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
-    return Atelier(base_dir=tmp_path / ".atelier")
+    global_dir: Path = _isolate_global_atelier_dir
+    return Atelier(
+        base_dir=tmp_path / ".atelier",
+        settings=AtelierSettings(
+            atelier_dir=tmp_path / ".atelier",
+            global_atelier_dir=global_dir,
+        ),
+    )
 
 
 # ----------------------------------------------------------- create

--- a/tests/services/executor/test_bash.py
+++ b/tests/services/executor/test_bash.py
@@ -1,5 +1,7 @@
 """BashExecutor tests."""
 
+from pathlib import Path
+
 from app.schemas.conduit import TaskDefinition, ToolType
 from app.services.executor.base import FlowContext
 from app.services.executor.bash import BashExecutor
@@ -19,16 +21,18 @@ def _task(cmd: str) -> TaskDefinition:
     )
 
 
-def _ctx(timeout: int = 30) -> FlowContext:
+def _ctx(timeout: int = 30, working_dir: Path | None = None) -> FlowContext:
     """Build a FlowContext stub with a fake store.
 
     :param timeout: per-task timeout in seconds.
+    :param working_dir: optional working directory for the subprocess.
     """
     return FlowContext(
         flow_id="fake",
         store=None,  # type: ignore[arg-type]
         inputs={},
         timeout=timeout,
+        working_dir=working_dir,
     )
 
 
@@ -67,3 +71,15 @@ async def test_timeout_kills_process():
     )
     assert r.exit_code == 124
     assert "timeout" in r.stderr
+
+
+async def test_working_dir_sets_subprocess_cwd(tmp_path):
+    """Verify BashExecutor runs the command in context.working_dir."""
+    marker = tmp_path / "cwd_marker.txt"
+    r = await BashExecutor().execute(
+        _task(f"pwd > {marker}"),
+        f"pwd > {marker}",
+        _ctx(working_dir=tmp_path),
+    )
+    assert r.exit_code == 0
+    assert tmp_path.name in marker.read_text().strip()

--- a/tests/test_api/test_conduits_api.py
+++ b/tests/test_api/test_conduits_api.py
@@ -1,22 +1,30 @@
 """/conduits CRUD round-trip tests."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.services.api.app import FastApiServer
 
 
 @pytest.fixture
-async def client(tmp_path, monkeypatch):
+async def client(tmp_path, _isolate_global_atelier_dir):
     """Yield an httpx client wired to a fresh Atelier instance.
 
     :param tmp_path: pytest temp directory fixture.
-    :param monkeypatch: pytest monkeypatch fixture.
+    :param _isolate_global_atelier_dir: isolated global atelier dir fixture.
     """
-    monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
-    atelier = Atelier(base_dir=tmp_path / ".atelier")
+    global_dir: Path = _isolate_global_atelier_dir
+    atelier = Atelier(
+        settings=AtelierSettings(
+            atelier_dir=tmp_path / ".atelier",
+            global_atelier_dir=global_dir,
+        ),
+    )
     app = FastApiServer().create_app(atelier)
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:


### PR DESCRIPTION
## Summary
- Add `working_dir` to `FlowContext` and thread through `Engine.run()` → executors so tasks execute in the client's directory
- Bash and harness executors use `context.working_dir` as subprocess/agent cwd
- WS `/ws/run-conduit` stores flows and logs in `~/.atelier/` (global) instead of the backend's local `.atelier/`
- Schedule API (`serve` command) uses global schedule store with a custom executor that stores flows globally and runs tasks in `run_path`
- Conduit CRUD routes writes to global `~/.atelier/conduits/`

## Test plan
- [ ] Run full test suite: `python -m pytest tests/ -x`
- [ ] Send WS `run` message with a `run_path` pointing to a different directory — verify bash commands execute there and flow logs appear in `~/.atelier/flows/`
- [ ] Create a schedule via the API — verify it appears in `~/.atelier/schedules/`
- [ ] Verify CLI behavior is unchanged (schedules, conduits, runs still use project-level `.atelier/`)