### PR TITLE
feat: install scripts + auto-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,9 @@ jobs:
           path: artifacts
       - name: Flatten artifacts
         run: mkdir -p release && find artifacts -type f -exec cp {} release/ \;
+      - name: Generate SHA256SUMS
+        working-directory: release
+        run: sha256sum * > SHA256SUMS
       - uses: softprops/action-gh-release@v2
         with:
           files: release/*

--- a/flow_atelier/cli/main.py
+++ b/flow_atelier/cli/main.py
@@ -38,6 +38,9 @@ def _root(
 
     :param version: eager flag handled by :func:`_version_callback`.
     """
+    from flow_atelier.cli.updater import start_background_update_check
+
+    start_background_update_check()
 
 
 list_app = typer.Typer(

--- a/flow_atelier/cli/updater.py
+++ b/flow_atelier/cli/updater.py
@@ -1,0 +1,226 @@
+"""Background auto-updater for frozen (PyInstaller) binaries.
+
+Checks GitHub Releases for a newer version, downloads and verifies the
+binary in a daemon thread, and swaps it in via an ``atexit`` handler —
+so the update lands *after* the current command finishes and the process
+exits (no ``.exe`` lock issues on Windows).
+
+For ``pip``/``uv`` installs (``sys.frozen`` is falsy), prints an upgrade
+hint to stderr instead.  Set ``ATELIER_NO_UPDATE_CHECK=1`` to disable
+all update behaviour (useful in CI/tests).
+"""
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import platform
+import sys
+import threading
+import urllib.request
+from typing import Any, Optional
+
+OWNER = "LGuillermoAngaritaG"
+REPO = "flow-atelier"
+RELEASES_API = f"https://api.github.com/repos/{OWNER}/{REPO}/releases/latest"
+
+# Module-level state shared between the daemon thread and the atexit handler.
+_pending_update: Optional[bytes] = None
+_pending_asset_name: Optional[str] = None
+_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def is_frozen_binary() -> bool:
+    """Return ``True`` when running inside a PyInstaller bundle."""
+    return getattr(sys, "frozen", False)
+
+
+def _platform_asset_name() -> str:
+    """Return the release asset name for the current platform."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "linux" and machine == "x86_64":
+        return "atelier-linux-x86_64"
+    if system == "darwin":
+        # GitHub macos-latest is arm64; Intel macs are rare now.
+        if machine == "arm64":
+            return "atelier-macos-arm64"
+        return "atelier-macos-arm64"  # fall back to arm64 binary
+    if system == "windows" and machine in ("amd64", "x86_64"):
+        return "atelier-windows-x86_64.exe"
+
+    raise RuntimeError(f"unsupported platform: {system}-{machine}")
+
+
+def _fetch_json(url: str) -> Any:
+    """Fetch *url* and return the parsed JSON response."""
+    req = urllib.request.Request(url, headers={"User-Agent": "flow-atelier-updater"})
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+def _fetch_bytes(url: str) -> bytes:
+    """Fetch *url* and return the raw bytes."""
+    req = urllib.request.Request(url, headers={"User-Agent": "flow-atelier-updater"})
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+        return resp.read()
+
+
+def _download_and_verify(
+    asset_url: str,
+    asset_name: str,
+    sums_url: str,
+) -> Optional[bytes]:
+    """Download *asset_url*, verify its SHA-256 against *sums_url*, return bytes.
+
+    Returns ``None`` on any failure (network error, hash mismatch, etc.).
+    """
+    try:
+        binary = _fetch_bytes(asset_url)
+        sums_text = _fetch_bytes(sums_url).decode("utf-8")
+    except Exception:
+        return None
+
+    expected_hash: Optional[str] = None
+    for line in sums_text.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == asset_name:
+            expected_hash = parts[0]
+            break
+
+    if expected_hash is None:
+        return None
+
+    actual_hash = hashlib.sha256(binary).hexdigest()
+    if actual_hash != expected_hash:
+        return None
+
+    return binary
+
+
+# ---------------------------------------------------------------------------
+# Daemon thread + atexit
+# ---------------------------------------------------------------------------
+
+def _background_check() -> None:
+    """Run in a daemon thread: check for a newer version, download if found."""
+    global _pending_update, _pending_asset_name  # noqa: PLW0603
+
+    try:
+        release = _fetch_json(RELEASES_API)
+        remote_tag = release.get("tag_name", "")
+        if not remote_tag:
+            return
+
+        remote_version = remote_tag.lstrip("v")
+
+        from flow_atelier import __version__
+
+        if remote_version <= __version__:
+            return  # already up to date
+
+        # Build asset download URLs from the release assets list.
+        asset_name = _platform_asset_name()
+        asset_url: Optional[str] = None
+        sums_url: Optional[str] = None
+
+        for asset in release.get("assets", []):
+            name = asset.get("name", "")
+            if name == asset_name:
+                asset_url = asset.get("browser_download_url")
+            elif name == "SHA256SUMS":
+                sums_url = asset.get("browser_download_url")
+
+        if not asset_url or not sums_url:
+            return
+
+        binary = _download_and_verify(asset_url, asset_name, sums_url)
+        if binary is not None:
+            with _lock:
+                _pending_update = binary
+                _pending_asset_name = asset_name
+    except Exception:
+        # Updater must never crash the CLI.
+        pass
+
+
+def _do_swap() -> None:
+    """``atexit`` handler: replace the running binary with the downloaded one."""
+    global _pending_update, _pending_asset_name  # noqa: PLW0603
+
+    with _lock:
+        binary = _pending_update
+        asset_name = _pending_asset_name
+        _pending_update = None
+        _pending_asset_name = None
+
+    if binary is None or asset_name is None:
+        return
+
+    try:
+        current = os.path.realpath(sys.executable)
+        backup = current + ".old"
+        update_path = current  # replace in-place
+
+        # Write the new binary to a temp location first.
+        import tempfile
+
+        fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(current))
+        try:
+            os.write(fd, binary)
+            os.close(fd)
+            fd = -1
+
+            # Rename old → .old (may fail on Windows if .old exists from a
+            # previous update — that's fine, we just overwrite it).
+            try:
+                if os.path.exists(backup):
+                    os.remove(backup)
+                os.rename(current, backup)
+            except OSError:
+                # If we can't rename the old file, try direct replace.
+                pass
+
+            os.replace(tmp_path, update_path)
+            tmp_path = None  # prevent cleanup in finally
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            if tmp_path and os.path.exists(tmp_path):
+                os.remove(tmp_path)
+    except Exception:
+        # Swap failure must not crash on exit.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def start_background_update_check() -> None:
+    """Spawn the background update-check thread (or print a pip hint).
+
+    Called from the CLI root callback.  No-op when
+    ``ATELIER_NO_UPDATE_CHECK=1`` is set.
+    """
+    if os.environ.get("ATELIER_NO_UPDATE_CHECK") == "1":
+        return
+
+    if not is_frozen_binary():
+        # pip / uv install — just hint the user.
+        print(
+            "Tip: run `uv tool upgrade flow-atelier` to check for updates.",
+            file=sys.stderr,
+        )
+        return
+
+    thread = threading.Thread(target=_background_check, daemon=True)
+    thread.start()
+
+    atexit.register(_do_swap)

--- a/flow_atelier/cli/updater.py
+++ b/flow_atelier/cli/updater.py
@@ -19,15 +19,15 @@ import platform
 import sys
 import threading
 import urllib.request
-from typing import Any, Optional
+from typing import Any
 
 OWNER = "LGuillermoAngaritaG"
 REPO = "flow-atelier"
 RELEASES_API = f"https://api.github.com/repos/{OWNER}/{REPO}/releases/latest"
 
 # Module-level state shared between the daemon thread and the atexit handler.
-_pending_update: Optional[bytes] = None
-_pending_asset_name: Optional[str] = None
+_pending_update: bytes | None = None
+_pending_asset_name: str | None = None
 _lock = threading.Lock()
 
 
@@ -76,7 +76,7 @@ def _download_and_verify(
     asset_url: str,
     asset_name: str,
     sums_url: str,
-) -> Optional[bytes]:
+) -> bytes | None:
     """Download *asset_url*, verify its SHA-256 against *sums_url*, return bytes.
 
     Returns ``None`` on any failure (network error, hash mismatch, etc.).
@@ -87,7 +87,7 @@ def _download_and_verify(
     except Exception:
         return None
 
-    expected_hash: Optional[str] = None
+    expected_hash: str | None = None
     for line in sums_text.splitlines():
         parts = line.split()
         if len(parts) >= 2 and parts[1] == asset_name:
@@ -127,8 +127,8 @@ def _background_check() -> None:
 
         # Build asset download URLs from the release assets list.
         asset_name = _platform_asset_name()
-        asset_url: Optional[str] = None
-        sums_url: Optional[str] = None
+        asset_url: str | None = None
+        sums_url: str | None = None
 
         for asset in release.get("assets", []):
             name = asset.get("name", "")

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,109 @@
+# install.ps1 — one-command installer for flow-atelier (Windows)
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/LGuillermoAngaritaG/flow-atelier/main/install.ps1 | iex
+#
+# Downloads the latest binary for the current platform to
+# %USERPROFILE%\.atelier\bin\ and adds it to the user-level PATH (idempotent).
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "LGuillermoAngaritaG/flow-atelier"
+$InstallDir = Join-Path $env:USERPROFILE ".atelier" "bin"
+$BinaryName = "atelier.exe"
+
+# --- Detect platform ---
+$AssetName = "atelier-windows-x86_64.exe"
+
+# --- Fetch latest release info ---
+Write-Host "Fetching latest release info..."
+$ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+$Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "flow-atelier-installer" }
+$Tag = $Release.tag_name
+
+if (-not $Tag) {
+    Write-Error "Could not determine latest release tag."
+    exit 1
+}
+
+Write-Host "Latest release: $Tag"
+
+# --- Extract download URLs ---
+$AssetUrl = $null
+$SumsUrl = $null
+
+foreach ($asset in $Release.assets) {
+    if ($asset.name -eq $AssetName) {
+        $AssetUrl = $asset.browser_download_url
+    }
+    elseif ($asset.name -eq "SHA256SUMS") {
+        $SumsUrl = $asset.browser_download_url
+    }
+}
+
+if (-not $AssetUrl -or -not $SumsUrl) {
+    Write-Error "Could not find download URLs for $AssetName."
+    exit 1
+}
+
+# --- Download binary + checksums ---
+$TmpDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "atelier-install-$(Get-Random)") -Force
+trap { Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue }
+
+Write-Host "Downloading $AssetName..."
+$BinaryPath = Join-Path $TmpDir $AssetName
+Invoke-WebRequest -Uri $AssetUrl -OutFile $BinaryPath
+
+Write-Host "Downloading SHA256SUMS..."
+$SumsPath = Join-Path $TmpDir "SHA256SUMS"
+Invoke-WebRequest -Uri $SumsUrl -OutFile $SumsPath
+
+# --- Verify SHA-256 ---
+$SumsContent = Get-Content $SumsPath -Raw
+$ExpectedHash = $null
+foreach ($line in $SumsContent -split "`n") {
+    $parts = $line -split "\s+"
+    if ($parts.Length -ge 2 -and $parts[1] -eq $AssetName) {
+        $ExpectedHash = $parts[0].ToLower()
+        break
+    }
+}
+
+if (-not $ExpectedHash) {
+    Write-Error "$AssetName not found in SHA256SUMS."
+    exit 1
+}
+
+$ActualHash = (Get-FileHash -Path $BinaryPath -Algorithm SHA256).Hash.ToLower()
+if ($ActualHash -ne $ExpectedHash) {
+    Write-Error "SHA-256 mismatch!`n  expected: $ExpectedHash`n  actual:   $ActualHash"
+    exit 1
+}
+
+Write-Host "SHA-256 verified."
+
+# --- Install ---
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+$DestPath = Join-Path $InstallDir $BinaryName
+Copy-Item -Path $BinaryPath -Destination $DestPath -Force
+
+# --- Add to PATH (idempotent, user-level) ---
+$CurrentPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+if ($CurrentPath -notlike "*$InstallDir*") {
+    $NewPath = if ($CurrentPath.EndsWith(";")) {
+        "$CurrentPath$InstallDir"
+    } else {
+        "$CurrentPath;$InstallDir"
+    }
+    [System.Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+    Write-Host "Added $InstallDir to user PATH."
+} else {
+    Write-Host "$InstallDir already in PATH."
+}
+
+# --- Cleanup ---
+Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Host "Installed atelier $Tag to $DestPath"
+Write-Host "Restart your shell or open a new terminal to use 'atelier'."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# install.sh — one-command installer for flow-atelier (Unix)
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/LGuillermoAngaritaG/flow-atelier/main/install.sh | bash
+#
+# Downloads the latest binary for the current platform to ~/.atelier/bin/
+# and adds it to PATH (idempotent).
+set -euo pipefail
+
+REPO="LGuillermoAngaritaG/flow-atelier"
+INSTALL_DIR="$HOME/.atelier/bin"
+
+# --- Detect platform ---
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "${OS}-${ARCH}" in
+    linux-x86_64)   ASSET="atelier-linux-x86_64" ;;
+    darwin-arm64)   ASSET="atelier-macos-arm64" ;;
+    darwin-x86_64)  ASSET="atelier-macos-arm64" ;;
+    *) echo "Unsupported platform: ${OS}-${ARCH}" >&2; exit 1 ;;
+esac
+
+# --- Fetch latest release tag ---
+echo "Fetching latest release info..."
+RELEASE_JSON="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")"
+TAG="$(echo "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+
+if [ -z "$TAG" ]; then
+    echo "ERROR: could not determine latest release tag." >&2
+    exit 1
+fi
+
+echo "Latest release: ${TAG}"
+
+# --- Extract download URLs ---
+ASSET_URL="$(echo "$RELEASE_JSON" | grep "\"browser_download_url\"" | grep "${ASSET}" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+SUMS_URL="$(echo "$RELEASE_JSON" | grep "\"browser_download_url\"" | grep "SHA256SUMS" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+
+if [ -z "$ASSET_URL" ] || [ -z "$SUMS_URL" ]; then
+    echo "ERROR: could not find download URLs for ${ASSET}." >&2
+    exit 1
+fi
+
+# --- Download binary + checksums ---
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${ASSET}..."
+curl -fsSL -o "${TMPDIR}/${ASSET}" "$ASSET_URL"
+
+echo "Downloading SHA256SUMS..."
+curl -fsSL -o "${TMPDIR}/SHA256SUMS" "$SUMS_URL"
+
+# --- Verify SHA-256 ---
+EXPECTED="$(grep "  ${ASSET}$" "${TMPDIR}/SHA256SUMS" | awk '{print $1}')"
+if [ -z "$EXPECTED" ]; then
+    echo "ERROR: ${ASSET} not found in SHA256SUMS." >&2
+    exit 1
+fi
+
+ACTUAL="$(sha256sum "${TMPDIR}/${ASSET}" | awk '{print $1}')"
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "ERROR: SHA-256 mismatch!" >&2
+    echo "  expected: ${EXPECTED}" >&2
+    echo "  actual:   ${ACTUAL}" >&2
+    exit 1
+fi
+
+echo "SHA-256 verified."
+
+# --- Install ---
+mkdir -p "$INSTALL_DIR"
+cp "${TMPDIR}/${ASSET}" "${INSTALL_DIR}/atelier"
+chmod +x "${INSTALL_DIR}/atelier"
+
+# --- Add to PATH (idempotent) ---
+SHELL_RC=""
+if [ -n "${ZSH_VERSION:-}" ]; then
+    SHELL_RC="$HOME/.zshrc"
+elif [ -n "${BASH_VERSION:-}" ]; then
+    SHELL_RC="$HOME/.bashrc"
+fi
+
+if [ -n "$SHELL_RC" ]; then
+    if ! grep -qF "$INSTALL_DIR" "$SHELL_RC" 2>/dev/null; then
+        echo "" >> "$SHELL_RC"
+        echo "# Added by flow-atelier installer" >> "$SHELL_RC"
+        echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >> "$SHELL_RC"
+        echo "Added ${INSTALL_DIR} to PATH in ${SHELL_RC}"
+    fi
+fi
+
+echo ""
+echo "Installed atelier ${TAG} to ${INSTALL_DIR}/atelier"
+echo "Restart your shell or run: export PATH=\"\$PATH:${INSTALL_DIR}\""

--- a/tests/cli/test_updater.py
+++ b/tests/cli/test_updater.py
@@ -1,8 +1,7 @@
 """Tests for flow_atelier.cli.updater — all network calls are mocked."""
 from __future__ import annotations
 
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -13,7 +12,6 @@ from flow_atelier.cli.updater import (
     is_frozen_binary,
     start_background_update_check,
 )
-
 
 # ---------------------------------------------------------------------------
 # 1. is_frozen_binary
@@ -101,7 +99,6 @@ def test_pip_install_shows_upgrade_hint(monkeypatch, capsys):
 def test_verify_hash_rejects_mismatch():
     """_download_and_verify returns None when the SHA-256 doesn't match."""
     fake_binary = b"this is a fake binary"
-    correct_hash = __import__("hashlib").sha256(fake_binary).hexdigest()
     wrong_hash = "0" * 64
 
     sums_content = f"{wrong_hash}  atelier-linux-x86_64\n"

--- a/tests/cli/test_updater.py
+++ b/tests/cli/test_updater.py
@@ -1,0 +1,123 @@
+"""Tests for flow_atelier.cli.updater — all network calls are mocked."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flow_atelier.cli.updater import (
+    _do_swap,
+    _download_and_verify,
+    _platform_asset_name,
+    is_frozen_binary,
+    start_background_update_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. is_frozen_binary
+# ---------------------------------------------------------------------------
+
+
+def test_is_frozen_returns_false_in_dev():
+    """In the test environment (not PyInstaller), is_frozen_binary() is False."""
+    assert is_frozen_binary() is False
+
+
+# ---------------------------------------------------------------------------
+# 2. _platform_asset_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sys_name", "machine", "expected"),
+    [
+        ("Linux", "x86_64", "atelier-linux-x86_64"),
+        ("Darwin", "arm64", "atelier-macos-arm64"),
+        ("Windows", "AMD64", "atelier-windows-x86_64.exe"),
+    ],
+)
+def test_platform_asset_name_known_platforms(sys_name, machine, expected):
+    """All three supported platforms produce the correct asset name."""
+    with (
+        patch("flow_atelier.cli.updater.platform") as mock_plat,
+    ):
+        mock_plat.system.return_value = sys_name
+        mock_plat.machine.return_value = machine
+        assert _platform_asset_name() == expected
+
+
+# ---------------------------------------------------------------------------
+# 3. start_background_update_check disabled by env
+# ---------------------------------------------------------------------------
+
+
+def test_background_check_disabled_by_env(monkeypatch):
+    """ATELIER_NO_UPDATE_CHECK=1 prevents thread spawn and pip hint."""
+    monkeypatch.setenv("ATELIER_NO_UPDATE_CHECK", "1")
+    # Should return immediately without doing anything.
+    start_background_update_check()
+    # No assertion needed — just verify no exception and no stderr output.
+
+
+# ---------------------------------------------------------------------------
+# 4. _do_swap noop when nothing pending
+# ---------------------------------------------------------------------------
+
+
+def test_do_swap_noop_when_no_pending():
+    """_do_swap() is safe to call when no update has been downloaded."""
+    import flow_atelier.cli.updater as mod
+
+    # Ensure no pending update.
+    with mod._lock:
+        mod._pending_update = None
+        mod._pending_asset_name = None
+
+    # Should not raise.
+    _do_swap()
+
+
+# ---------------------------------------------------------------------------
+# 5. pip install shows upgrade hint
+# ---------------------------------------------------------------------------
+
+
+def test_pip_install_shows_upgrade_hint(monkeypatch, capsys):
+    """Non-frozen install prints a uv upgrade hint to stderr."""
+    monkeypatch.delenv("ATELIER_NO_UPDATE_CHECK", raising=False)
+    # is_frozen_binary() returns False (default in test env).
+    start_background_update_check()
+    captured = capsys.readouterr()
+    assert "uv tool upgrade" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 6. verify hash rejects mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_verify_hash_rejects_mismatch():
+    """_download_and_verify returns None when the SHA-256 doesn't match."""
+    fake_binary = b"this is a fake binary"
+    correct_hash = __import__("hashlib").sha256(fake_binary).hexdigest()
+    wrong_hash = "0" * 64
+
+    sums_content = f"{wrong_hash}  atelier-linux-x86_64\n"
+
+    with (
+        patch("flow_atelier.cli.updater._fetch_bytes") as mock_fetch,
+    ):
+        # First call = binary, second call = sums text.
+        mock_fetch.side_effect = [
+            fake_binary,
+            sums_content.encode("utf-8"),
+        ]
+        result = _download_and_verify(
+            "https://example.com/atelier-linux-x86_64",
+            "atelier-linux-x86_64",
+            "https://example.com/SHA256SUMS",
+        )
+
+    assert result is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,4 +36,5 @@ def _isolate_global_atelier_dir(tmp_path_factory, monkeypatch):
     """
     global_dir = tmp_path_factory.mktemp("global_atelier")
     monkeypatch.setenv("ATELIER_GLOBAL_ATELIER_DIR", str(global_dir))
+    monkeypatch.setenv("ATELIER_NO_UPDATE_CHECK", "1")
     yield Path(global_dir)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,10 @@ def workdir(tmp_path, monkeypatch):
     (atelier_dir / "conduits" / "hello" / "conduit.yaml").write_text(CONDUIT_YAML)
     monkeypatch.chdir(tmp_path)
     for k in list(os.environ):
-        if k.startswith("ATELIER_") and k != "ATELIER_GLOBAL_ATELIER_DIR":
+        if k.startswith("ATELIER_") and k not in (
+            "ATELIER_GLOBAL_ATELIER_DIR",
+            "ATELIER_NO_UPDATE_CHECK",
+        ):
             monkeypatch.delenv(k, raising=False)
     return tmp_path
 
@@ -680,7 +683,10 @@ def test_run_failure_prints_flow_id_and_status_hint(tmp_path, monkeypatch):
     )
     monkeypatch.chdir(tmp_path)
     for k in list(os.environ):
-        if k.startswith("ATELIER_") and k != "ATELIER_GLOBAL_ATELIER_DIR":
+        if k.startswith("ATELIER_") and k not in (
+            "ATELIER_GLOBAL_ATELIER_DIR",
+            "ATELIER_NO_UPDATE_CHECK",
+        ):
             monkeypatch.delenv(k, raising=False)
 
     runner = CliRunner()
@@ -963,7 +969,10 @@ def prompted_workdir(tmp_path, monkeypatch):
     )
     monkeypatch.chdir(tmp_path)
     for k in list(os.environ):
-        if k.startswith("ATELIER_") and k != "ATELIER_GLOBAL_ATELIER_DIR":
+        if k.startswith("ATELIER_") and k not in (
+            "ATELIER_GLOBAL_ATELIER_DIR",
+            "ATELIER_NO_UPDATE_CHECK",
+        ):
             monkeypatch.delenv(k, raising=False)
     return tmp_path
 


### PR DESCRIPTION
## What

Adds one-command install scripts and a background auto-updater for frozen (PyInstaller) binaries.

## Changes

- **SHA256SUMS** in release workflow (verifies binary integrity)
- **updater.py** — daemon thread checks GitHub Releases, downloads + verifies, swaps binary via atexit
- **8 unit tests** for updater (all mocked, no real network)
- **Hooked into CLI** — lazy import in _root() so --version skips it
- **install.sh** (Unix) + **install.ps1** (Windows) — detect platform, download, verify hash, add to PATH

## How it works

- pip/uv install: prints upgrade hint to stderr
- Frozen binary (install script): full auto-update in background

## Test plan

- [x] 563 tests pass (555 existing + 8 new)
- [ ] Install script tested against a real release (needs merge + tag first)
- [ ] Auto-update tested across two releases (needs v0.2.0 + v0.3.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic update checks for the CLI application, with background downloads and installation of new versions on frozen binaries.
  * Introduced one-command installers for Windows (PowerShell) and Unix-like systems (Bash), both with SHA-256 checksum verification for security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->