### PR TITLE
refactor: update autonomous-projects conduit to folder-based kanban

### DIFF
--- a/.atelier/conduits/autonomous-projects/Project example.md
+++ b/.atelier/conduits/autonomous-projects/Project example.md
@@ -1,0 +1,10 @@
+---
+priority: 1-5
+location: local path of where the project is stored
+use_git: true/false
+---
+# Goal
+
+# Description
+
+# Decisions Log

--- a/.atelier/conduits/autonomous-projects/README.md
+++ b/.atelier/conduits/autonomous-projects/README.md
@@ -73,8 +73,9 @@ Only the human moves tasks to `done/`. The bot never does.
 3. **Frontmatter parse.** Files without `---`-delimited frontmatter are
    warned to stderr and dropped. Task folders are auto-created for projects
    that don't have them yet.
-4. **Global in-progress gate.** If *any* project has a task in
-   `TASKS/<name>/in-progress/`, the picker skips — work is already underway.
+4. **In-progress gate.** If *any* project has a task in
+   `TASKS/<name>/in-progress/`, that project is returned immediately so the
+   loop can resume the unfinished task.
 5. **Pending-Review gate.** Projects with `max_pending_review` or more files
    in `TASKS/<name>/pending-review/` are dropped. This caps unreviewed work
    per project.

--- a/.atelier/conduits/autonomous-projects/README.md
+++ b/.atelier/conduits/autonomous-projects/README.md
@@ -1,101 +1,136 @@
 # autonomous-projects
 
-A conduit that picks one project from a directory of Obsidian-style project
-markdown files and hands it to Claude Code to advance.
+A conduit that picks one project from a folder-structured project directory
+and advances it via Claude Code.
+
+## Directory structure
+
+```
+AUTONOMOUS_PROJECTS/
+├── PAUSED/                          # Drop a project .md here to skip it
+├── PROJECTS/                        # One .md file per project
+│   └── my-project.md
+├── TASKS/                           # Kanban folders per project
+│   └── my-project/
+│       ├── to-do/
+│       ├── in-progress/
+│       ├── pending-review/
+│       └── done/
+├── Project example.md               # Template for new projects
+└── task template.md                 # Template for new tasks
+```
 
 ## Project file format
 
-Each `*.md` file under `projects_dir` is one project:
+Each `.md` file under `PROJECTS/` is one project:
 
 ```markdown
 ---
-description: Short description
-goal: What you want done
-priority: 1            # integer; lower = higher priority
+priority: 1
 location: /abs/path/to/project/working/dir
-use_git: true          # or false
+use_git: true
 ---
-# To-Do's
-* **task_name** task description
-
-# In-Progress
-* **task_name** task description
-
-# Pending-Review
-* **task_name:** description
-    * **summary:** what was done
-    * **location:** local path or PR URL
-
-# Done
-* **task_name:** description
-    * **summary:** what was done
-    * **location:** local path or PR URL
+# Goal
+What you want done.
+# Description
+Short description of the project.
+# Decisions Log
 ```
+
+`# Decisions Log` is the AI's memory — it records past decisions, discarded
+ideas, and failed attempts so future runs don't repeat them.
+
+## Task file format
+
+Each `.md` file in a kanban folder is one task:
+
+```markdown
+# Description
+What to do.
+```
+
+When a task moves to `pending-review/`, the bot fills in:
+
+```markdown
+# Description
+What to do.
+# Summary of what was done
+What was actually done.
+# Location
+local path or PR URL
+```
+
+Only the human moves tasks to `done/`. The bot never does.
 
 ## How the pick works
 
-`picker.py` runs four gates in order:
+`picker.py` runs five gates in order:
 
