### PR TITLE
feat: add loop-history templating for iterative tasks

### DIFF
--- a/.atelier/conduits/autonomous-projects/Project example.md
+++ b/.atelier/conduits/autonomous-projects/Project example.md
@@ -6,5 +6,3 @@ use_git: true/false
 # Goal
 
 # Description
-
-# Decisions Log

--- a/.atelier/conduits/autonomous-projects/README.md
+++ b/.atelier/conduits/autonomous-projects/README.md
@@ -34,11 +34,12 @@ use_git: true
 What you want done.
 # Description
 Short description of the project.
-# Decisions Log
 ```
 
-`# Decisions Log` is the AI's memory — it records past decisions, discarded
-ideas, and failed attempts so future runs don't repeat them.
+The project file is **owned by the human** — the bot treats it as read-only and
+never edits it. The bot's cross-run memory comes from the task files in
+`done/` and `pending-review/` (their `# Summary of what was done`), not from
+the project file.
 
 ## Task file format
 
@@ -96,12 +97,12 @@ Stdout is always one line:
 
 When a project is picked, the bot:
 
-1. Reads the project file, `# Goal`, and `# Decisions Log`
+1. Reads the project file (`# Goal`) — read-only — and skims past task
+   summaries in `done/` and `pending-review/` for context
 2. Picks the top task from `TASKS/<name>/to-do/` (or proposes a new one if
    the folder is empty)
 3. Moves it to `in-progress/`, does the work, commits if `use_git: true`
 4. Fills in summary and location, moves to `pending-review/`
-5. Appends decisions, discarded ideas, and findings to `# Decisions Log`
 
 ## Files
 

--- a/.atelier/conduits/autonomous-projects/conduit.yaml
+++ b/.atelier/conduits/autonomous-projects/conduit.yaml
@@ -55,44 +55,44 @@ tasks:
           The picker emitted:
           {{pick_project.output}}
 
+          Reviewer feedback from your previous attempt this run (empty on the
+          first iteration):
+          {{loop.previous}}
+
+          If that feedback is a NOT_DONE verdict, treat its REASON as the
+          priority signal — address what the reviewer flagged before picking
+          unrelated work.
+
           The project file path is on the line beginning with "READY: ".
           The projects root directory is: {{inputs.projects_dir}}
 
           Do the following:
           1. Read the project markdown file (path from the READY line). Parse the YAML
-             frontmatter (priority, location, use_git) and the `# Goal` section.
-          2. Read the `# Decisions Log` section carefully. This is the project's memory —
-             it records past decisions, findings, and ideas that were discarded. You MUST
-             respect it: do not re-attempt things already tried, do not suggest ideas that
-             were already rejected, and use it to understand what approaches have already
-             been ruled in or out.
-          3. The project name is the stem of the project markdown file. Find its task
+             frontmatter (priority, location, use_git) and the `# Goal` section. Treat
+             this file as READ-ONLY: it is owned by the human. Never edit it.
+          2. The project name is the stem of the project markdown file. Find its task
              directory at: {{inputs.projects_dir}}/TASKS/<project-name>/
-          4. If in-progress/ has a .md file, resume it — skip to step 6 to finish that
+          3. For memory of what has already happened, skim the task files in `done/` and
+             `pending-review/` — their `# Summary of what was done` sections record past
+             work. Use them to avoid repeating work already completed or awaiting review.
+          4. If in-progress/ has a .md file, resume it — skip to step 7 to finish that
              task before picking new work.
           5. If to-do/ has at least one .md file, pick the top one. This is the task to work on.
-             If to-do/ is empty: review the project against its `# Goal` and `# Decisions
-             Log`, propose one concrete next step, and create a new task .md file there
-             with only a description:
+             If to-do/ is empty: review the project against its `# Goal` and the task
+             history from step 3, propose one concrete next step, and create a new task
+             .md file there with only a description:
                ```
                # Description
                <what to do>
                ```
              Name the file with a descriptive slug (e.g. `setup-ci-pipeline.md`).
              This new file is now the task to work on.
