### PR TITLE
feature: global atelier dir, Windows support, and endpoint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ wheels/
 claude.md
 .pytest_cache
 .DS_Store
+.opencode
+AGENTS.md

--- a/app/cli/commands/serve.py
+++ b/app/cli/commands/serve.py
@@ -11,11 +11,13 @@ import typer
 from app.cli._shared import console
 from app.cli.main import app
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.schemas.api import ScheduledJob
 from app.schemas.log import TaskEvent
 from app.services.api.app import FastApiServer
 from app.services.api.scheduler_bus import SchedulerEventBus
 from app.services.scheduler import SchedulerDaemon, default_local_zone
+from app.services.scheduler.store import ScheduleStore
 
 
 @app.command(
@@ -55,11 +57,12 @@ def serve_cmd(
         format="%(asctime)s %(levelname)-7s %(name)s — %(message)s",
     )
 
-    atelier = Atelier()
+    settings = AtelierSettings()
+    atelier = Atelier(base_dir=settings.global_atelier_dir)
     bus = SchedulerEventBus()
-    # The WS route subscribes new sockets to this bus so scheduled fires
-    # (which don't originate from a connected socket) still reach UIs.
     atelier.scheduler_bus = bus  # type: ignore[attr-defined]
+
+    global_schedule_store = ScheduleStore(settings.global_atelier_dir)
 
     async def _broadcasting_executor(job: ScheduledJob, working_dir: Path) -> None:
         """Run the conduit and fan lifecycle envelopes out to the bus."""
@@ -69,7 +72,7 @@ def serve_cmd(
             "conduit_name": job.conduit_name,
             "run_path": str(working_dir),
         }
-        scheduled_atelier = Atelier(base_dir=working_dir / ".atelier")
+        scheduled_atelier = Atelier(base_dir=settings.global_atelier_dir)
         captured: dict[str, str | None] = {"flow_id": None}
 
         def _on_started(flow_id: str) -> None:
@@ -98,6 +101,7 @@ def serve_cmd(
                 dict(job.inputs),
                 on_flow_started=_on_started,
                 on_task_event=_on_task_event,
+                working_dir=working_dir,
             )
         except Exception as e:  # noqa: BLE001
             await bus.broadcast(
@@ -114,7 +118,7 @@ def serve_cmd(
         )
 
     daemon = SchedulerDaemon(
-        atelier.schedule_store,
+        global_schedule_store,
         executor=_broadcasting_executor,
         default_zone=default_local_zone(),
         default_working_dir=Path.cwd(),

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -356,4 +356,3 @@ class Atelier:
             logger.warning("open_conduit_path failed: %s", e)
             return False
         return True
-        return target

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -126,6 +126,7 @@ class Atelier:
         on_flow_started: FlowStartedCallback | None = None,
         on_task_starting: TaskStartingCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | str | None = None,
     ) -> str:
         """Start a new flow for the named conduit.
 
@@ -144,8 +145,11 @@ class Atelier:
             tool calls, tool results) to the executor's prompt sink as
             they happen. Defaults to ``True``; the CLI exposes
             ``--hide-steps`` to opt out.
+        :param working_dir: working directory for task execution. When
+            ``None``, executors use the process cwd.
         :returns: the newly created flow id
         """
+        wd = Path(working_dir) if working_dir is not None else None
         conduit = self.store.read_conduit(name)
         return await self.engine.run(
             conduit,
@@ -154,6 +158,7 @@ class Atelier:
             on_flow_started=on_flow_started,
             on_task_starting=on_task_starting,
             show_steps=show_steps,
+            working_dir=wd,
         )
 
     def get_status(self, flow_id: str) -> Progress:
@@ -328,15 +333,12 @@ class Atelier:
         self.store._flow_dir(flow_id)
         return self.store.read_logs(flow_id)
 
-    def open_conduit_path(self, conduit_name: str, run_path: str) -> bool:
+    def open_conduit_path(self, run_path: str) -> bool:
         """Reveal ``run_path`` in the host's file explorer.
 
-        :param conduit_name: conduit context (not used by the OS opener,
-            kept for API symmetry with the frontend contract)
         :param run_path: absolute path to open
         :returns: True if the platform opener was launched, False otherwise
         """
-        del conduit_name
         cmd: list[str]
         if sys.platform == "darwin":
             cmd = ["open", run_path]
@@ -350,3 +352,4 @@ class Atelier:
             logger.warning("open_conduit_path failed: %s", e)
             return False
         return True
+        return target

--- a/app/core/atelier.py
+++ b/app/core/atelier.py
@@ -238,7 +238,7 @@ class Atelier:
         """
         conduit = Conduit.model_validate(
             {
-                "name": f"adhoc__{payload.name}",
+                "name": f"task__{payload.name}",
                 "description": payload.description or payload.name,
                 "tasks": [
                     {
@@ -262,7 +262,10 @@ class Atelier:
 
         try:
             flow_id = await self.engine.run(
-                conduit, dict(payload.inputs), on_flow_started=_on_started
+                conduit,
+                {},
+                on_flow_started=_on_started,
+                working_dir=Path(payload.run_path) if payload.run_path else None,
             )
         except Exception:  # noqa: BLE001
             flow_id = captured["id"] or ""
@@ -339,13 +342,14 @@ class Atelier:
         :param run_path: absolute path to open
         :returns: True if the platform opener was launched, False otherwise
         """
+        target = str(Path(run_path))
         cmd: list[str]
         if sys.platform == "darwin":
-            cmd = ["open", run_path]
+            cmd = ["open", target]
         elif sys.platform == "win32":
-            cmd = ["explorer", run_path]
+            cmd = ["explorer", target]
         else:
-            cmd = ["xdg-open", run_path]
+            cmd = ["xdg-open", target]
         try:
             subprocess.Popen(cmd)
         except (FileNotFoundError, OSError) as e:

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -31,7 +31,7 @@ class AtelierSettings(BaseSettings):
         default_factory=list,
         description=(
             "Override argv for the harness:claude-code ACP agent. "
-            "Empty = use the bundled default (@zed-industries/claude-code-acp)."
+            "Empty = use the bundled default (@agentclientprotocol/claude-agent-acp)."
         ),
     )
     codex_launch_cmd: list[str] = Field(

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -18,6 +18,7 @@ import asyncio
 import sys
 import traceback
 from collections.abc import Callable
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,9 @@ def _now() -> str:
     :returns: ISO-8601 timestamp ending with ``Z``.
     """
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+_current_task_ctx: ContextVar[str] = ContextVar("current_task_name", default="")
 
 
 def _validate_dag(conduit: Conduit) -> dict[str, list]:
@@ -346,6 +350,7 @@ class Engine:
             :param t: task definition to execute.
             """
             nonlocal failed, failure_error
+            _current_task_ctx.set(t.name)
             try:
                 # Resolve {{task.output}} templates now (inputs resolved per-iteration)
                 unavailable = {

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -19,6 +19,7 @@ import sys
 import traceback
 from collections.abc import Callable
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from app.modules.conditions import (
@@ -133,6 +134,7 @@ class Engine:
         on_flow_started: FlowStartedCallback | None = None,
         on_task_starting: TaskStartingCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | None = None,
     ) -> str:
         """Execute a conduit to completion, returning the flow id.
 
@@ -381,9 +383,10 @@ class Engine:
                     inputs=runtime_inputs,
                     task_outputs=outputs,
                     timeout=conduit.timeout,
+                    working_dir=working_dir,
                     show_steps=show_steps,
                     run_nested_conduit=self._make_nested_runner(
-                        on_task_event, show_steps=show_steps
+                        on_task_event, show_steps=show_steps, working_dir=working_dir
                     ),
                 )
 
@@ -590,11 +593,13 @@ class Engine:
         self,
         on_task_event: TaskEventCallback | None = None,
         show_steps: bool = True,
+        working_dir: Path | None = None,
     ):
         """Build the nested-conduit runner passed to executors via FlowContext.
 
         :param on_task_event: optional task-event callback forwarded to the child run.
         :param show_steps: whether the nested run should surface per-step progress.
+        :param working_dir: working directory forwarded to nested runs.
         :returns: an async callable ``(conduit_name, child_inputs, parent_flow_id)``
             that loads and runs the named child conduit.
         """
@@ -612,6 +617,7 @@ class Engine:
                 parent_flow_id,
                 on_task_event=on_task_event,
                 show_steps=show_steps,
+                working_dir=working_dir,
             )
 
         return _run_nested

--- a/app/routes/conduits.py
+++ b/app/routes/conduits.py
@@ -118,11 +118,10 @@ async def delete_conduit(name: str, atelier: Atelier = Depends(get_atelier)):
 async def open_path(
     payload: OpenPathInput, atelier: Atelier = Depends(get_atelier)
 ) -> dict[str, Any]:
-    """Open a conduit-relative path in the host OS and report what was opened.
+    """Open a path in the host OS file explorer.
 
     :param payload: parsed :class:`OpenPathInput` body.
     :param atelier: injected :class:`Atelier` facade.
-    :returns: ``{"opened": <path>}`` echoing the resolved target.
+    :returns: ``{"opened": true}`` on success, ``{"opened": false}`` on failure.
     """
-    opened = atelier.open_conduit_path(payload.conduit_name, payload.run_path)
-    return {"opened": opened}
+    return {"opened": atelier.open_conduit_path(payload.run_path)}

--- a/app/routes/conduits.py
+++ b/app/routes/conduits.py
@@ -79,7 +79,6 @@ async def create_conduit(
     return ConduitDTO.model_validate(conduit.model_dump()).model_dump()
 
 
-@router.put("/{name}")
 @router.patch("/{name}")
 async def update_conduit(
     name: str,

--- a/app/routes/conduits.py
+++ b/app/routes/conduits.py
@@ -79,6 +79,7 @@ async def create_conduit(
     return ConduitDTO.model_validate(conduit.model_dump()).model_dump()
 
 
+@router.put("/{name}")
 @router.patch("/{name}")
 async def update_conduit(
     name: str,

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -22,6 +22,7 @@ from app.schemas.ws import (
 from app.services.api.base import get_atelier
 from app.services.api.ws_hitl import WsHitlExecutor
 from app.services.api.ws_manager import WebSocketBroker
+from app.services.api.ws_sink import WsPromptSink
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -125,7 +126,10 @@ async def _spawn_run(
     """
     # Per-connection Atelier instance keeps executor swaps from leaking
     # across sockets (SPEC §10 / risk table).
-    atelier = Atelier(base_dir=base_atelier.settings.global_atelier_dir)
+    atelier = Atelier(
+        base_dir=base_atelier.settings.global_atelier_dir,
+        prompt_sink=WsPromptSink(broker, message.flow_id),
+    )
     broker.register_flow(message.flow_id)
     atelier.executors["tool:hitl"] = WsHitlExecutor(
         broker=broker, flow_id=message.flow_id
@@ -136,16 +140,18 @@ async def _spawn_run(
 
         :param event: task event produced by the engine.
         """
-        # Emit intermediate steps as individual StepMessage envelopes
-        for step in event.steps:
-            await broker.send(
-                {
-                    "type": "step",
-                    "flow_id": message.flow_id,
-                    "task": event.task,
-                    "step": step.model_dump(mode="json"),
-                }
-            )
+        # Harness tasks stream steps live via WsPromptSink.display_step;
+        # only emit batched steps for non-harness tools (bash, hitl, conduit).
+        if not event.tool.startswith("harness:"):
+            for step in event.steps:
+                await broker.send(
+                    {
+                        "type": "step",
+                        "flow_id": message.flow_id,
+                        "task": event.task,
+                        "step": step.model_dump(mode="json"),
+                    }
+                )
         await broker.send(
             {
                 "type": "step_status",

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, WebSocket
@@ -124,7 +125,7 @@ async def _spawn_run(
     """
     # Per-connection Atelier instance keeps executor swaps from leaking
     # across sockets (SPEC §10 / risk table).
-    atelier = Atelier(base_dir=base_atelier.settings.atelier_dir)
+    atelier = Atelier(base_dir=base_atelier.settings.global_atelier_dir)
     broker.register_flow(message.flow_id)
     atelier.executors["tool:hitl"] = WsHitlExecutor(
         broker=broker, flow_id=message.flow_id
@@ -184,6 +185,7 @@ async def _spawn_run(
                     conduit,
                     dict(message.inputs),
                     on_task_event=_on_task_event_sync,
+                    working_dir=Path(message.run_path) if message.run_path else None,
                 )
             except asyncio.CancelledError:
                 await broker.send(

--- a/app/routes/ws.py
+++ b/app/routes/ws.py
@@ -104,8 +104,11 @@ async def run_conduit_ws(websocket: WebSocket) -> None:
     finally:
         if scheduler_bus is not None:
             scheduler_bus.unsubscribe(_send)
-        if websocket.application_state == WebSocketState.CONNECTED:
-            await websocket.close()
+        try:
+            if websocket.application_state == WebSocketState.CONNECTED:
+                await websocket.close()
+        except RuntimeError:
+            pass
 
 
 async def _spawn_run(

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -57,7 +57,6 @@ class RunTaskInput(BaseModel):
     description: str = ""
     task: str
     tool: str
-    inputs: dict[str, Any] = Field(default_factory=dict)
     run_path: str
 
 

--- a/app/services/api/ws_sink.py
+++ b/app/services/api/ws_sink.py
@@ -56,13 +56,16 @@ class WsPromptSink:
     async def request_permission(
         self, summary: str, options: list[PermissionOption]
     ) -> str:
-        """Auto-approve with the first available option.
+        """Deny all permission requests until interactive approval is implemented.
 
         :param summary: permission description (unused).
-        :param options: available permission choices.
-        :returns: the ``id`` of the first option.
+        :param options: available permission choices (unused).
+        :raises PermissionError: always, as interactive approval is not yet supported.
         """
-        return options[0].id if options else ""
+        raise PermissionError(
+            "WS sink does not support interactive permission approval: "
+            f"denied request '{summary}'"
+        )
 
     async def display_step(self, step: IntermediateStep) -> None:
         """Forward an intermediate step as a ``step`` envelope over WebSocket.

--- a/app/services/api/ws_sink.py
+++ b/app/services/api/ws_sink.py
@@ -1,0 +1,82 @@
+"""WebSocket-driven PromptSink for real-time step streaming.
+
+Replaces :class:`TerminalPromptSink` for connections served over the
+WebSocket endpoint: ``display_step`` forwards intermediate steps as
+``step`` envelopes through the broker as they arrive from the harness
+executor, rather than writing them to the terminal.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.modules.engine import _current_task_ctx
+from app.services.api.ws_manager import WebSocketBroker
+from app.services.executor.prompt_sink import PermissionOption
+
+if TYPE_CHECKING:
+    from app.schemas.log import IntermediateStep
+
+
+class WsPromptSink:
+    """:class:`PromptSink` that streams intermediate steps over WebSocket.
+
+    :param broker: per-connection broker used to send envelopes
+    :param flow_id: flow this sink instance is bound to
+    """
+
+    def __init__(self, broker: WebSocketBroker, flow_id: str) -> None:
+        """Bind the sink to a broker and a specific flow.
+
+        :param broker: per-connection broker used to send envelopes
+        :param flow_id: flow this sink instance is bound to
+        """
+        self._broker = broker
+        self._flow_id = flow_id
+
+    async def display(self, text: str) -> None:
+        """No-op for WebSocket runs (agent text streaming is separate).
+
+        :param text: text to display (ignored).
+        """
+
+    async def start_agent_turn(self, label: str = "agent") -> None:
+        """No-op for WebSocket runs.
+
+        :param label: turn label (ignored).
+        """
+
+    async def request_input(self, prompt: str) -> str:
+        """Not supported over WebSocket — interactive input uses HITL.
+
+        :param prompt: prompt label (unused).
+        :raises NotImplementedError: always.
+        """
+        raise NotImplementedError("WS sink does not support request_input")
+
+    async def request_permission(
+        self, summary: str, options: list[PermissionOption]
+    ) -> str:
+        """Auto-approve with the first available option.
+
+        :param summary: permission description (unused).
+        :param options: available permission choices.
+        :returns: the ``id`` of the first option.
+        """
+        return options[0].id if options else ""
+
+    async def display_step(self, step: IntermediateStep) -> None:
+        """Forward an intermediate step as a ``step`` envelope over WebSocket.
+
+        Reads the current task name from the engine's contextvar so that
+        concurrent tasks don't clobber each other.
+
+        :param step: the :class:`IntermediateStep` to forward.
+        """
+        await self._broker.send(
+            {
+                "type": "step",
+                "flow_id": self._flow_id,
+                "task": _current_task_ctx.get(""),
+                "step": step.model_dump(mode="json"),
+            }
+        )

--- a/app/services/executor/base.py
+++ b/app/services/executor/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from app.schemas.conduit import TaskDefinition
@@ -23,6 +24,9 @@ class FlowContext:
     inputs: dict[str, Any]
     task_outputs: dict[str, str] = field(default_factory=dict)
     timeout: int = 3600
+    working_dir: Path | None = None
+    """Working directory for subprocess / agent execution. When ``None``,
+    executors use the process cwd."""
     show_steps: bool = True
     """Stream intermediate steps (thinking, tool calls, tool results) to the
     executor's :class:`PromptSink` as they happen. Independent of

--- a/app/services/executor/bash.py
+++ b/app/services/executor/bash.py
@@ -28,6 +28,7 @@ class BashExecutor(ExecutorBase):
             resolved_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=str(context.working_dir) if context.working_dir else None,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -19,7 +19,11 @@ when the marker appears or when :attr:`MAX_INTERACTIVE_TURNS` is reached.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import os
+import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +49,26 @@ from app.services.executor.prompt_sink import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_cmd(cmd: str) -> str:
+    """On Windows, resolve .cmd/.bat wrappers that ``create_subprocess_exec`` can't find."""
+    if os.name == "nt":
+        resolved = shutil.which(cmd)
+        if resolved is not None:
+            return resolved
+    return cmd
+
+
+def _close_proc_transports(proc: asyncio.subprocess.Process) -> None:
+    """Explicitly close pipe transports on Windows to prevent ``__del__`` errors."""
+    for stream in (proc.stdout, proc.stderr):
+        if stream is None:
+            continue
+        transport = getattr(stream, "_transport", None)
+        if transport is not None:
+            with contextlib.suppress(OSError, ValueError):
+                transport.close()
 
 
 DEFAULT_DONE_MARKER = "[ATELIER_DONE]"
@@ -467,6 +491,7 @@ class AcpHarnessExecutor(ExecutorBase):
         :returns: :class:`ExecutionResult` from single-turn or interactive run.
         """
         cmd, *args = self.launch_cmd
+        cmd = _resolve_cmd(cmd)
         # Raise the per-line StreamReader limit well above asyncio's 64 KiB
         # default; Codex and similar harnesses emit large JSON-RPC frames
         # (tool results, planning output) that routinely exceed it.
@@ -478,19 +503,23 @@ class AcpHarnessExecutor(ExecutorBase):
             transport_kwargs={"limit": 8 * 1024 * 1024},
         ) as (
             conn,
-            _proc,
+            proc,
         ):
             await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
             sess = await conn.new_session(cwd=cwd)
             await self._maybe_switch_to_permissive_mode(conn, sess)
 
-            if not interactive:
-                return await self._run_single_turn(
+            try:
+                if not interactive:
+                    return await self._run_single_turn(
+                        conn, sess.session_id, initial_prompt, client
+                    )
+                return await self._run_interactive(
                     conn, sess.session_id, initial_prompt, client
                 )
-            return await self._run_interactive(
-                conn, sess.session_id, initial_prompt, client
-            )
+            finally:
+                if sys.platform == "win32":
+                    _close_proc_transports(proc)
 
     @staticmethod
     async def _maybe_switch_to_permissive_mode(conn, sess) -> None:

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -3,7 +3,7 @@
 Each harness is a thin :class:`AcpHarnessExecutor` subclass differing only
 in its ``launch_cmd``. Each reuses the host CLI's own config and auth.
 
-- ``harness:claude-code`` → ``@zed-industries/claude-code-acp`` via ``npx``
+- ``harness:claude-code`` → ``@agentclientprotocol/claude-agent-acp`` via ``npx``
 - ``harness:codex``       → ``@zed-industries/codex-acp`` via ``npx``
 - ``harness:opencode``    → ``opencode acp`` (native ACP)
 - ``harness:copilot``     → ``copilot --acp`` (GitHub Copilot CLI, native ACP)
@@ -116,7 +116,7 @@ def _pick_permissive_mode(state: SessionModeState | None) -> str | None:
 CLAUDE_ACP_LAUNCH = [
     "npx",
     "-y",
-    "@zed-industries/claude-code-acp@0.16.2",
+    "@agentclientprotocol/claude-agent-acp@0.37.0",
 ]
 CODEX_ACP_LAUNCH = [
     "npx",

--- a/app/services/executor/harness.py
+++ b/app/services/executor/harness.py
@@ -442,7 +442,7 @@ class AcpHarnessExecutor(ExecutorBase):
         if task.interactive:
             prompt_text = prompt_text + build_interactive_suffix(self.done_marker)
 
-        cwd = str(Path.cwd())
+        cwd = str(context.working_dir) if context.working_dir else str(Path.cwd())
         client = _BufferingClient(
             self.sink,
             stream_messages=task.interactive,

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -20,6 +20,7 @@ import json
 import os
 import shutil
 import time
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -181,7 +182,7 @@ class FilesystemStore(StoreBase):
         conduit_dir.mkdir(parents=True, exist_ok=True)
         payload = conduit.model_dump(mode="json", by_alias=True, exclude_none=True)
         path = self._conduit_yaml(conduit.name)
-        tmp = path.with_suffix(".yaml.tmp")
+        tmp = path.with_suffix(f".yaml.tmp.{uuid.uuid4().hex}")
         tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
         _atomic_replace(tmp, path)
 
@@ -200,7 +201,7 @@ class FilesystemStore(StoreBase):
         conduit_dir.mkdir(parents=True, exist_ok=True)
         path = conduit_dir / "conduit.yaml"
         payload = conduit.model_dump(mode="json", by_alias=True, exclude_none=True)
-        tmp = path.with_suffix(".yaml.tmp")
+        tmp = path.with_suffix(f".yaml.tmp.{uuid.uuid4().hex}")
         tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
         _atomic_replace(tmp, path)
 
@@ -383,7 +384,7 @@ class FilesystemStore(StoreBase):
             that did not complete)
         """
         path = self._flow_dir(flow_id) / "outputs.yaml"
-        tmp = path.with_suffix(".yaml.tmp")
+        tmp = path.with_suffix(f".yaml.tmp.{uuid.uuid4().hex}")
         tmp.write_text(yaml.safe_dump(outputs, sort_keys=False))
         _atomic_replace(tmp, path)
 

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -19,6 +19,7 @@ import asyncio
 import json
 import os
 import shutil
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,20 @@ from app.schemas.flow import new_flow_id, parse_flow_id
 from app.schemas.log import LogEntry
 from app.schemas.progress import Progress
 from app.services.store.base import ConduitSource, StoreBase
+
+if os.name == "nt":
+    def _atomic_replace(src: str | Path, dst: str | Path) -> None:
+        for attempt in range(5):
+            try:
+                os.replace(src, dst)
+                return
+            except PermissionError:
+                if attempt == 4:
+                    raise
+                time.sleep(0.05 * (attempt + 1))
+else:
+    def _atomic_replace(src: str | Path, dst: str | Path) -> None:
+        os.replace(src, dst)
 
 
 class FilesystemStore(StoreBase):
@@ -72,14 +87,22 @@ class FilesystemStore(StoreBase):
         """
         return self._conduit_dir(name) / "conduit.yaml"
 
-    def _global_conduit_yaml(self, name: str) -> Path | None:
-        """Return the global ``conduit.yaml`` path for ``name`` or ``None``.
+    def _global_conduit_dir(self, name: str) -> Path | None:
+        """Return the global directory for conduit ``name`` or ``None``.
 
         :param name: conduit name
         """
         if self.global_dir is None:
             return None
-        return self.global_dir / "conduits" / name / "conduit.yaml"
+        return self.global_dir / "conduits" / name
+
+    def _global_conduit_yaml(self, name: str) -> Path | None:
+        """Return the global ``conduit.yaml`` path for ``name`` or ``None``.
+
+        :param name: conduit name
+        """
+        conduit_dir = self._global_conduit_dir(name)
+        return conduit_dir / "conduit.yaml" if conduit_dir is not None else None
 
     def _flow_dir(self, flow_id: str) -> Path:
         """Resolve and cache the directory for ``flow_id``.
@@ -160,7 +183,51 @@ class FilesystemStore(StoreBase):
         path = self._conduit_yaml(conduit.name)
         tmp = path.with_suffix(".yaml.tmp")
         tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
+
+    def write_conduit_global(self, conduit: Conduit) -> None:
+        """Persist ``conduit`` under the global ``~/.atelier/conduits/<name>/``.
+
+        :param conduit: validated conduit to persist.
+        :raises RuntimeError: if no global directory is available.
+        """
+        conduit_dir = self._global_conduit_dir(conduit.name)
+        if conduit_dir is None:
+            raise RuntimeError(
+                "global conduit directory is not available "
+                "(home directory may be read-only)"
+            )
+        conduit_dir.mkdir(parents=True, exist_ok=True)
+        path = conduit_dir / "conduit.yaml"
+        payload = conduit.model_dump(mode="json", by_alias=True, exclude_none=True)
+        tmp = path.with_suffix(".yaml.tmp")
+        tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
+        _atomic_replace(tmp, path)
+
+    def conduit_source(self, name: str) -> ConduitSource:
+        """Return whether ``name`` lives in the project or global store.
+
+        :param name: conduit name
+        :raises FileNotFoundError: if not found in either store
+        """
+        if self._conduit_yaml(name).exists():
+            return "project"
+        global_yaml = self._global_conduit_yaml(name)
+        if global_yaml is not None and global_yaml.exists():
+            return "global"
+        raise FileNotFoundError(f"conduit not found: {name}")
+
+    def delete_conduit_global(self, name: str) -> bool:
+        """Remove a global conduit by name.
+
+        :param name: conduit name
+        :returns: True if deleted, False if it didn't exist
+        """
+        conduit_dir = self._global_conduit_dir(name)
+        if conduit_dir is None or not conduit_dir.exists():
+            return False
+        shutil.rmtree(conduit_dir)
+        return True
 
     def delete_conduit(self, name: str) -> bool:
         """Remove ``conduits/<name>/`` if present (project store only).
@@ -270,7 +337,7 @@ class FilesystemStore(StoreBase):
             existing.append(entry.model_dump())
             tmp = path.with_suffix(".json.tmp")
             tmp.write_text(json.dumps(existing, indent=2))
-            os.replace(tmp, path)
+            _atomic_replace(tmp, path)
 
     def read_logs(self, flow_id: str) -> list[LogEntry]:
         """Return all log entries for ``flow_id`` in append order.
@@ -296,7 +363,7 @@ class FilesystemStore(StoreBase):
         path = self._flow_dir(flow_id) / "progress.json"
         tmp = path.with_suffix(".json.tmp")
         tmp.write_text(progress.model_dump_json(indent=2))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
 
     def read_progress(self, flow_id: str) -> Progress:
         """Load and return the ``Progress`` snapshot for ``flow_id``.

--- a/app/services/store/filesystem.py
+++ b/app/services/store/filesystem.py
@@ -385,7 +385,7 @@ class FilesystemStore(StoreBase):
         path = self._flow_dir(flow_id) / "outputs.yaml"
         tmp = path.with_suffix(".yaml.tmp")
         tmp.write_text(yaml.safe_dump(outputs, sort_keys=False))
-        os.replace(tmp, path)
+        _atomic_replace(tmp, path)
 
     # ------------------------------------------------------------------ input.yaml
 

--- a/tests/core/test_atelier_conduit_crud.py
+++ b/tests/core/test_atelier_conduit_crud.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.schemas.api import CreateConduitInput, UpdateConduitInput
 
 
@@ -34,14 +36,20 @@ def _payload(name: str = "release_notes", description: str = "Release notes"):
 
 
 @pytest.fixture
-def atelier(tmp_path, monkeypatch):
-    """Construct an Atelier instance rooted under tmp_path.
+def atelier(tmp_path, _isolate_global_atelier_dir):
+    """Construct an Atelier instance rooted under tmp_path with an isolated global dir.
 
     :param tmp_path: pytest temp directory fixture.
-    :param monkeypatch: pytest monkeypatch fixture.
+    :param _isolate_global_atelier_dir: isolated global atelier dir fixture.
     """
-    monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
-    return Atelier(base_dir=tmp_path / ".atelier")
+    global_dir: Path = _isolate_global_atelier_dir
+    return Atelier(
+        base_dir=tmp_path / ".atelier",
+        settings=AtelierSettings(
+            atelier_dir=tmp_path / ".atelier",
+            global_atelier_dir=global_dir,
+        ),
+    )
 
 
 # ----------------------------------------------------------- create

--- a/tests/core/test_atelier_conduit_crud.py
+++ b/tests/core/test_atelier_conduit_crud.py
@@ -138,7 +138,7 @@ def test_open_conduit_path_invokes_platform_opener(tmp_path, atelier):
     run_path.mkdir()
     with patch("subprocess.Popen") as popen:
         popen.return_value.poll.return_value = None
-        ok = atelier.open_conduit_path("release_notes", str(run_path))
+        ok = atelier.open_conduit_path(str(run_path))
     assert ok is True
     args = popen.call_args[0][0]
     if sys.platform == "darwin":
@@ -157,5 +157,5 @@ def test_open_conduit_path_returns_false_on_failure(tmp_path, atelier):
     """
     atelier.create_conduit(_payload())
     with patch("subprocess.Popen", side_effect=FileNotFoundError("no opener")):
-        ok = atelier.open_conduit_path("release_notes", str(tmp_path))
+        ok = atelier.open_conduit_path(str(tmp_path))
     assert ok is False

--- a/tests/core/test_atelier_history.py
+++ b/tests/core/test_atelier_history.py
@@ -19,7 +19,7 @@ def atelier(tmp_path, monkeypatch):
     return Atelier(base_dir=tmp_path / ".atelier")
 
 
-async def test_list_prior_flows_after_run_returns_one(atelier):
+async def test_list_prior_flows_after_run_returns_one(atelier, tmp_path):
     """Verify list_prior_flows returns the just-completed run.
 
     :param atelier: Atelier facade fixture.
@@ -29,7 +29,7 @@ async def test_list_prior_flows_after_run_returns_one(atelier):
         description="d",
         task="echo hi",
         tool="tool:bash",
-        run_path="/tmp",
+        run_path=str(tmp_path),
     )
     out = await atelier.run_single_task(payload)
     flows = atelier.list_prior_flows()
@@ -39,7 +39,7 @@ async def test_list_prior_flows_after_run_returns_one(atelier):
     assert flows[0].status == "completed"
 
 
-async def test_get_flow_logs_round_trips(atelier):
+async def test_get_flow_logs_round_trips(atelier, tmp_path):
     """Verify get_flow_logs returns LogEntry objects from a completed run.
 
     :param atelier: Atelier facade fixture.
@@ -49,7 +49,7 @@ async def test_get_flow_logs_round_trips(atelier):
         description="d",
         task="echo round-trip",
         tool="tool:bash",
-        run_path="/tmp",
+        run_path=str(tmp_path),
     )
     out = await atelier.run_single_task(payload)
     logs = atelier.get_flow_logs(out.flow_id)

--- a/tests/core/test_atelier_history.py
+++ b/tests/core/test_atelier_history.py
@@ -29,7 +29,6 @@ async def test_list_prior_flows_after_run_returns_one(atelier):
         description="d",
         task="echo hi",
         tool="tool:bash",
-        inputs={},
         run_path="/tmp",
     )
     out = await atelier.run_single_task(payload)
@@ -50,7 +49,6 @@ async def test_get_flow_logs_round_trips(atelier):
         description="d",
         task="echo round-trip",
         tool="tool:bash",
-        inputs={},
         run_path="/tmp",
     )
     out = await atelier.run_single_task(payload)

--- a/tests/core/test_atelier_run_task.py
+++ b/tests/core/test_atelier_run_task.py
@@ -28,7 +28,6 @@ async def test_run_single_task_runs_bash_echo_and_returns_logs(atelier):
         description="ad-hoc echo",
         task="echo hello-from-task",
         tool="tool:bash",
-        inputs={},
         run_path="/tmp",
     )
     out = await atelier.run_single_task(payload)
@@ -49,7 +48,6 @@ async def test_run_single_task_persists_flow_dir(atelier):
         description="ad-hoc echo",
         task="echo persisted",
         tool="tool:bash",
-        inputs={},
         run_path="/tmp",
     )
     out = await atelier.run_single_task(payload)
@@ -67,7 +65,6 @@ async def test_run_single_task_failure_returns_non_zero_exit(atelier):
         description="explode",
         task="exit 7",
         tool="tool:bash",
-        inputs={},
         run_path="/tmp",
     )
     out = await atelier.run_single_task(payload)

--- a/tests/core/test_atelier_run_task.py
+++ b/tests/core/test_atelier_run_task.py
@@ -18,7 +18,7 @@ def atelier(tmp_path, monkeypatch):
     return Atelier(base_dir=tmp_path / ".atelier")
 
 
-async def test_run_single_task_runs_bash_echo_and_returns_logs(atelier):
+async def test_run_single_task_runs_bash_echo_and_returns_logs(atelier, tmp_path):
     """Verify run_single_task runs bash echo and returns logs with exit 0.
 
     :param atelier: Atelier facade fixture.
@@ -28,7 +28,7 @@ async def test_run_single_task_runs_bash_echo_and_returns_logs(atelier):
         description="ad-hoc echo",
         task="echo hello-from-task",
         tool="tool:bash",
-        run_path="/tmp",
+        run_path=str(tmp_path),
     )
     out = await atelier.run_single_task(payload)
     assert isinstance(out, RunTaskOutput)
@@ -38,7 +38,7 @@ async def test_run_single_task_runs_bash_echo_and_returns_logs(atelier):
     assert out.logs[-1].exit_code == 0
 
 
-async def test_run_single_task_persists_flow_dir(atelier):
+async def test_run_single_task_persists_flow_dir(atelier, tmp_path):
     """Verify run_single_task writes the flow's logs.json to disk.
 
     :param atelier: Atelier facade fixture.
@@ -48,14 +48,14 @@ async def test_run_single_task_persists_flow_dir(atelier):
         description="ad-hoc echo",
         task="echo persisted",
         tool="tool:bash",
-        run_path="/tmp",
+        run_path=str(tmp_path),
     )
     out = await atelier.run_single_task(payload)
     flow_dir = atelier.store._flow_dir(out.flow_id)
     assert (flow_dir / "logs.json").exists()
 
 
-async def test_run_single_task_failure_returns_non_zero_exit(atelier):
+async def test_run_single_task_failure_returns_non_zero_exit(atelier, tmp_path):
     """Verify run_single_task returns a non-zero exit code on failure.
 
     :param atelier: Atelier facade fixture.
@@ -65,7 +65,7 @@ async def test_run_single_task_failure_returns_non_zero_exit(atelier):
         description="explode",
         task="exit 7",
         tool="tool:bash",
-        run_path="/tmp",
+        run_path=str(tmp_path),
     )
     out = await atelier.run_single_task(payload)
     assert out.flow_id

--- a/tests/schemas/test_api_schemas.py
+++ b/tests/schemas/test_api_schemas.py
@@ -90,7 +90,6 @@ def test_run_task_input_validates_minimum_fields():
             "description": "d",
             "task": "echo hello",
             "tool": "tool:bash",
-            "inputs": {},
             "run_path": "/tmp/x",
         }
     )

--- a/tests/services/executor/test_bash.py
+++ b/tests/services/executor/test_bash.py
@@ -1,4 +1,7 @@
 """BashExecutor tests."""
+import sys
+
+import pytest
 
 from app.schemas.conduit import TaskDefinition, ToolType
 from app.services.executor.base import FlowContext
@@ -47,6 +50,7 @@ async def test_failure_exit_code():
     assert not r.success
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax not supported in cmd.exe")
 async def test_stderr_captured():
     """Verify stderr output is captured separately from stdout."""
     r = await BashExecutor().execute(

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -515,9 +515,9 @@ class TestInteractive:
 
 class TestPreset:
     def test_claude_harness_default_launch_cmd(self) -> None:
-        """Verify ClaudeHarness uses the claude-code-acp launch command."""
+        """Verify ClaudeHarness uses the claude-agent-acp launch command."""
         h = ClaudeHarness(sink=RecordingSink())
-        assert "claude-code-acp" in " ".join(h.launch_cmd)
+        assert "claude-agent-acp" in " ".join(h.launch_cmd)
 
     def test_claude_harness_override_launch_cmd(self) -> None:
         """Verify ClaudeHarness honors an explicit launch_cmd override."""

--- a/tests/services/scheduler/test_runner.py
+++ b/tests/services/scheduler/test_runner.py
@@ -14,16 +14,17 @@ from app.services.scheduler.store import ScheduleStore
 UTC = ZoneInfo("UTC")
 
 
-def _recurring(conduit: str = "report") -> CreateScheduleInput:
+def _recurring(conduit: str = "report", run_path: str = "/tmp/run") -> CreateScheduleInput:
     """Build a recurring CreateScheduleInput for the given conduit.
 
     :param conduit: conduit name to embed in the schedule payload.
+    :param run_path: working directory for the scheduled run.
     """
     return CreateScheduleInput.model_validate(
         {
             "conduit_name": conduit,
             "inputs": {},
-            "run_path": "/tmp/run",
+            "run_path": run_path,
             "schedule": {
                 "mode": "recurring",
                 "name": conduit,
@@ -231,21 +232,23 @@ async def test_sync_replaces_when_config_changes(daemon, store):
 # -------------------------------------------------------------- fire
 
 
-async def test_fire_invokes_executor_with_run_path(daemon, store, executor):
+async def test_fire_invokes_executor_with_run_path(daemon, store, executor, tmp_path):
     """Verify _fire invokes the executor with the schedule's run_path.
 
     :param daemon: SchedulerDaemon fixture.
     :param store: ScheduleStore fixture.
     :param executor: recording executor fixture.
+    :param tmp_path: pytest temp directory fixture.
     """
-    job = store.create(_recurring())
+    run_path = str(tmp_path / "run")
+    job = store.create(_recurring(run_path=run_path))
     await daemon.start()
     await daemon._fire(job.id)
     assert len(executor.calls) == 1
     fired_job, working_dir = executor.calls[0]
     assert fired_job.id == job.id
     assert fired_job.conduit_name == "report"
-    assert working_dir == Path("/tmp/run")
+    assert working_dir == Path(run_path)
 
 
 async def test_fire_passes_inputs(daemon, store, executor):

--- a/tests/test_api/test_conduits_api.py
+++ b/tests/test_api/test_conduits_api.py
@@ -1,22 +1,30 @@
 """/conduits CRUD round-trip tests."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 
 from app.core.atelier import Atelier
+from app.core.settings import AtelierSettings
 from app.services.api.app import FastApiServer
 
 
 @pytest.fixture
-async def client(tmp_path, monkeypatch):
+async def client(tmp_path, _isolate_global_atelier_dir):
     """Yield an httpx client wired to a fresh Atelier instance.
 
     :param tmp_path: pytest temp directory fixture.
-    :param monkeypatch: pytest monkeypatch fixture.
+    :param _isolate_global_atelier_dir: isolated global atelier dir fixture.
     """
-    monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
-    atelier = Atelier(base_dir=tmp_path / ".atelier")
+    global_dir: Path = _isolate_global_atelier_dir
+    atelier = Atelier(
+        settings=AtelierSettings(
+            atelier_dir=tmp_path / ".atelier",
+            global_atelier_dir=global_dir,
+        ),
+    )
     app = FastApiServer().create_app(atelier)
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:

--- a/tests/test_api/test_flows_api.py
+++ b/tests/test_api/test_flows_api.py
@@ -26,10 +26,11 @@ async def fixture(tmp_path, monkeypatch):
         yield c, atelier
 
 
-async def _seed_flow(atelier: Atelier) -> str:
+async def _seed_flow(atelier: Atelier, run_path: str = ".") -> str:
     """Run a one-off bash task to seed a completed flow.
 
     :param atelier: Atelier instance to run the task against.
+    :param run_path: working directory for the bash subprocess.
     """
     out = await atelier.run_single_task(
         RunTaskInput(
@@ -37,7 +38,7 @@ async def _seed_flow(atelier: Atelier) -> str:
             description="d",
             task="echo flow-api-output",
             tool="tool:bash",
-            run_path="/tmp",
+            run_path=run_path,
         )
     )
     return out.flow_id
@@ -54,13 +55,13 @@ async def test_list_flows_empty(fixture):
     assert resp.json() == []
 
 
-async def test_list_flows_returns_completed(fixture):
+async def test_list_flows_returns_completed(fixture, tmp_path):
     """Verify GET /flows includes the seeded completed flow.
 
     :param fixture: client+atelier tuple fixture.
     """
     client, atelier = fixture
-    flow_id = await _seed_flow(atelier)
+    flow_id = await _seed_flow(atelier, run_path=str(tmp_path))
     resp = await client.get("/flows")
     assert resp.status_code == 200
     bodies = resp.json()
@@ -69,13 +70,13 @@ async def test_list_flows_returns_completed(fixture):
     assert target["status"] == "completed"
 
 
-async def test_get_logs_round_trips(fixture):
+async def test_get_logs_round_trips(fixture, tmp_path):
     """Verify GET /flows/<id>/logs returns the recorded stdout entries.
 
     :param fixture: client+atelier tuple fixture.
     """
     client, atelier = fixture
-    flow_id = await _seed_flow(atelier)
+    flow_id = await _seed_flow(atelier, run_path=str(tmp_path))
     resp = await client.get(f"/flows/{flow_id}/logs")
     assert resp.status_code == 200
     logs = resp.json()

--- a/tests/test_api/test_flows_api.py
+++ b/tests/test_api/test_flows_api.py
@@ -37,7 +37,6 @@ async def _seed_flow(atelier: Atelier) -> str:
             description="d",
             task="echo flow-api-output",
             tool="tool:bash",
-            inputs={},
             run_path="/tmp",
         )
     )

--- a/tests/test_api/test_tasks_api.py
+++ b/tests/test_api/test_tasks_api.py
@@ -38,7 +38,6 @@ async def test_run_task_executes_bash_and_returns_logs(fixture):
         "description": "ad-hoc",
         "task": "echo task-api-output",
         "tool": "tool:bash",
-        "inputs": {},
         "run_path": "/tmp",
     }
     resp = await client.post("/tasks/run", json=payload)

--- a/tests/test_api/test_tasks_api.py
+++ b/tests/test_api/test_tasks_api.py
@@ -38,7 +38,7 @@ async def test_run_task_executes_bash_and_returns_logs(fixture):
         "description": "ad-hoc",
         "task": "echo task-api-output",
         "tool": "tool:bash",
-        "run_path": "/tmp",
+        "run_path": str(tmp_path),
     }
     resp = await client.post("/tasks/run", json=payload)
     assert resp.status_code == 200, resp.text

--- a/tests/test_api/test_ws_run_conduit.py
+++ b/tests/test_api/test_ws_run_conduit.py
@@ -40,16 +40,16 @@ def env(tmp_path, monkeypatch):
     :param tmp_path: pytest temp directory fixture.
     :param monkeypatch: pytest monkeypatch fixture.
     """
-    monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
+    global_dir = tmp_path / ".atelier-global"
+    monkeypatch.setenv("ATELIER_GLOBAL_ATELIER_DIR", str(global_dir))
     atelier = Atelier(base_dir=tmp_path / ".atelier")
-    (atelier.store.base_dir / "conduits" / "hello").mkdir(parents=True, exist_ok=True)
-    (atelier.store.base_dir / "conduits" / "hello" / "conduit.yaml").write_text(
-        HELLO_YAML
-    )
-    (atelier.store.base_dir / "conduits" / "human").mkdir(parents=True, exist_ok=True)
-    (atelier.store.base_dir / "conduits" / "human" / "conduit.yaml").write_text(
-        HITL_YAML
-    )
+    for name, yaml_str in [("hello", HELLO_YAML), ("human", HITL_YAML)]:
+        (atelier.store.global_dir / "conduits" / name).mkdir(
+            parents=True, exist_ok=True
+        )
+        (
+            atelier.store.global_dir / "conduits" / name / "conduit.yaml"
+        ).write_text(yaml_str)
     app = FastApiServer().create_app(atelier)
     return atelier, app
 
@@ -73,10 +73,11 @@ def _drain_until(ws, predicate, *, max_messages: int = 50):
     )
 
 
-def test_ws_happy_path_emits_started_log_and_complete(env):
+def test_ws_happy_path_emits_started_log_and_complete(env, tmp_path):
     """Verify the WS happy path emits started, log, and flow_complete envelopes.
 
     :param env: env fixture providing (atelier, app).
+    :param tmp_path: pytest temp directory fixture.
     """
     _, app = env
     with TestClient(app) as client:
@@ -88,7 +89,7 @@ def test_ws_happy_path_emits_started_log_and_complete(env):
                         "flow_id": "T-1",
                         "conduit_name": "hello",
                         "inputs": {},
-                        "run_path": "/tmp",
+                        "run_path": str(tmp_path),
                     }
                 )
             )
@@ -107,10 +108,11 @@ def test_ws_happy_path_emits_started_log_and_complete(env):
     )
 
 
-def test_ws_hitl_round_trip_completes_after_answer(env):
+def test_ws_hitl_round_trip_completes_after_answer(env, tmp_path):
     """Verify the WS hitl round-trip completes after an answer is sent.
 
     :param env: env fixture providing (atelier, app).
+    :param tmp_path: pytest temp directory fixture.
     """
     _, app = env
     with TestClient(app) as client:
@@ -122,7 +124,7 @@ def test_ws_hitl_round_trip_completes_after_answer(env):
                         "flow_id": "T-2",
                         "conduit_name": "human",
                         "inputs": {},
-                        "run_path": "/tmp",
+                        "run_path": str(tmp_path),
                     }
                 )
             )
@@ -160,10 +162,11 @@ def test_ws_unknown_message_type_emits_error_envelope(env):
             assert envelope["type"] == "error"
 
 
-def test_ws_run_unknown_conduit_emits_flow_failed(env):
+def test_ws_run_unknown_conduit_emits_flow_failed(env, tmp_path):
     """Verify running an unknown conduit emits flow_failed or error.
 
     :param env: env fixture providing (atelier, app).
+    :param tmp_path: pytest temp directory fixture.
     """
     _, app = env
     with TestClient(app) as client:
@@ -175,7 +178,7 @@ def test_ws_run_unknown_conduit_emits_flow_failed(env):
                         "flow_id": "T-4",
                         "conduit_name": "ghost",
                         "inputs": {},
-                        "run_path": "/tmp",
+                        "run_path": str(tmp_path),
                     }
                 )
             )

--- a/tests/test_api/test_ws_sink.py
+++ b/tests/test_api/test_ws_sink.py
@@ -17,11 +17,14 @@ async def test_display_step_sends_step_envelope() -> None:
     broker = FakeBroker()
     sink = WsPromptSink(broker=broker, flow_id="flow-123")  # type: ignore[arg-type]
 
-    _current_task_ctx.set("my-task")
-    step = IntermediateStep(kind=StepKind.thinking, text="analyzing input")
-    await sink.display_step(step)
+    token = _current_task_ctx.set("my-task")
+    try:
+        step = IntermediateStep(kind=StepKind.thinking, text="analyzing input")
+        await sink.display_step(step)
 
-    assert len(sent) == 1
+        assert len(sent) == 1
+    finally:
+        _current_task_ctx.reset(token)
     msg = sent[0]
     assert msg["type"] == "step"
     assert msg["flow_id"] == "flow-123"
@@ -41,15 +44,19 @@ async def test_display_step_reads_current_task_from_contextvar() -> None:
     broker = FakeBroker()
     sink = WsPromptSink(broker=broker, flow_id="flow-456")  # type: ignore[arg-type]
 
-    _current_task_ctx.set("other-task")
-    step = IntermediateStep(kind=StepKind.tool_call, tool_name="Read")
-    await sink.display_step(step)
+    token = _current_task_ctx.set("other-task")
+    try:
+        step = IntermediateStep(kind=StepKind.tool_call, tool_name="Read")
+        await sink.display_step(step)
 
-    assert sent[0]["task"] == "other-task"
+        assert sent[0]["task"] == "other-task"
+    finally:
+        _current_task_ctx.reset(token)
 
 
-async def test_request_permission_auto_approves() -> None:
-    """request_permission should auto-approve with the first option."""
+async def test_request_permission_denies_all_requests() -> None:
+    """request_permission should deny all requests with a PermissionError."""
+    import pytest
     from app.services.executor.prompt_sink import PermissionOption
 
     sink = WsPromptSink(broker=None, flow_id="f1")  # type: ignore[arg-type]
@@ -57,5 +64,5 @@ async def test_request_permission_auto_approves() -> None:
         PermissionOption(id="allow", label="Allow"),
         PermissionOption(id="deny", label="Deny"),
     ]
-    result = await sink.request_permission("summary", options)
-    assert result == "allow"
+    with pytest.raises(PermissionError, match="does not support interactive permission"):
+        await sink.request_permission("summary", options)

--- a/tests/test_api/test_ws_sink.py
+++ b/tests/test_api/test_ws_sink.py
@@ -1,0 +1,61 @@
+"""Test WsPromptSink sends step envelopes via the broker."""
+from __future__ import annotations
+
+from app.modules.engine import _current_task_ctx
+from app.schemas.log import IntermediateStep, StepKind
+from app.services.api.ws_sink import WsPromptSink
+
+
+async def test_display_step_sends_step_envelope() -> None:
+    """display_step should forward an IntermediateStep as a step envelope."""
+    sent: list[dict] = []
+
+    class FakeBroker:
+        async def send(self, payload: dict) -> None:
+            sent.append(payload)
+
+    broker = FakeBroker()
+    sink = WsPromptSink(broker=broker, flow_id="flow-123")  # type: ignore[arg-type]
+
+    _current_task_ctx.set("my-task")
+    step = IntermediateStep(kind=StepKind.thinking, text="analyzing input")
+    await sink.display_step(step)
+
+    assert len(sent) == 1
+    msg = sent[0]
+    assert msg["type"] == "step"
+    assert msg["flow_id"] == "flow-123"
+    assert msg["task"] == "my-task"
+    assert msg["step"]["kind"] == "thinking"
+    assert msg["step"]["text"] == "analyzing input"
+
+
+async def test_display_step_reads_current_task_from_contextvar() -> None:
+    """display_step should read the task name from _current_task_ctx."""
+    sent: list[dict] = []
+
+    class FakeBroker:
+        async def send(self, payload: dict) -> None:
+            sent.append(payload)
+
+    broker = FakeBroker()
+    sink = WsPromptSink(broker=broker, flow_id="flow-456")  # type: ignore[arg-type]
+
+    _current_task_ctx.set("other-task")
+    step = IntermediateStep(kind=StepKind.tool_call, tool_name="Read")
+    await sink.display_step(step)
+
+    assert sent[0]["task"] == "other-task"
+
+
+async def test_request_permission_auto_approves() -> None:
+    """request_permission should auto-approve with the first option."""
+    from app.services.executor.prompt_sink import PermissionOption
+
+    sink = WsPromptSink(broker=None, flow_id="f1")  # type: ignore[arg-type]
+    options = [
+        PermissionOption(id="allow", label="Allow"),
+        PermissionOption(id="deny", label="Deny"),
+    ]
+    result = await sink.request_permission("summary", options)
+    assert result == "allow"

--- a/tests/test_api/test_ws_step_messages.py
+++ b/tests/test_api/test_ws_step_messages.py
@@ -1,15 +1,13 @@
-"""Test that WebSocket emits StepMessage when tasks have steps."""
+"""Test that WebSocket emits step messages correctly for harness vs non-harness tasks."""
 from __future__ import annotations
 
 from app.schemas.log import IntermediateStep, StepKind, TaskEvent
 from app.schemas.progress import TaskStatus
 
 
-async def test_step_messages_emitted_for_task_with_steps() -> None:
-    """When a TaskEvent contains steps, the WS route should emit
-    individual StepMessage envelopes alongside the StepStatusMessage."""
-    # Import the route's _on_task_event factory indirectly by checking the
-    # emitted messages through a mock broker.
+async def test_step_messages_emitted_for_non_harness_task() -> None:
+    """Non-harness tasks (bash, hitl, conduit) should emit individual StepMessage
+    envelopes from on_task_event."""
     from app.routes.ws import _step_status_for
 
     steps = [
@@ -18,16 +16,15 @@ async def test_step_messages_emitted_for_task_with_steps() -> None:
     ]
     event = TaskEvent(
         task="build",
-        tool="harness:claude-code",
+        tool="tool:bash",
         success=True,
         status=TaskStatus.completed,
         steps=steps,
     )
 
-    # Verify the helper function still works
     assert _step_status_for(event) == "completed"
+    assert not event.tool.startswith("harness:")
 
-    # Build the expected step message format
     for step in steps:
         msg = {
             "type": "step",
@@ -37,3 +34,19 @@ async def test_step_messages_emitted_for_task_with_steps() -> None:
         }
         assert msg["type"] == "step"
         assert msg["task"] == "build"
+
+
+async def test_step_messages_skipped_for_harness_task() -> None:
+    """Harness tasks stream steps live via WsPromptSink, so on_task_event
+    should skip the step iteration."""
+    event = TaskEvent(
+        task="scrape",
+        tool="harness:opencode",
+        success=True,
+        status=TaskStatus.completed,
+        steps=[
+            IntermediateStep(kind=StepKind.thinking, text="planning"),
+        ],
+    )
+
+    assert event.tool.startswith("harness:")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 """End-to-end integration tests (no live harnesses)."""
 import builtins
 import json
+import sys
 
 import pytest
 import yaml
@@ -244,6 +245,7 @@ tasks:
     assert p.tasks["bad"].status.value == "failed"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="uses Unix tr/wc管道")
 async def test_until_early_exit_with_real_bash(workdir):
     """Verify `until:` exits the repeat loop when the predicate matches.
 
@@ -279,6 +281,7 @@ tasks:
     assert "HIT" in poll_logs[-1]["output"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="uses Unix tr/wc pipes")
 async def test_while_early_exit_with_real_bash(workdir):
     """`while: output.match(retry)` keeps iterating while bash emits
     "retry" and breaks the iteration that emits something else.
@@ -316,6 +319,7 @@ tasks:
     assert "settled" in poll_logs[-1]["output"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="uses Unix tr/wc pipes")
 async def test_until_over_nested_conduit_sub_task_outputs(workdir):
     """`tool:conduit` task with `until: output.match(PASS)` stops when a
     nested sub-task emits PASS, even though the conduit's aggregate

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ tasks:
     assert p.tasks["bad"].status.value == "failed"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="uses Unix tr/wc管道")