-1. **Claude usage gate.** Calls `npx ccusage blocks --active --json`, divides
-   `totalTokens` by `token_limit`, and skips if the result is `>= max_usage_pct`.
-2. **Frontmatter parse.** Files without `---`-delimited frontmatter are
-   warned to stderr and dropped.
-3. **Pending-Review gate.** Projects with `max_pending_review` or more
-   bullets under `# Pending-Review` are dropped. The worker only ever moves
-   completed tasks to `# Pending-Review`; only the human reviewer moves
-   them to `# Done`. This caps how much un-reviewed work piles up before
-   the picker skips the project.
-4. **Idle gate.** For each survivor, `last_touched = max(git_last_commit,
+1. **Claude usage gate.** Reads `~/.claude/rate-limit-cache.json` (written by
+   the statusline hook) and skips if usage is `>= max_usage_pct`.
+2. **PAUSED gate.** Projects whose `.md` filename matches a file in `PAUSED/`
+   are dropped. Human-only — the bot never pauses projects.
+3. **Frontmatter parse.** Files without `---`-delimited frontmatter are
+   warned to stderr and dropped. Task folders are auto-created for projects
+   that don't have them yet.
+4. **Pending-Review gate.** Projects with `max_pending_review` or more files
+   in `TASKS/<name>/pending-review/` are dropped. This caps unreviewed work.
+5. **Idle gate.** `last_touched = max(git_last_commit,
    max_mtime_under(location))`. Projects touched in the last `idle_hours`
    are dropped. (`use_git: true` enables the git half; otherwise only mtime
    is considered.)
 
 Survivors are sorted by `priority` ascending. On ties, the project markdown
-file with the **oldest mtime** wins — i.e. the one whose task list has been
-untouched the longest. This is a different signal from the idle gate's
-"working dir activity" check: the idle gate keeps the agent from stepping on
-in-progress work, while the tie-break picks the project you've thought about
-least recently.
+file with the **oldest mtime** wins — the one whose task list has been
+untouched the longest.
 
 Stdout is always one line:
 - `READY: /abs/path/to/winner.md` — the worker task runs.
 - `SKIP: <reason>` — the worker task is auto-skipped by the engine.
 
+## What the bot does
+
+When a project is picked, the bot:
+
+1. Reads the project file, `# Goal`, and `# Decisions Log`
+2. Picks the top task from `TASKS/<name>/to-do/` (or proposes a new one if
+   the folder is empty)
+3. Moves it to `in-progress/`, does the work, commits if `use_git: true`
+4. Fills in summary and location, moves to `pending-review/`
+5. Appends decisions, discarded ideas, and findings to `# Decisions Log`
+
 ## Files
 
-- `conduit.yaml` — two-task DAG: `pick_project` (bash) → `work_on_project` (claude-code).
+- `conduit.yaml` — two-task DAG: `pick_project` (bash) → `loop_until_done` (conduit).
 - `picker.py` — stdlib-only Python picker.
-- `schedule.example.yaml` — example schedule you can install.
+- `autonomous-projects-night.yaml` — schedule you can install.
 
 ## Manual run
 
 ```bash
 atelier run autonomous-projects \
-  --input projects_dir="/Users/ganga/Library/Mobile Documents/iCloud~md~obsidian/Documents/Cerebro/AUTONOMOUS_PROJECTS/WORKING" \
+  --input projects_dir="/path/to/AUTONOMOUS_PROJECTS" \
   --input max_usage_pct=80 \
   --input idle_hours=2 \
   --input max_pending_review=3 \
   --input token_limit=19000000
 ```
 
-All five inputs are required at run time (no per-conduit defaults exist in
-the framework). Edit `schedule.example.yaml` for your preferred values.
+All five inputs are required at run time. Edit
+`autonomous-projects-night.yaml` for your preferred values.
 
 ## Schedule
 
 ```bash
-atelier schedule add .atelier/conduits/autonomous-projects/schedule.example.yaml
+atelier schedule add .atelier/conduits/autonomous-projects/autonomous-projects-night.yaml
 atelier scheduler start    # foreground daemon; Ctrl+C to stop
 ```
-
-`atelier schedule list` shows the next fire times. Use `atelier schedule
-run-now autonomous-projects-tick` to fire it once on demand.
 
 ## Machine-specific bits
 
 - `conduit.yaml` references `picker.py` by absolute path. If you move this
-  repo, update the `python3 ...picker.py` line in `conduit.yaml`.
-- The example projects_dir points at an iCloud-synced Obsidian vault on
-  this machine. Change it in `schedule.example.yaml` if needed.
+  repo, update the `python3 ...picker.py` line.
+- The schedule's `projects_dir` and `run_path` are machine-specific. Update
+  `autonomous-projects-night.yaml` for your setup.
 - `token_limit` is a coarse approximation of your Claude Code 5h quota.
   Tune it based on what `npx ccusage blocks` shows during a typical session.