-          5. Move that file from to-do/ to in-progress/.
-          6. Read the task file. The `# Description` section tells you what to do.
-          7. cd into the project's `location` directory from the frontmatter.
-          8. Do the work. Respect `use_git`: if true, commit changes with a clear message;
+          6. Move that file from to-do/ to in-progress/.
+          7. Read the task file. The `# Description` section tells you what to do.
+          8. cd into the project's `location` directory from the frontmatter.
+          9. Do the work. Respect `use_git`: if true, commit changes with a clear message;
              if false, just edit files.
-          9. When finished, update the task file: fill in `# Summary of what was done` and
-             `# Location` (local path or PR URL). Then move the file from in-progress/ to
-             pending-review/. Never move tasks to done/ — that is reserved for the human
-             reviewer.
-          10. Append to the project markdown's `# Decisions Log` section. Log:
-              - Decisions you made and why (e.g. "Chose library X over Y because...")
-              - Ideas or approaches you discarded and why
-              - Things you tried that didn't work out
-              - Key findings about the codebase or project
-              This log prevents future runs from repeating work or re-suggesting rejected
-              ideas. Write concise bullet points — future-you will read this before starting.
+          10. When finished, update the task file: fill in `# Summary of what was done` and
+              `# Location` (local path or PR URL). Then move the file from in-progress/ to
+              pending-review/. Never move tasks to done/ — that is reserved for the human
+              reviewer.

--- a/.atelier/schedules/autonomous-projects-day.yaml
+++ b/.atelier/schedules/autonomous-projects-day.yaml
@@ -1,10 +1,10 @@
 id: d6af488f-03d0-465b-8716-8d24915ee00f
 conduit_name: autonomous-projects
 inputs:
-  projects_dir: /Users/ganga/Library/Mobile Documents/iCloud~md~obsidian/Documents/Cerebro/AUTONOMOUS_PROJECTS/WORKING
+  projects_dir: /Users/ganga/Library/Mobile Documents/iCloud~md~obsidian/Documents/Cerebro/AUTONOMOUS_PROJECTS
   max_usage_pct: '50'
-  idle_hours: '1'
-  max_pending_review: '3'
+  idle_hours: '0.3'
+  max_pending_review: '5'
   token_limit: '19000000'
 run_path: /Users/ganga/Documents/personal_repos/flow-atelier
 schedule:
@@ -20,10 +20,26 @@ schedule:
   - 7
   times:
   - 09:00
+  - 09:30
+  - '10:00'
+  - '10:30'
   - '11:00'
+  - '11:30'
+  - '12:00'
+  - '12:30'
   - '13:00'
+  - '13:30'
+  - '14:00'
+  - '14:30'
   - '15:00'
+  - '15:30'
+  - '16:00'
+  - '16:30'
   - '17:00'
+  - '17:30'
+  - '18:00'
+  - '18:30'
   - '19:00'
+  - '19:30'
 created_at: 1779778874
-runs_completed: 26
+runs_completed: 52

--- a/.atelier/schedules/autonomous-projects-night.yaml
+++ b/.atelier/schedules/autonomous-projects-night.yaml
@@ -1,10 +1,10 @@
-id: d6af488f-03d0-465b-8716-8d24915ee00f
+id: bf20371c-bc1a-4f57-8ad7-92805b5509ec
 conduit_name: autonomous-projects
 inputs:
-  projects_dir: /Users/ganga/Library/Mobile Documents/iCloud~md~obsidian/Documents/Cerebro/AUTONOMOUS_PROJECTS/WORKING
-  max_usage_pct: '70'
-  idle_hours: '1'
-  max_pending_review: '3'
+  projects_dir: /Users/ganga/Library/Mobile Documents/iCloud~md~obsidian/Documents/Cerebro/AUTONOMOUS_PROJECTS
+  max_usage_pct: '75'
+  idle_hours: '0.3'
+  max_pending_review: '10'
   token_limit: '19000000'
 run_path: /Users/ganga/Documents/personal_repos/flow-atelier
 schedule:
@@ -19,16 +19,31 @@ schedule:
   - 6
   - 7
   times:
+  - '20:00'
+  - '20:30'
+  - '21:00'
+  - '21:30'
   - '22:00'
+  - '22:30'
   - '23:00'
+  - '23:30'
   - 00:00
+  - 00:30
   - 01:00
+  - 01:30
   - 02:00
+  - 02:30
   - 03:00
+  - 03:30
   - 04:00
+  - 04:30
   - 05:00