+@pytest.mark.skipif(sys.platform == "win32", reason="uses Unix tr/wc pipes")
 async def test_until_early_exit_with_real_bash(workdir):
     """Verify `until:` exits the repeat loop when the predicate matches.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """CLI smoke tests via Typer's CliRunner."""
 import io
 import os
+import sys
 from datetime import UTC, datetime
 
 import pytest
@@ -222,6 +223,7 @@ def test_logs_unknown_flow(workdir):
     assert "unknown flow" in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax in conduit YAML")
 def test_logs_shows_task_output(workdir):
     """Verify `logs` prints stdout for every task in the flow.
 
@@ -238,6 +240,7 @@ def test_logs_shows_task_output(workdir):
     assert "beta-output" in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax in conduit YAML")
 def test_logs_filter_by_task(workdir):
     """Verify `logs --task` filters output to the named task only.
 
@@ -252,6 +255,7 @@ def test_logs_filter_by_task(workdir):
     assert "beta-output" not in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax in conduit YAML")
 def test_logs_show_stderr(workdir):
     """Verify `logs --show stderr` shows stderr and hides stdout.
 
@@ -396,6 +400,7 @@ def test_status_json(workdir):
     assert data["tasks"]["greet"]["status"] == "completed"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax in conduit YAML")
 def test_logs_json(workdir):
     """Verify `logs --json` returns one entry per task with output.
 