--- a/.atelier/conduits/autonomous-projects/README.md
+++ b/.atelier/conduits/autonomous-projects/README.md
@@ -64,7 +64,7 @@ Only the human moves tasks to `done/`. The bot never does.
 
 ## How the pick works
 
-`picker.py` runs five gates in order:
+`picker.py` runs six gates in order:
 
 1. **Claude usage gate.** Reads `~/.claude/rate-limit-cache.json` (written by
    the statusline hook) and skips if usage is `>= max_usage_pct`.
@@ -73,16 +73,19 @@ Only the human moves tasks to `done/`. The bot never does.
 3. **Frontmatter parse.** Files without `---`-delimited frontmatter are
    warned to stderr and dropped. Task folders are auto-created for projects
    that don't have them yet.
-4. **Pending-Review gate.** Projects with `max_pending_review` or more files
-   in `TASKS/<name>/pending-review/` are dropped. This caps unreviewed work.
-5. **Idle gate.** `last_touched = max(git_last_commit,
+4. **Global in-progress gate.** If *any* project has a task in
+   `TASKS/<name>/in-progress/`, the picker skips — work is already underway.
+5. **Pending-Review gate.** Projects with `max_pending_review` or more files
+   in `TASKS/<name>/pending-review/` are dropped. This caps unreviewed work
+   per project.
+6. **Idle gate.** `last_touched = max(git_last_commit,
    max_mtime_under(location))`. Projects touched in the last `idle_hours`
    are dropped. (`use_git: true` enables the git half; otherwise only mtime
    is considered.)
 
 Survivors are sorted by `priority` ascending. On ties, the project markdown
-file with the **oldest mtime** wins — the one whose task list has been
-untouched the longest.
+file with the **oldest mtime** wins — the one whose project file
+has been modified the longest ago.
 
 Stdout is always one line:
 - `READY: /abs/path/to/winner.md` — the worker task runs.

--- a/.atelier/conduits/autonomous-projects/conduit.yaml
+++ b/.atelier/conduits/autonomous-projects/conduit.yaml
@@ -67,8 +67,10 @@ tasks:
              were already rejected, and use it to understand what approaches have already
              been ruled in or out.
           3. The project name is the stem of the project markdown file. Find its task
-             directory at: {{inputs.projects_dir}}/TASKS/<project-name>/to-do/
-          4. If to-do/ has at least one .md file, pick the top one. This is the task to work on.
+             directory at: {{inputs.projects_dir}}/TASKS/<project-name>/
+          4. If in-progress/ has a .md file, resume it — skip to step 6 to finish that
+             task before picking new work.
+          5. If to-do/ has at least one .md file, pick the top one. This is the task to work on.
              If to-do/ is empty: review the project against its `# Goal` and `# Decisions
              Log`, propose one concrete next step, and create a new task .md file there
              with only a description:

--- a/.atelier/conduits/autonomous-projects/conduit.yaml
+++ b/.atelier/conduits/autonomous-projects/conduit.yaml
@@ -1,17 +1,18 @@
 name: autonomous-projects
 description: >
-  Pick the highest-priority idle project from a directory of project markdown
-  files and advance it via Claude Code. If no project is eligible (Claude usage
-  too high, every project recently touched, too many pending-review items, or
-  no projects at all), emit a SKIP reason and short-circuit.
+  Pick the highest-priority idle project from a folder-structured project
+  directory and advance it via Claude Code. Projects live in PROJECTS/, tasks
+  in TASKS/<name>/ with kanban folders (to-do, in-progress, pending-review,
+  done). PAUSED/ holds projects the human wants skipped. If no project is
+  eligible, emit SKIP and short-circuit.
 
 timeout: 7200
 max_concurrency: 1
 
 inputs:
   projects_dir: >-
-    Directory containing one .md file per project. Each file must have YAML
-    frontmatter with: description, goal, priority, location, use_git.
+    Path to the AUTONOMOUS_PROJECTS root directory containing PROJECTS/,
+    TASKS/, and PAUSED/ subdirectories.
   max_usage_pct: >-
     Skip if Claude Code 5h-window usage is at or above this percent.
     Recommended default: "80".
@@ -19,11 +20,11 @@ inputs:
     Project must have been untouched (no git commit or file edit under
     `location`) for at least this many hours. Recommended default: "2".
   max_pending_review: >-
-    Skip a project once its `# Pending-Review` section has at least this
-    many bullets (i.e. block at this count). Recommended default: "3".
+    Skip a project once its pending-review/ folder has at least this many
+    task files. Recommended default: "3".
   token_limit: >-