+  - 05:30
   - 06:00
+  - 06:30
   - 07:00
+  - 07:30
   - 08:00
+  - 08:30
 created_at: 1779778874
-runs_completed: 5
+runs_completed: 21

--- a/.atelier/schedules/vault-organizer.yaml
+++ b/.atelier/schedules/vault-organizer.yaml
@@ -61,4 +61,4 @@ schedule:
   - '12:30'
   - '18:30'
 created_at: 1779781588
-runs_completed: 5
+runs_completed: 8

--- a/app/modules/engine.py
+++ b/app/modules/engine.py
@@ -357,9 +357,11 @@ class Engine:
                     n for n, s in statuses.items()
                     if s in (TaskStatus.skipped, TaskStatus.failed, TaskStatus.cancelled)
                 }
+                loop_history: list[str] = []
                 try:
                     resolved = resolve(
-                        t.task, runtime_inputs, outputs, unavailable_tasks=unavailable
+                        t.task, runtime_inputs, outputs,
+                        unavailable_tasks=unavailable, loop_history=loop_history,
                     )
                 except SkipSignal as e:
                     mark_skipped(t.name, str(e))
@@ -393,6 +395,7 @@ class Engine:
                     run_nested_conduit=self._make_nested_runner(
                         on_task_event, show_steps=show_steps, working_dir=working_dir
                     ),
+                    loop_history=loop_history,
                 )
 
                 # Pre-parse the loop predicate once per task. Schema enforces
@@ -412,6 +415,12 @@ class Engine:
                 async with semaphore:
                     last_output = ""
                     for iteration in range(1, t.repeat + 1):
+                        if iteration > 1:
+                            resolved = resolve(
+                                t.task, runtime_inputs, outputs,
+                                unavailable_tasks=unavailable,
+                                loop_history=loop_history,
+                            )
                         mark_running(t.name, iteration)
                         started = _now()
                         start_ts = datetime.now(UTC)
@@ -466,6 +475,7 @@ class Engine:
                             if result.last_turn_output is not None
                             else result.output
                         )
+                        loop_history.append(last_output)
                         if loop_predicate is not None:
                             # Conduit tasks evaluate the predicate against the
                             # outputs of every nested sub-task (any-match),

--- a/app/modules/templating.py
+++ b/app/modules/templating.py
@@ -1,12 +1,15 @@
 """Template resolution for task prompts and inputs.
 
-Supports two forms:
+Supports four forms:
     {{inputs.<name>}}           — replaced with conduit/hitl input value
     {{<task_name>.output}}      — replaced with upstream task's output
+    {{loop.previous}}           — this task's previous-iteration output
+    {{loop.history}}            — all prior iterations of this task, numbered
 
 Rules:
     - Missing `inputs.x`              -> TemplateError (immediate failure)
     - Reference to task not in outputs (or marked skipped/failed) -> SkipSignal
+    - `loop.*` resolves to "" before the first iteration completes
 """
 from __future__ import annotations
 
@@ -14,6 +17,17 @@ import re
 from typing import Any
 
 _TEMPLATE_RE = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
+
+
+def _format_history(history: list[str]) -> str:
+    """Render prior loop iterations as numbered, separated blocks.
+
+    :param history: outputs of completed iterations, oldest first.
+    :returns: numbered history string, or "" when no iterations have run.
+    """
+    return "\n\n".join(
+        f"--- iteration {i} ---\n{out}" for i, out in enumerate(history, 1)
+    )
 
 
 class TemplateError(ValueError):
@@ -40,6 +54,7 @@ def resolve(
     inputs: dict[str, Any],
     task_outputs: dict[str, str],
     unavailable_tasks: set[str] | None = None,
+    loop_history: list[str] | None = None,
 ) -> str:
     """Resolve `{{...}}` expressions in ``template``.
 
@@ -48,10 +63,13 @@ def resolve(
     :param task_outputs: mapping of task name -> completed output string
     :param unavailable_tasks: names of tasks whose outputs cannot be used
         (skipped / failed / cancelled)
+    :param loop_history: this task's prior-iteration outputs, oldest first,
+        backing ``{{loop.previous}}`` and ``{{loop.history}}``
     :raises TemplateError: missing input or unknown identifier
     :raises SkipSignal: reference to a skipped/failed task output
     """
     unavailable = unavailable_tasks or set()