@@ -638,6 +643,7 @@ def test_scheduler_status_alias(workdir, tmp_path):
     assert "nightly" in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="bash ; syntax in conduit YAML")
 def test_run_failure_prints_flow_id_and_status_hint(tmp_path, monkeypatch):
     """Failure output must include the flow_id and a next-step hint so
     the user can inspect what happened. Previously the flow_id was only


### PR DESCRIPTION
## Summary
- Route API endpoints to global `~/.atelier` so schedules persist independently of project directory
- Add Windows support for subprocess execution and atomic file operations (`_atomic_replace`)
- Thread `working_dir` through the engine and executors (bash, harness)
- Fix duplicate PUT route decorator on `update_conduit` endpoint
- Add `ws_sink` service for structured WebSocket step message handling

## Test plan
- [ ] Verify `atelier serve` starts and serves API endpoints from `~/.atelier`
- [ ] Verify conduit runs work on Windows (subprocess, file writes)
- [ ] Verify `working_dir` is correctly passed through to executors
- [ ] Verify WebSocket step messages are received correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time task step streaming over WebSocket connections
  * Global conduit management (write/delete) and reporting of conduit source
  * Per-run working-directory support for task execution flows

* **Improvements**
  * Scheduled runs persist and execute against a global directory
  * Updated Claude agent launch default
  * More robust atomic file persistence and improved OS file-open behavior

* **Tests**
  * Added WebSocket sink tests and updated many tests to match new behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LGuillermoAngaritaG/flow-atelier/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->