-    Token ceiling used to compute usage %. Pick a number that approximates
-    your 5h Claude Code session quota. Recommended default: "19000000".
+    Token ceiling used to compute usage %. Approximate your 5h Claude Code
+    session quota. Recommended default: "19000000".
 
 tasks:
   - pick_project:
@@ -43,41 +44,53 @@ tasks:
       description: Hand the chosen project to the goal conduit so it loops until a DONE verdict.
       task: task-with-review
       tool: tool:conduit
-      depends_on: 
-      - "pick_project.output.match(^READY: )"
+      depends_on:
+        - "pick_project.output.match(^READY: )"
       repeat: 100
       until: 'output.match(VERDICT:\s*DONE)'
       inputs:
         task: |
-          You are advancing an autonomous project tracked in a markdown file.
+          You are advancing an autonomous project tracked in a folder-structured project directory.
 
           The picker emitted:
           {{pick_project.output}}
 
           The project file path is on the line beginning with "READY: ".
-
-          The project's working directory is the `location` field in the
-          project markdown's YAML frontmatter. Always read the markdown
-          first and use that exact path for every cd, file check, git
-          command, and verification step. Never guess the working
-          directory from the project filename.
+          The projects root directory is: {{inputs.projects_dir}}
 
           Do the following:
-          1. Read the project markdown file. Parse the YAML frontmatter
-             (description, goal, priority, location, use_git).
-          2. cd into the `location` directory (the project's working dir).
-          3. If the `# To-Do's` section has at least one task, pick the top one.
-             Otherwise, review the project against its `goal`, propose one
-             concrete improvement, and add it to `# To-Do's` first.
-          4. BEFORE starting work, move that task from `# To-Do's` to
-             `# In-Progress` in the project markdown file, preserving format.
-          5. Do the work. Respect `use_git`: if true, commit the changes with a
-             clear message; if false, just edit files.
-          6. When finished, move the task from `# In-Progress` to
-             `# Pending-Review` and fill in `summary:` and `location:`
-             sub-bullets per the file's existing bullet format. Never move
-             tasks to `# Done` — that section is reserved for the human
-             reviewer and is the only place a human-approved task lives.
-          7. Save the project markdown file.
-
-
+          1. Read the project markdown file (path from the READY line). Parse the YAML
+             frontmatter (priority, location, use_git) and the `# Goal` section.
+          2. Read the `# Decisions Log` section carefully. This is the project's memory —
+             it records past decisions, findings, and ideas that were discarded. You MUST
+             respect it: do not re-attempt things already tried, do not suggest ideas that
+             were already rejected, and use it to understand what approaches have already
+             been ruled in or out.
+          3. The project name is the stem of the project markdown file. Find its task
+             directory at: {{inputs.projects_dir}}/TASKS/<project-name>/to-do/
+          4. If to-do/ has at least one .md file, pick the top one. This is the task to work on.
+             If to-do/ is empty: review the project against its `# Goal` and `# Decisions
+             Log`, propose one concrete next step, and create a new task .md file there
+             with only a description:
+               ```
+               # Description
+               <what to do>
+               ```
+             Name the file with a descriptive slug (e.g. `setup-ci-pipeline.md`).
+             This new file is now the task to work on.
+          5. Move that file from to-do/ to in-progress/.
+          6. Read the task file. The `# Description` section tells you what to do.
+          7. cd into the project's `location` directory from the frontmatter.
+          8. Do the work. Respect `use_git`: if true, commit changes with a clear message;
+             if false, just edit files.
+          9. When finished, update the task file: fill in `# Summary of what was done` and
+             `# Location` (local path or PR URL). Then move the file from in-progress/ to
+             pending-review/. Never move tasks to done/ — that is reserved for the human
+             reviewer.
+          10. Append to the project markdown's `# Decisions Log` section. Log:
+              - Decisions you made and why (e.g. "Chose library X over Y because...")
+              - Ideas or approaches you discarded and why
+              - Things you tried that didn't work out
+              - Key findings about the codebase or project
+              This log prevents future runs from repeating work or re-suggesting rejected
+              ideas. Write concise bullet points — future-you will read this before starting.

--- a/.atelier/conduits/autonomous-projects/picker.py
+++ b/.atelier/conduits/autonomous-projects/picker.py
@@ -7,8 +7,8 @@ Stdout contract (single line, always exit 0):
 Filters, in order:
     1. Claude Code 5h-window usage gate
     2. PAUSED gate (skip if project name exists in PAUSED/)
-    3. Pending-Review gate (count files in TASKS/<name>/pending-review/)
-    4. To-Do gate (skip if TASKS/<name>/to-do/ is empty)
+    3. In-progress gate (resume project with a task in in-progress/)
+    4. Pending-Review gate (count files in TASKS/<name>/pending-review/)
     5. Idle time = max(latest git commit, latest mtime under `location`)
     6. Sort survivors by frontmatter priority asc; ties broken by oldest
        project file mtime.
@@ -173,15 +173,12 @@ def main() -> int:
             (project_tasks / sub).mkdir(parents=True, exist_ok=True)
         parsed.append((f, fm))
 
-    # 4. Global in-progress gate
-    global_ip = sum(
-        len(list((tasks_dir / f.stem / "in-progress").glob("*.md")))
-        for f, _fm in parsed
-        if (tasks_dir / f.stem / "in-progress").is_dir()
-    )
-    if global_ip > 0:
-        print(f"SKIP: {global_ip} task(s) still in-progress globally")
-        return 0
+    # 4. In-progress gate — pick the project with an unfinished task
+    for f, _fm in parsed:
+        ip_dir = tasks_dir / f.stem / "in-progress"
+        if ip_dir.is_dir() and any(ip_dir.glob("*.md")):
+            print(f"READY: {f}")
+            return 0
 
     # 5. Pending-Review gate
     survivors_pr: list[tuple[Path, dict[str, str]]] = []

--- a/.atelier/conduits/autonomous-projects/picker.py
+++ b/.atelier/conduits/autonomous-projects/picker.py
@@ -173,7 +173,17 @@ def main() -> int:
             (project_tasks / sub).mkdir(parents=True, exist_ok=True)
         parsed.append((f, fm))
 
-    # 4. Pending-Review gate
+    # 4. Global in-progress gate
+    global_ip = sum(
+        len(list((tasks_dir / f.stem / "in-progress").glob("*.md")))
+        for f, _fm in parsed
+        if (tasks_dir / f.stem / "in-progress").is_dir()
+    )
+    if global_ip > 0:
+        print(f"SKIP: {global_ip} task(s) still in-progress globally")
+        return 0
+
+    # 5. Pending-Review gate
     survivors_pr: list[tuple[Path, dict[str, str]]] = []
     pr_filtered = 0
     for f, fm in parsed:
@@ -184,7 +194,7 @@ def main() -> int:
             continue
         survivors_pr.append((f, fm))
 
-    # 5. Idle gate
+    # 6. Idle gate
     now = time.time()
     idle_cutoff_secs = args.idle_hours * 3600.0
     survivors_idle: list[tuple[Path, dict[str, str], float]] = []

--- a/.atelier/conduits/autonomous-projects/picker.py
+++ b/.atelier/conduits/autonomous-projects/picker.py
@@ -1,16 +1,17 @@
 """Pick the next autonomous project to work on, or emit a SKIP reason.
 
 Stdout contract (single line, always exit 0):
-    READY: <absolute path to chosen .md file>
+    READY: <absolute path to chosen project .md file>
     SKIP:  <human-readable reason>
 
 Filters, in order:
-    1. Claude Code 5h-window usage gate (read from ~/.claude/rate-limit-cache.json
-       written by the statusline hook).
-    2. Pending-Review section item count
-    3. Idle time = max(latest git commit, latest mtime under `location`)
-    4. Sort survivors by frontmatter priority asc; on ties, the project
-       markdown file with the oldest mtime wins (= task list untouched longest).
+    1. Claude Code 5h-window usage gate
+    2. PAUSED gate (skip if project name exists in PAUSED/)
+    3. Pending-Review gate (count files in TASKS/<name>/pending-review/)
+    4. To-Do gate (skip if TASKS/<name>/to-do/ is empty)
+    5. Idle time = max(latest git commit, latest mtime under `location`)
+    6. Sort survivors by frontmatter priority asc; ties broken by oldest
+       project file mtime.
 """
 
 from __future__ import annotations
@@ -30,10 +31,6 @@ _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 
 
 def parse_frontmatter(text: str) -> dict[str, str] | None:
-    """Parse the simple key: value frontmatter block at the top of a project file.
-
-    Returns None if no frontmatter is present.
-    """
     m = _FRONTMATTER_RE.match(text)
     if not m:
         return None
@@ -45,35 +42,12 @@ def parse_frontmatter(text: str) -> dict[str, str] | None:
     return out
 
 
-_SECTION_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
-
-
-def count_section_items(text: str, section_name: str) -> int:
-    """Count top-level `* ` bullets under a `# <section_name>` heading."""
-    # find the section heading line
-    pattern = re.compile(
-        rf"^#\s+{re.escape(section_name)}\s*$(.*?)(?=^#\s|\Z)",
-        re.MULTILINE | re.DOTALL,
-    )
-    m = pattern.search(text)
-    if not m:
-        return 0
-    body = m.group(1)
-    return sum(1 for line in body.splitlines() if line.startswith("* "))
-
-
 # ---------- usage gate ----------
 
 
 def claude_usage_pct(token_limit: int) -> tuple[float | None, str | None]:
-    """Return (pct_used, error). pct_used is None when the cache is unreadable.
-
-    Reads the 5h rate-limit snapshot that the statusline hook writes to
-    ``~/.claude/rate-limit-cache.json`` on every Claude Code refresh. The
-    ``token_limit`` argument is accepted for backwards-compatible CLI plumbing
-    but ignored — the cached value is already a server-side percentage.
-    """
-    del token_limit  # no longer used; kept for CLI compatibility
+    """Return (pct_used, error). pct_used is None when the cache is unreadable."""
+    del token_limit  # accepted for CLI compatibility, unused
     cache_path = Path.home() / ".claude" / "rate-limit-cache.json"
     try:
         payload = json.loads(cache_path.read_text())
@@ -87,7 +61,7 @@ def claude_usage_pct(token_limit: int) -> tuple[float | None, str | None]:
     if pct is None or resets_at is None:
         return None, "rate-limit cache missing five_hour fields"
     if resets_at <= time.time():
-        return 0.0, None  # 5h window has rolled over since the snapshot
+        return 0.0, None
     return float(pct), None
 
 
@@ -121,9 +95,7 @@ def git_last_commit_ts(path: Path) -> float:
     try:
         result = subprocess.run(
             ["git", "-C", str(path), "log", "-1", "--format=%ct"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+            capture_output=True, text=True, timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 0.0
@@ -140,14 +112,19 @@ def git_last_commit_ts(path: Path) -> float:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--projects-dir", required=True)
-    parser.add_argument("--max-usage-pct", type=float, required=True)
-    parser.add_argument("--idle-hours", type=float, required=True)
-    parser.add_argument("--max-pending-review", type=int, required=True)
+    parser.add_argument("--projects-dir", required=True,
+                        help="Path to AUTONOMOUS_PROJECTS root directory.")
+    parser.add_argument("--max-usage-pct", type=float, required=True,
+                        help="Skip if Claude usage >= this percent.")
+    parser.add_argument("--idle-hours", type=float, required=True,
+                        help="Project must be untouched for this many hours.")
+    parser.add_argument("--max-pending-review", type=int, required=True,
+                        help="Skip project if pending-review/ >= this many files.")
     parser.add_argument("--token-limit", type=int, required=True,
-                        help="Token ceiling used to compute usage %. e.g. 19000000.")
+                        help="Token ceiling for usage computation.")
     args = parser.parse_args()
 
+    # 1. Usage gate
     pct, err = claude_usage_pct(args.token_limit)
     if pct is None:
         print(f"SKIP: cannot determine Claude usage ({err})")
@@ -156,9 +133,17 @@ def main() -> int:
         print(f"SKIP: Claude Code usage {pct:.1f}% >= threshold {args.max_usage_pct:.0f}%")
         return 0
 
-    projects_dir = Path(args.projects_dir).expanduser()
+    root = Path(args.projects_dir).expanduser()
+    if not root.is_dir():
+        print(f"SKIP: projects_dir does not exist: {root}")
+        return 0
+
+    projects_dir = root / "PROJECTS"
+    paused_dir = root / "PAUSED"
+    tasks_dir = root / "TASKS"
+
     if not projects_dir.is_dir():
-        print(f"SKIP: projects_dir does not exist: {projects_dir}")
+        print(f"SKIP: PROJECTS/ not found under {root}")
         return 0
 
     files = sorted(projects_dir.glob("*.md"))
@@ -166,31 +151,45 @@ def main() -> int:
         print(f"SKIP: no .md files in {projects_dir}")
         return 0
 
+    # 2. PAUSED gate
+    paused_names: set[str] = set()
+    if paused_dir.is_dir():
+        paused_names = {f.stem for f in paused_dir.glob("*.md")}
+
+    # 3. Parse frontmatter + ensure task folders exist
+    _KANBAN = ("to-do", "in-progress", "pending-review", "done")
     total = len(files)
-    parsed: list[tuple[Path, dict[str, str], str]] = []
+    parsed: list[tuple[Path, dict[str, str]]] = []
     for f in files:
+        if f.stem in paused_names:
+            continue
         text = f.read_text(encoding="utf-8", errors="replace")
         fm = parse_frontmatter(text)
         if fm is None:
             print(f"warn: skipping {f.name}: no frontmatter", file=sys.stderr)
             continue
-        parsed.append((f, fm, text))
+        project_tasks = tasks_dir / f.stem
+        for sub in _KANBAN:
+            (project_tasks / sub).mkdir(parents=True, exist_ok=True)
+        parsed.append((f, fm))
 
-    # Pending-Review gate
-    survivors_pr: list[tuple[Path, dict[str, str], str]] = []
+    # 4. Pending-Review gate
+    survivors_pr: list[tuple[Path, dict[str, str]]] = []
     pr_filtered = 0
-    for f, fm, text in parsed:
-        if count_section_items(text, "Pending-Review") >= args.max_pending_review:
+    for f, fm in parsed:
+        pr_dir = tasks_dir / f.stem / "pending-review"
+        pr_count = len(list(pr_dir.glob("*.md"))) if pr_dir.is_dir() else 0
+        if pr_count >= args.max_pending_review:
             pr_filtered += 1
             continue
-        survivors_pr.append((f, fm, text))
+        survivors_pr.append((f, fm))
 
-    # Idle gate
+    # 5. Idle gate
     now = time.time()
     idle_cutoff_secs = args.idle_hours * 3600.0
     survivors_idle: list[tuple[Path, dict[str, str], float]] = []
     idle_filtered = 0
-    for f, fm, _text in survivors_pr:
+    for f, fm in survivors_pr:
         location = Path(fm.get("location", "")).expanduser()
         mtime = max_mtime_under(location)
         gtime = git_last_commit_ts(location) if fm.get("use_git", "").lower() == "true" else 0.0
@@ -203,13 +202,12 @@ def main() -> int:
     if not survivors_idle:
         print(
             f"SKIP: no eligible project "
-            f"({idle_filtered} filtered by idle, {pr_filtered} by pending-review, "
-            f"{total} total)"
+            f"({idle_filtered} idle, "
+            f"{pr_filtered} pending-review, {total} total)"
         )
         return 0
 
-    # Sort: priority asc (1 = highest); tie-break on oldest project-file
-    # mtime so projects whose task list has been edited least recently win.
+    # Sort: priority asc (1 = highest); tie-break on oldest project-file mtime
     def sort_key(entry: tuple[Path, dict[str, str], float]) -> tuple[int, float]:
         f, fm, _lt = entry
         try:

--- a/.atelier/conduits/autonomous-projects/task template.md
+++ b/.atelier/conduits/autonomous-projects/task template.md
@@ -1,0 +1,5 @@
+# Description
+
+# Summary of what was done
+
+# Location

--- a/tests/test_api/test_ws_sink.py
+++ b/tests/test_api/test_ws_sink.py
@@ -1,6 +1,8 @@
 """Test WsPromptSink sends step envelopes via the broker."""
 from __future__ import annotations
 
+import pytest
+
 from app.modules.engine import _current_task_ctx
 from app.schemas.log import IntermediateStep, StepKind
 from app.services.api.ws_sink import WsPromptSink
@@ -55,12 +57,12 @@ async def test_display_step_reads_current_task_from_contextvar() -> None:
         _current_task_ctx.reset(token)
 
 
-async def test_request_permission_auto_approves() -> None:
-    """request_permission should auto-approve with the first option."""
+async def test_request_permission_denies_all_requests() -> None:
+    """request_permission should deny all requests with a PermissionError."""
     sink = WsPromptSink(broker=None, flow_id="f1")  # type: ignore[arg-type]
     options = [
         PermissionOption(id="allow", label="Allow"),
         PermissionOption(id="deny", label="Deny"),
     ]
-    result = await sink.request_permission("summary", options)
-    assert result == "allow"
+    with pytest.raises(PermissionError, match="does not support interactive permission"):
+        await sink.request_permission("summary", options)

--- a/tests/test_api/test_ws_sink.py
+++ b/tests/test_api/test_ws_sink.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from app.modules.engine import _current_task_ctx
 from app.schemas.log import IntermediateStep, StepKind
 from app.services.api.ws_sink import WsPromptSink
+from app.services.executor.prompt_sink import PermissionOption
 
 
 async def test_display_step_sends_step_envelope() -> None:
@@ -50,8 +51,6 @@ async def test_display_step_reads_current_task_from_contextvar() -> None:
 
 async def test_request_permission_auto_approves() -> None:
     """request_permission should auto-approve with the first option."""
-    from app.services.executor.prompt_sink import PermissionOption
-
     sink = WsPromptSink(broker=None, flow_id="f1")  # type: ignore[arg-type]
     options = [
         PermissionOption(id="allow", label="Allow"),

--- a/tests/test_api/test_ws_sink.py
+++ b/tests/test_api/test_ws_sink.py
@@ -62,5 +62,5 @@ async def test_request_permission_auto_approves() -> None:
         PermissionOption(id="allow", label="Allow"),
         PermissionOption(id="deny", label="Deny"),
     ]
-    with pytest.raises(PermissionError, match="does not support interactive permission"):
-        await sink.request_permission("summary", options)
+    result = await sink.request_permission("summary", options)
+    assert result == "allow"


### PR DESCRIPTION
## Summary
- Restructures the autonomous-projects conduit from inline markdown bullets to a folder-based kanban (PROJECTS/, TASKS/<name>/{to-do,in-progress,pending-review,done}, PAUSED/)
- Adds PAUSED gate (human-only control to skip projects), Decisions Log (AI memory to avoid repeating/re-suggesting discarded ideas), and auto-creation of task folders
- Bot can now propose and create new tasks when to-do/ is empty (restored from previous behavior)
- Updated picker.py: 5 gates (usage → PAUSED → frontmatter + folder creation → pending-review → idle), counts files instead of markdown bullets
- Updated README with new directory structure, project/task file formats, and workflow docs

## Test plan
- [ ] Run `atelier run autonomous-projects` with the new folder structure and verify picker picks the correct project
- [ ] Verify PAUSED gate skips projects whose .md exists in PAUSED/
- [ ] Verify pending-review gate counts files in TASKS/<name>/pending-review/ correctly
- [ ] Verify auto-creation of TASKS/<name>/{to-do,in-progress,pending-review,done}/ when missing
- [ ] Verify bot creates a new task .md when to-do/ is empty
- [ ] Verify Decisions Log is read before work and appended to after work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New folder-based autonomous projects layout (PROJECTS/, TASKS/, PAUSED/) and updated workflow docs.
  * Standardized project frontmatter (priority, location, use_git) and required sections (Goal, Decisions Log).
  * Updated task format and instructions for bot-augmented pending-review entries.

* **Chores**
  * Improved project-picker gating and selection logic; clarified operational instructions and run configuration.
  * Added project and task templates for consistent authoring.

* **Tests**
  * Minor test import cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LGuillermoAngaritaG/flow-atelier/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->