+    history = loop_history or []
 
     def _sub(match: re.Match[str]) -> str:
         """Replace a single ``{{...}}`` occurrence with its resolved value.
@@ -65,6 +83,10 @@ def resolve(
             if key not in inputs:
                 raise TemplateError(f"missing input: {key!r}")
             return str(inputs[key])
+        if expr == "loop.previous":
+            return history[-1] if history else ""
+        if expr == "loop.history":
+            return _format_history(history)
         if expr.endswith(".output"):
             task = expr[: -len(".output")]
             if task in unavailable:

--- a/app/services/executor/base.py
+++ b/app/services/executor/base.py
@@ -33,6 +33,11 @@ class FlowContext:
     ``task.interactive`` (which gates raw message-chunk streaming)."""
     run_nested_conduit: Callable[[str, dict[str, Any], str], Awaitable[str]] | None = None
     """Callback: (conduit_name, inputs, parent_flow_id) -> child flow_id."""
+    loop_history: list[str] = field(default_factory=list)
+    """This task's prior-iteration outputs, oldest first. Backs
+    ``{{loop.previous}}`` / ``{{loop.history}}`` when an executor resolves
+    its own templates (e.g. nested-conduit / hitl inputs). Shared by
+    reference with the engine, so it reflects iterations completed so far."""
 
 
 class ExecutorBase(ABC):

--- a/app/services/executor/conduit.py
+++ b/app/services/executor/conduit.py
@@ -39,7 +39,8 @@ class ConduitExecutor(ExecutorBase):
         for key, raw in task.inputs.items():
             if isinstance(raw, str):
                 child_inputs[key] = resolve(
-                    raw, context.inputs, context.task_outputs
+                    raw, context.inputs, context.task_outputs,
+                    loop_history=context.loop_history,
                 )
             else:
                 child_inputs[key] = raw

--- a/app/services/scheduler/runner.py
+++ b/app/services/scheduler/runner.py
@@ -102,6 +102,10 @@ class SchedulerDaemon:
         """Boot the APScheduler, install the reload job, and sync from disk."""
         if self._scheduler is not None:
             return
+        # APScheduler logs every job execution at INFO, including our 30s
+        # reload tick, which buries the actual schedule-fire logs. Quiet its
+        # executor logger so only our own fire logs (and real errors) surface.
+        logging.getLogger("apscheduler.executors.default").setLevel(logging.WARNING)
         self._scheduler = AsyncIOScheduler(timezone=self.default_zone)
         self._scheduler.add_job(
             self.sync,
@@ -257,8 +261,9 @@ class SchedulerDaemon:
             return
         working_dir = self._resolve_working_dir(job)
         logger.info(
-            "firing schedule %s → %s in %s",
+            "RUNNING schedule %s (%s) → conduit '%s' in %s",
             schedule_id,
+            job.schedule.name or schedule_id,
             job.conduit_name,
             working_dir,
         )
@@ -266,8 +271,13 @@ class SchedulerDaemon:
         try:
             await self.executor(job, working_dir)
             succeeded = True
+            logger.info(
+                "DONE schedule %s → conduit '%s'", schedule_id, job.conduit_name
+            )
         except Exception:  # noqa: BLE001 — daemon must survive a single failed fire
-            logger.exception("schedule %s failed", schedule_id)
+            logger.exception(
+                "FAILED schedule %s → conduit '%s'", schedule_id, job.conduit_name
+            )
         finally:
             if job.schedule.mode == "once":
                 self.store.mark_fired(schedule_id)

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -1051,3 +1051,66 @@ async def test_engine_falls_back_to_output_when_last_turn_is_none(store):
     flow_id = await engine.run(conduit, {})
     data = yaml.safe_load((store._flow_dir(flow_id) / "outputs.yaml").read_text())
     assert data == {"a": "alpha"}
+
+
+# ---------------------------------------------------------------- loop feedback
+
+
+class RecordingScriptedExecutor(ScriptedExecutor):
+    """Scripted executor that also records each resolved command string."""
+
+    def __init__(self, outputs_per_call: list[str]):
+        """Initialize and prepare a command-capture list.
+
+        :param outputs_per_call: outputs returned, one per call, in order.
+        """
+        super().__init__(outputs_per_call)
+        self.commands: list[str] = []
+
+    async def execute(self, task, resolved_command, context):
+        """Record the resolved command, then defer to the scripted output.
+
+        :param task: task definition being executed.
+        :param resolved_command: command string after template resolution.
+        :param context: flow context provided by the engine.
+        """
+        self.commands.append(resolved_command)
+        return await super().execute(task, resolved_command, context)
+
+
+async def test_loop_previous_feeds_prior_iteration_output(store):
+    """Verify {{loop.previous}} injects the prior iteration's output.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "refine", "description": "d", "task": "prev=[{{loop.previous}}]",
+             "tool": "tool:bash", "depends_on": [], "repeat": 3},
+        ]
+    )
+    fake = RecordingScriptedExecutor(["o1", "o2", "o3"])
+    engine = Engine({"tool:bash": fake}, store)
+    await engine.run(conduit, {})
+    assert fake.commands == ["prev=[]", "prev=[o1]", "prev=[o2]"]
+
+
+async def test_loop_history_accumulates_all_iterations(store):
+    """Verify {{loop.history}} accumulates every prior iteration's output.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "refine", "description": "d", "task": "{{loop.history}}",
+             "tool": "tool:bash", "depends_on": [], "repeat": 3},
+        ]
+    )
+    fake = RecordingScriptedExecutor(["o1", "o2", "o3"])
+    engine = Engine({"tool:bash": fake}, store)
+    await engine.run(conduit, {})
+    assert fake.commands == [
+        "",
+        "--- iteration 1 ---\no1",
+        "--- iteration 1 ---\no1\n\n--- iteration 2 ---\no2",
+    ]

--- a/tests/modules/test_templating.py
+++ b/tests/modules/test_templating.py
@@ -63,3 +63,25 @@ def test_resolve_unknown_expression():
 def test_resolve_non_template_string_unchanged():
     """Verify resolve() returns plain strings unchanged."""
     assert resolve("plain text", {}, {}) == "plain text"
+
+
+def test_resolve_loop_previous_empty_on_first_iteration():
+    """Verify {{loop.previous}} is empty when no iterations have run."""
+    assert resolve("p=[{{loop.previous}}]", {}, {}) == "p=[]"
+
+
+def test_resolve_loop_previous_returns_last_output():
+    """Verify {{loop.previous}} resolves to the most recent iteration output."""
+    out = resolve("p={{loop.previous}}", {}, {}, loop_history=["a", "b"])
+    assert out == "p=b"
+
+
+def test_resolve_loop_history_empty_on_first_iteration():
+    """Verify {{loop.history}} is empty when no iterations have run."""
+    assert resolve("h=[{{loop.history}}]", {}, {}) == "h=[]"
+
+
+def test_resolve_loop_history_numbers_iterations():
+    """Verify {{loop.history}} renders numbered, separated iteration blocks."""
+    out = resolve("{{loop.history}}", {}, {}, loop_history=["a", "b"])
+    assert out == "--- iteration 1 ---\na\n\n--- iteration 2 ---\nb"

--- a/tests/services/executor/test_conduit.py
+++ b/tests/services/executor/test_conduit.py
@@ -123,6 +123,40 @@ async def test_sub_outputs_includes_failed_iterations():
     assert result.sub_outputs == ["ok", "boom"]
 
 
+async def test_inputs_resolve_loop_previous_from_context_history():
+    """Verify nested-conduit inputs resolve {{loop.previous}} against the
+    loop history threaded in via FlowContext."""
+    captured: dict[str, Any] = {}
+
+    async def run_nested(name: str, inputs: dict[str, Any], parent: str) -> str:
+        """Capture the resolved child inputs, return a stub flow id.
+
+        :param name: nested conduit name.
+        :param inputs: resolved inputs passed to the nested conduit.
+        :param parent: parent flow id.
+        """
+        captured.update(inputs)
+        return "child-flow-id"
+
+    task = TaskDefinition(
+        name="outer",
+        description="d",
+        task="child",
+        tool=ToolType.conduit,
+        depends_on=[],
+        inputs={"task": "got=[{{loop.previous}}]"},
+    )
+    ctx = FlowContext(
+        flow_id="parent-flow-id",
+        store=_FakeStore([], FlowStatus.completed),  # type: ignore[arg-type]
+        inputs={},
+        run_nested_conduit=run_nested,
+        loop_history=["earlier"],
+    )
+    await ConduitExecutor().execute(task, "child", ctx)
+    assert captured["task"] == "got=[earlier]"
+
+
 def test_execution_result_default_sub_outputs_is_empty_list():
     """Verify ExecutionResult.sub_outputs defaults to a fresh empty list."""
     r = ExecutionResult()


### PR DESCRIPTION
# Loop-history templating for iterative tasks

## What

Adds two new template expressions that a looping task can use to reference its
own prior-iteration outputs:

- `{{loop.previous}}` — the output of this task's immediately preceding
  iteration (empty string before the first iteration completes).
- `{{loop.history}}` — every prior iteration's output, rendered as numbered,
  separated blocks (`--- iteration 1 ---`, `--- iteration 2 ---`, ...).

These join the existing `{{inputs.<name>}}` and `{{<task>.output}}` forms.
`loop.*` resolves to `""` until the first iteration has finished.

The `autonomous-projects` conduit is reworked on top of this: it now feeds the
reviewer's previous-attempt feedback back into the worker via
`{{loop.previous}}`, and the old `# Decisions Log` mechanism is removed in favor
of treating the project file as human-owned (read-only) with cross-run memory
coming from task summaries in `done/` and `pending-review/`.

Also included: clearer scheduler fire logging (RUNNING / DONE / FAILED with
conduit names) and quieting of APScheduler's executor logger so real
schedule-fire logs surface.

## Why

Looping tasks previously had no way to see what they produced on earlier passes.
A task running with `repeat`/`until`/`while_` re-ran the same resolved command
every iteration, so any feedback loop (refine-until-good, retry-with-context,
review-and-fix) had to be hacked together through external state.

The concrete driver is the `autonomous-projects` conduit: the worker and a
reviewer alternate, and the worker needs to act on the reviewer's NOT_DONE
verdict from the prior iteration. `{{loop.previous}}` makes that a first-class
template instead of a workaround. Folding memory into per-task summaries also
removes the fragile "bot edits its own log file" pattern.

## How

The mechanism is a single `loop_history: list[str]` per task, shared **by
reference** between the engine's iteration loop and the task's `FlowContext`:

- `app/modules/engine.py` — creates `loop_history` before the loop, appends each
  iteration's resolved output to it, and re-resolves the task template on every
  iteration after the first so `{{loop.*}}` picks up the latest history. The same
  list is handed to `FlowContext`, so executors that resolve their own templates
  (nested conduits, hitl inputs) see the accumulated history.
- `app/modules/templating.py` — `resolve()` gains a `loop_history` parameter;
  `{{loop.previous}}` returns `history[-1]`, `{{loop.history}}` is rendered by a
  new `_format_history()` helper.
- `app/services/executor/base.py` — `FlowContext` gains a `loop_history` field
  (shared by reference with the engine).
- `app/services/executor/conduit.py` — passes `context.loop_history` through when
  resolving nested-conduit inputs.

### Tests
- `tests/modules/test_templating.py` — empty-on-first-iteration and
  last-output / numbered-history rendering for both expressions.
- `tests/modules/test_engine.py` — a recording executor asserts the exact
  command each iteration received, proving `{{loop.previous}}` and
  `{{loop.history}}` accumulate correctly across a 3-iteration loop.
- `tests/services/executor/test_conduit.py` — nested-conduit inputs resolve
  `{{loop.previous}}` from the history threaded in via `FlowContext`.

## Known sharp edges

- `{{loop.history}}` is unbounded — it accumulates every iteration's full output.
  For long loops with large outputs (e.g. AI-agent runs) it can grow the prompt
  significantly; prefer `{{loop.previous}}` there.
- The per-iteration re-resolve cannot newly raise (the unavailable-task set is a
  snapshot and history only grows), so it is intentionally not re-wrapped in the
  first iteration's `SkipSignal` / `TemplateError` guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loop iteration history support—tasks can now reference previous outputs via template variables.
  * Updated autonomous-projects workflow to track memory from task summaries rather than project files.

* **Improvements**
  * Enhanced schedule configurations with adjusted timing and operational thresholds.
  * Improved execution logging clarity for scheduled job runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->