### PR TITLE
Feat/engine cli hardening

### DIFF
--- a/.atelier/conduits/autonomous-projects/README.md
+++ b/.atelier/conduits/autonomous-projects/README.md
@@ -14,6 +14,8 @@ scaffold is self-contained — no external project directory to configure.
 │   └── paused/                      # Drop a project .md here to skip it
 ├── tasks/                           # Kanban folders per project
 │   └── my-project/
+│       ├── ideas/                   # Bot writes idea_*.md / review_*.md proposals here
+│       ├── bad_ideas/               # Human drops rejected proposals (+ reasoning) here
 │       ├── to-do/
 │       ├── in-progress/
 │       ├── pending-review/
@@ -78,7 +80,7 @@ Only the human moves tasks to `done/`. The bot never does.
 
 ## How the pick works
 
-`picker.py` runs six gates in order:
+`picker.py` runs five gates in order:
 
 1. **Claude usage gate.** Reads `~/.claude/rate-limit-cache.json` (written by
    the statusline hook) and skips if usage is `>= max_usage_pct`.
@@ -90,10 +92,7 @@ Only the human moves tasks to `done/`. The bot never does.
 4. **In-progress gate.** If *any* project has a task in
    `tasks/<name>/in-progress/`, that project is returned immediately so the
    loop can resume the unfinished task.
-5. **Pending-Review gate.** Projects with `max_pending_review` or more files
-   in `tasks/<name>/pending-review/` are dropped. This caps unreviewed work
-   per project.
-6. **Idle gate.** `last_touched = max(git_last_commit,
+5. **Idle gate.** `last_touched = max(git_last_commit,
    max_mtime_under(location))`. Projects touched in the last `idle_hours`
    are dropped. (`use_git: true` enables the git half; otherwise only mtime
    is considered.)
@@ -102,25 +101,60 @@ Survivors are sorted by `priority` ascending. On ties, the project markdown
 file with the **oldest mtime** wins — the one whose project file
 has been modified the longest ago.
 
-Stdout is always one line:
-- `READY: /abs/path/to/winner.md` — the worker task runs.
-- `SKIP: <reason>` — the worker task is auto-skipped by the engine.
+Stdout is `SKIP: <reason>` (worker auto-skipped) or three lines —
+`READY: /abs/path/to/winner.md`, `NAME: <stem>`, `LOCATION: <codebase dir>` —
+that the resolver tasks consume.
 
-## What the bot does
+### Pending-review cap (work-only)
 
-When a project is picked, the bot:
+The `max_pending_review` cap is **not** a picker gate — it does not drop the
+project from selection. It is enforced by the conduit's `pr_gate` task, which
+pauses only `work_task` (to-do execution) once `pending-review/` holds
+`max_pending_review` or more files. Idea/review generation keeps running, so a
+project with a full review backlog still accumulates proposals; only new
+implementation pauses until you clear the backlog.
+
+## The loop is human-in-the-loop
+
+The bot never decides *what* is worth doing or *when* work is finished — those
+judgments stay with the human:
+
+1. **Bot proposes.** Each tick, the bot generates one idea and one review into
+   `tasks/<name>/ideas/` (`idea_*.md`, `review_*.md`).
+2. **Human triages.** You move each proposal into `tasks/<name>/bad_ideas/`
+   (rejected — leave your reasoning in the file so future generation avoids that
+   kind) or into `tasks/<name>/to-do/` (approved — becomes work).
+3. **Bot executes.** The bot works only existing `to-do/`/`in-progress/` tasks. It
+   never proposes or creates tasks itself. It moves a task to `in-progress/`, does
+   the work, commits if `use_git: true`, fills in the frontmatter and
+   `# Validation process`, then moves it to `pending-review/`.
+4. **Human approves.** Only the human moves a task to `done/`.
+
+### Idea/review generation
+
+Generation is delegated to two nested conduits, `generate-idea` and
+`generate-review`, run per tick while under the `max_ideas` cap (the combined count
+of `idea_*.md` + `review_*.md` in `ideas/`). Each produces one plain-language
+proposal plus a deeper plan. Rejected proposals in `bad_ideas/` steer future
+generation away from that kind.
+
+## What the bot does when executing a task
+
+When a project is picked and it has a `to-do`/`in-progress` task, the bot:
 
 1. Reads the project file (`# Goal`) — read-only — and skims past task
    files in `done/` and `pending-review/` for context
-2. Picks the top task from `tasks/<name>/to-do/` (or proposes a new one from
-   `task template.md` if the folder is empty)
+2. Picks the top task from `tasks/<name>/to-do/` (or resumes `in-progress/`)
 3. Moves it to `in-progress/`, does the work, commits if `use_git: true`
 4. Fills in the frontmatter and `# Validation process`, moves to `pending-review/`
 
 ## Files
 
-- `conduit.yaml` — two-task DAG: `pick_project` (bash) → `loop_until_done` (conduit).
+- `conduit.yaml` — DAG: `pick_project` (bash) → `resolve_*` (bash) → `gen_gate` →
+  `generate_idea`/`generate_review` (conduits); and `check_todo` + `pr_gate` →
+  `work_task` (the `task-with-review` conduit, looped until a DONE verdict).
 - `picker.py` — stdlib-only Python picker; defaults its root to this directory.
+  Emits `READY:`/`NAME:`/`LOCATION:` lines the resolver tasks consume.
 
 ## Manual run
 
@@ -128,10 +162,10 @@ When a project is picked, the bot:
 atelier run autonomous-projects
 ```
 
-All five inputs declare a `default` in `conduit.yaml`, so none are required —
+All six inputs declare a `default` in `conduit.yaml`, so none are required —
 the command above runs with the recommended values (`max_usage_pct=80`,
-`idle_hours=2`, `max_pending_review=3`, `token_limit=19000000`, and
-`projects_dir` = this conduit's own directory). Override any of them with
+`idle_hours=2`, `max_pending_review=10`, `token_limit=19000000`, `max_ideas=20`,
+and `projects_dir` = this conduit's own directory). Override any of them with
 `--input key=value`, e.g. `--input projects_dir=/path/that/has/projects-and-tasks`.
 
 ## Schedule

--- a/.atelier/conduits/autonomous-projects/conduit.yaml
+++ b/.atelier/conduits/autonomous-projects/conduit.yaml
@@ -27,14 +27,19 @@ inputs:
     default: "2"
   max_pending_review:
     description: >-
-      Skip a project once its pending-review/ folder has at least this many
-      task files.
-    default: "3"
+      Pause to-do execution (not idea/review generation) once a project's
+      pending-review/ folder has at least this many task files.
+    default: "10"
   token_limit:
     description: >-
       Token ceiling used to compute usage %. Approximate your 5h Claude Code
       session quota.
     default: "19000000"
+  max_ideas:
+    description: >-
+      Stop generating ideas/reviews for a project once its ideas/ folder already
+      holds this many idea (resp. review) documents.
+    default: "20"
 
 tasks:
   - pick_project:
@@ -47,68 +52,159 @@ tasks:
           --projects-dir "{{inputs.projects_dir}}" \
           --max-usage-pct "{{inputs.max_usage_pct}}" \
           --idle-hours "{{inputs.idle_hours}}" \
-          --max-pending-review "{{inputs.max_pending_review}}" \
           --token-limit "{{inputs.token_limit}}"
 
-  - loop_until_done:
-      description: Hand the chosen project to the goal conduit so it loops until a DONE verdict.
-      task: task-with-review
-      tool: tool:conduit
+  - resolve_project_file:
+      description: Extract the clean project .md path from the picker output.
+      tool: tool:bash
       depends_on:
         - "pick_project.output.match(^READY: )"
-      repeat: 100
+      task: |
+        set -eu
+        printf '%s' "$(printf '%s' '{{pick_project.output}}' | sed -n 's/^READY:[[:space:]]*//p')"
+
+  - resolve_name:
+      description: Extract the project name (file stem) from the picker output.
+      tool: tool:bash
+      depends_on:
+        - "pick_project.output.match(^READY: )"
+      task: |
+        set -eu
+        printf '%s' "$(printf '%s' '{{pick_project.output}}' | sed -n 's/^NAME:[[:space:]]*//p')"
+
+  - resolve_location:
+      description: Read the frontmatter location (codebase dir) from the picker output.
+      tool: tool:bash
+      depends_on:
+        - "pick_project.output.match(^READY: )"
+      task: |
+        set -eu
+        printf '%s' "$(printf '%s' '{{pick_project.output}}' | sed -n 's/^LOCATION:[[:space:]]*//p')"
+
+  - gen_gate:
+      description: Allow idea/review generation only while under the combined max_ideas cap.
+      tool: tool:bash
+      depends_on: [resolve_name]
+      task: |
+        set -eu
+        dir="{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/ideas"
+        count="$(find "$dir" -maxdepth 1 \( -name 'idea_*.md' -o -name 'review_*.md' \) 2>/dev/null | wc -l | tr -d ' ')"
+        if [ "$count" -lt "{{inputs.max_ideas}}" ]; then
+          echo "GEN: yes ($count idea+review docs < {{inputs.max_ideas}})"
+        else
+          echo "GEN: skip ($count idea+review docs >= {{inputs.max_ideas}})"
+        fi
+
+  - generate_idea:
+      description: Generate one idea into the project's ideas/ folder.
+      tool: tool:conduit
+      task: generate-idea
+      depends_on:
+        - resolve_location
+        - resolve_project_file
+        - resolve_name
+        - "gen_gate.output.match(GEN: yes)"
+      inputs:
+        path: "{{resolve_location.output}}"
+        project_document: "{{resolve_project_file.output}}"
+        path_idea: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/ideas"
+        current_ideas: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/ideas"
+        bad_ideas: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/bad_ideas"
+        tasks_dir: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}"
+
+  - generate_review:
+      description: Generate one review into the project's ideas/ folder.
+      tool: tool:conduit
+      task: generate-review
+      depends_on:
+        - resolve_location
+        - resolve_project_file
+        - resolve_name
+        - "gen_gate.output.match(GEN: yes)"
+      inputs:
+        path: "{{resolve_location.output}}"
+        project_document: "{{resolve_project_file.output}}"
+        path_review: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/ideas"
+        current_reviews: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/ideas"
+        bad_ideas: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/bad_ideas"
+        tasks_dir: "{{inputs.projects_dir}}/tasks/{{resolve_name.output}}"
+
+  - check_todo:
+      description: Decide whether there is a task to execute this tick.
+      tool: tool:bash
+      depends_on: [resolve_name]
+      task: |
+        set -eu
+        base="{{inputs.projects_dir}}/tasks/{{resolve_name.output}}"
+        if find "$base/to-do" "$base/in-progress" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q .; then
+          echo "WORK: yes"
+        else
+          echo "WORK: none"
+        fi
+
+  - pr_gate:
+      description: Pause to-do execution once pending-review/ is full (does not gate generation).
+      tool: tool:bash
+      depends_on: [resolve_name]
+      task: |
+        set -eu
+        dir="{{inputs.projects_dir}}/tasks/{{resolve_name.output}}/pending-review"
+        count="$(find "$dir" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
+        if [ "$count" -lt "{{inputs.max_pending_review}}" ]; then
+          echo "PR: ok ($count pending-review < {{inputs.max_pending_review}})"
+        else
+          echo "PR: full ($count pending-review >= {{inputs.max_pending_review}})"
+        fi
+
+  - work_task:
+      description: Advance one existing to-do task, looping until a DONE verdict.
+      tool: tool:conduit
+      task: task-with-review
+      depends_on:
+        - resolve_project_file
+        - resolve_name
+        - "check_todo.output.match(WORK: yes)"
+        - "pr_gate.output.match(PR: ok)"
+      repeat: 10
       until: 'output.match(VERDICT:\s*DONE)'
       inputs:
         task: |
           You are advancing an autonomous project tracked in a folder-structured project directory.
-
-          The picker emitted:
-          {{pick_project.output}}
 
           Reviewer feedback from your previous attempt this run (empty on the
           first iteration):
           {{loop.previous}}
 
           If that feedback is a NOT_DONE verdict, treat its REASON as the
-          priority signal — address what the reviewer flagged before picking
-          unrelated work.
+          priority signal — address what the reviewer flagged before doing
+          anything else.
 
-          The project file path is on the line beginning with "READY: ". It lives at
-          {{inputs.projects_dir}}/projects/working/<name>.md.
+          The project markdown file is at: {{resolve_project_file.output}}
+          The task directory is at: {{inputs.projects_dir}}/tasks/{{resolve_name.output}}/
 
           Do the following:
-          1. Read the project markdown file (path from the READY line). Parse the YAML
-             frontmatter (priority, location, use_git), the `# Goal` section, and the
-             `# Constraints` section if present. Treat this file as READ-ONLY: it is
-             owned by the human. Never edit it. The constraints are binding — every task
-             you propose or execute must respect them. If a constraint blocks the obvious
-             next step or names a decision only the human can make, do not work around it:
-             record the conflict in the task's `# Validation process` and pick work that
-             does not depend on the unresolved decision.
-          2. The project name is the stem of the project markdown file. Find its task
-             directory at: {{inputs.projects_dir}}/tasks/<project-name>/
-          3. For memory of what has already happened, skim the task files in `done/` and
+          1. Read the project markdown file. Parse the YAML frontmatter (priority,
+             location, use_git), the `# Goal` section, and the `# Constraints` section if
+             present. Treat this file as READ-ONLY: it is owned by the human. Never edit it.
+             The constraints are binding — every task you execute must respect them. If a
+             constraint blocks the obvious next step or names a decision only the human can
+             make, do not work around it: record the conflict in the task's
+             `# Validation process`.
+          2. For memory of what has already happened, skim the task files in `done/` and
              `pending-review/` — their `# What` and `# Validation process` sections record
              past work. Use them to avoid repeating work already completed or awaiting review.
-          4. If in-progress/ has a .md file, resume it — skip to step 7 to finish that
-             task before picking new work.
-          5. If to-do/ has at least one .md file, pick the top one. This is the task to work on.
-             If to-do/ is empty: review the project against its `# Goal` and the task
-             history from step 3, propose one concrete next step, and create a new task .md
-             file there by copying `.atelier/conduits/autonomous-projects/task template.md`
-             and filling in `# What`
-             (the next step), `# Why`, and `# How`. Leave the frontmatter and
-             `# Validation process` for the completion step. Name the file with a descriptive
-             slug (e.g. `setup-ci-pipeline.md`). This new file is now the task to work on.
-          6. Move that file from to-do/ to in-progress/.
-          7. Read the task file. The `# What` section tells you what to do.
-          8. cd into the project's `location` directory from the frontmatter.
-          9. Do the work. Respect `use_git`: if true, commit changes with a clear message;
+          3. If in-progress/ has a .md file, resume it — skip to step 5 to finish that task.
+          4. Otherwise pick the top .md file in to-do/. This is the task to work on. Do NOT
+             propose or create new tasks — only existing to-do/in-progress tasks are executed.
+             If both to-do/ and in-progress/ are empty, output "NOTHING TO DO" and stop.
+             Move the chosen file from to-do/ to in-progress/.
+          5. Read the task file. The `# What` section tells you what to do.
+          6. cd into the project's `location` directory from the frontmatter.
+          7. Do the work. Respect `use_git`: if true, commit changes with a clear message;
              if false, just edit files.
-          10. When finished, update the task file: fill in the frontmatter (`datetime`
-              — the completion date AND time, e.g. the output of
-              `date '+%Y-%m-%d %H:%M:%S %Z'`; `location` (local path or PR URL);
-              `commits`) and the `# Validation process`
-              section describing how you verified the work. Then move the file from
-              in-progress/ to pending-review/. Never move tasks to done/ — that is reserved
-              for the human reviewer.
+          8. When finished, update the task file: fill in the frontmatter (`datetime`
+             — the completion date AND time, e.g. the output of
+             `date '+%Y-%m-%d %H:%M:%S %Z'`; `location` (local path or PR URL);
+             `commits`) and the `# Validation process` section describing how you verified
+             the work. Then move the file from in-progress/ to pending-review/. Never move
+             tasks to done/ — that is reserved for the human reviewer.

--- a/.atelier/conduits/autonomous-projects/idea_template.md
+++ b/.atelier/conduits/autonomous-projects/idea_template.md
@@ -1,0 +1,5 @@
+# Description
+
+# Plan
+
+# Comments from usergreat

--- a/.atelier/conduits/autonomous-projects/picker.py
+++ b/.atelier/conduits/autonomous-projects/picker.py
@@ -8,10 +8,13 @@ Filters, in order:
     1. Claude Code 5h-window usage gate
     2. PAUSED gate (skip if project name exists in projects/paused/)
     3. In-progress gate (resume project with a task in in-progress/)
-    4. Pending-Review gate (count files in tasks/<name>/pending-review/)
-    5. Idle time = max(latest git commit, latest mtime under `location`)
-    6. Sort survivors by frontmatter priority asc; ties broken by oldest
+    4. Idle time = max(latest git commit, latest mtime under `location`)
+    5. Sort survivors by frontmatter priority asc; ties broken by oldest
        project file mtime.
+
+The pending-review cap is NOT enforced here — it only throttles to-do
+execution, which the conduit gates separately. A project with a full
+pending-review/ stays eligible so idea/review generation keeps running.
 """
 
 from __future__ import annotations
@@ -67,8 +70,8 @@ def claude_usage_pct(token_limit: int) -> tuple[float | None, str | None]:
 
 # ---------- idle gate ----------
 
-_IGNORE_DIRS = {".git", "node_modules", "__pycache__", ".venv", ".mypy_cache",
-                ".pytest_cache", "dist", "build", ".next"}
+_IGNORE_DIRS = {".git", ".atelier", "node_modules", "__pycache__", ".venv",
+                ".mypy_cache", ".pytest_cache", "dist", "build", ".next"}
 
 
 def max_mtime_under(path: Path) -> float:
@@ -88,6 +91,12 @@ def max_mtime_under(path: Path) -> float:
             except OSError:
                 continue
     return newest
+
+
+def emit_ready(path: Path, fm: dict[str, str]) -> None:
+    print(f"READY: {path}")
+    print(f"NAME: {path.stem}")
+    print(f"LOCATION: {fm.get('location', '')}")
 
 
 def git_last_commit_ts(path: Path) -> float:
@@ -120,8 +129,6 @@ def main() -> int:
                         help="Skip if Claude usage >= this percent.")
     parser.add_argument("--idle-hours", type=float, required=True,
                         help="Project must be untouched for this many hours.")
-    parser.add_argument("--max-pending-review", type=int, required=True,
-                        help="Skip project if pending-review/ >= this many files.")
     parser.add_argument("--token-limit", type=int, required=True,
                         help="Token ceiling for usage computation.")
     args = parser.parse_args()
@@ -160,6 +167,7 @@ def main() -> int:
 
     # 3. Parse frontmatter + ensure task folders exist
     _KANBAN = ("to-do", "in-progress", "pending-review", "done")
+    _EXTRA_DIRS = ("ideas", "bad_ideas")
     total = len(files)
     parsed: list[tuple[Path, dict[str, str]]] = []
     for f in files:
@@ -171,34 +179,23 @@ def main() -> int:
             print(f"warn: skipping {f.name}: no frontmatter", file=sys.stderr)
             continue
         project_tasks = tasks_dir / f.stem
-        for sub in _KANBAN:
+        for sub in (*_KANBAN, *_EXTRA_DIRS):
             (project_tasks / sub).mkdir(parents=True, exist_ok=True)
         parsed.append((f, fm))
 
     # 4. In-progress gate — pick the project with an unfinished task
-    for f, _fm in parsed:
+    for f, fm in parsed:
         ip_dir = tasks_dir / f.stem / "in-progress"
         if ip_dir.is_dir() and any(ip_dir.glob("*.md")):
-            print(f"READY: {f}")
+            emit_ready(f, fm)
             return 0
 
-    # 5. Pending-Review gate
-    survivors_pr: list[tuple[Path, dict[str, str]]] = []
-    pr_filtered = 0
-    for f, fm in parsed:
-        pr_dir = tasks_dir / f.stem / "pending-review"
-        pr_count = len(list(pr_dir.glob("*.md"))) if pr_dir.is_dir() else 0
-        if pr_count >= args.max_pending_review:
-            pr_filtered += 1
-            continue
-        survivors_pr.append((f, fm))
-
-    # 6. Idle gate
+    # 5. Idle gate
     now = time.time()
     idle_cutoff_secs = args.idle_hours * 3600.0
     survivors_idle: list[tuple[Path, dict[str, str], float]] = []
     idle_filtered = 0
-    for f, fm in survivors_pr:
+    for f, fm in parsed:
         location = Path(fm.get("location", "")).expanduser()
         mtime = max_mtime_under(location)
         gtime = git_last_commit_ts(location) if fm.get("use_git", "").lower() == "true" else 0.0
@@ -211,8 +208,7 @@ def main() -> int:
     if not survivors_idle:
         print(
             f"SKIP: no eligible project "
-            f"({idle_filtered} idle, "
-            f"{pr_filtered} pending-review, {total} total)"
+            f"({idle_filtered} idle, {total} total)"
         )
         return 0
 
@@ -230,8 +226,8 @@ def main() -> int:
         return prio, proj_mtime
 
     survivors_idle.sort(key=sort_key)
-    winner = survivors_idle[0][0]
-    print(f"READY: {winner}")
+    winner, winner_fm, _lt = survivors_idle[0]
+    emit_ready(winner, winner_fm)
     return 0
 
 

--- a/.atelier/conduits/autonomous-projects/task template.md
+++ b/.atelier/conduits/autonomous-projects/task template.md
@@ -3,6 +3,12 @@ datetime:  # completion date AND time, e.g. 2026-06-05 14:32:07 CEST
 location: 
 commits: 
 ---
+# Description
+
+# Plan
+
+# Comments from user
+
 # What
 
 # Why

--- a/.atelier/conduits/generate-idea/conduit.yaml
+++ b/.atelier/conduits/generate-idea/conduit.yaml
@@ -1,0 +1,132 @@
+name: generate-idea
+description: Generate one idea for a project, plan it, and store it as an idea document.
+timeout: 3600
+max_concurrency: 3
+
+inputs:
+  path: Filesystem path to the project/codebase the idea should be about.
+  project_document: Path to the project document (goal/constraints/context) the agent reads.
+  path_idea: Target folder where the final idea_<name>.md document is written.
+  current_ideas:
+    description: Folder of existing idea documents; the new idea must not duplicate them.
+    default: ""
+  bad_ideas:
+    description: Folder of rejected ideas plus the user's reasoning; avoid ideas of those kinds.
+    default: ""
+  tasks_dir:
+    description: >-
+      Project task directory holding to-do/, in-progress/, pending-review/, done/;
+      the new idea must not duplicate work already queued, being worked, or implemented.
+    default: ""
+
+tasks:
+  - generate_idea:
+      description: Generate one concrete idea for the project via the idea skill.
+      tool: harness:claude-code
+      depends_on: []
+      task: |
+        /idea
+
+        Focus on the codebase at this path: {{inputs.path}}
+
+        Read this project document first to understand the project's goal and
+        constraints, and ground your idea in it: {{inputs.project_document}}
+
+        Before proposing anything, review prior context so you don't repeat work:
+        - Existing ideas live in this folder: {{inputs.current_ideas}}
+          Read the idea_*.md files there. Your new idea MUST be meaningfully
+          distinct from every one of them.
+        - Rejected ideas live in this folder: {{inputs.bad_ideas}}
+          Each file holds a bad idea and the user's reasoning for why it is bad.
+          Do NOT propose ideas of those kinds; respect the stated reasoning.
+        - Existing tasks live under this directory: {{inputs.tasks_dir}}
+          Read the .md files in its `to-do/`, `in-progress/`, `pending-review/`,
+          and `done/` subfolders — their `# What` sections describe work already
+          queued, being worked, implemented and awaiting review, or completed.
+          Your new idea MUST NOT duplicate any of them.
+        If a path is empty or the folder does not exist, treat it as "no prior
+        ideas/tasks" and continue.
+
+        Produce exactly ONE idea: a short theme plus a description anchored in the
+        real code you read. Do not propose multiple competing ideas.
+
+        Write the idea text (the part between the markers) in plain, accessible
+        language a non-expert can follow: explain the "what" and the "why" in
+        everyday terms. Avoid jargon and deep implementation detail here — that
+        belongs in the plan, not the description.
+
+        Output format (strict):
+        - Do all exploration and reasoning first; NONE of that narration may
+          appear in the final idea.
+        - Emit the idea between the two marker lines below, on their own lines,
+          with ONLY the idea text in between (no preamble, no tool commentary,
+          no closing remarks):
+          ===IDEA START===
+          ===IDEA END===
+        - After the END marker, output one final line naming the idea
+          (lowercase, kebab-case, no spaces):
+          IDEA_SLUG: <kebab-case-name>
+
+  - generate_plan:
+      description: Produce a plan for the generated idea, inline only.
+      tool: harness:claude-code
+      depends_on: [generate_idea]
+      task: |
+        /plan
+
+        Create a plan for the following idea (use only the text between the
+        "===IDEA START===" / "===IDEA END===" markers; ignore everything else):
+
+        ---
+        {{generate_idea.output}}
+        ---
+
+        IMPORTANT: Output the full plan inline in your response only. Do NOT write
+        the plan to any file on disk.
+
+        Output format (strict):
+        - Do all reasoning first; NONE of that narration may appear in the plan.
+        - Emit the plan between the two marker lines below, with ONLY the plan in
+          between (no preamble, no narration). Do not put a top-level "# Plan"
+          heading inside; use "##" for any section headings:
+          ===PLAN START===
+          ===PLAN END===
+
+  - store_idea:
+      description: Assemble the idea document from the template and write it to path_idea.
+      tool: harness:claude-code
+      depends_on: [generate_idea, generate_plan]
+      task: |
+        Create one idea document and write it to disk.
+
+        1. Read the template at:
+           .atelier/conduits/autonomous-projects/idea_template.md
+           It has three sections: "# Description", "# Plan", "# Comments from user".
+
+        2. Fill the sections:
+           - "# Description": ONLY the text between the "===IDEA START===" and
+             "===IDEA END===" markers in the idea below. Discard everything
+             outside the markers (model narration, the markers themselves, and
+             the IDEA_SLUG line).
+           - "# Plan": ONLY the text between the "===PLAN START===" and
+             "===PLAN END===" markers in the plan below. Strip a leading
+             top-level "# ..." heading if present (the template already provides
+             "# Plan"). Discard everything outside the markers.
+           - "# Comments from user": leave empty.
+
+        3. Determine the slug from the "IDEA_SLUG:" line in the idea below.
+
+        4. Run: mkdir -p "{{inputs.path_idea}}"
+           Then write the filled document to:
+           {{inputs.path_idea}}/idea_<slug>.md
+           (literal prefix "idea_" followed by the slug, e.g. idea_dark-mode.md).
+
+        Idea:
+        ---
+        {{generate_idea.output}}
+        ---
+
+        Plan:
+        ---
+        {{generate_plan.output}}
+        ---

--- a/.atelier/conduits/generate-review/conduit.yaml
+++ b/.atelier/conduits/generate-review/conduit.yaml
@@ -1,0 +1,135 @@
+name: generate-review
+description: Generate a code review for a project, plan it, and store it as a review document.
+timeout: 3600
+max_concurrency: 3
+
+inputs:
+  path: Filesystem path to the project/codebase the review should be about.
+  project_document: Path to the project document (goal/constraints/context) the agent reads.
+  path_review: Target folder where the final review_<name>.md document is written.
+  current_reviews:
+    description: Folder of existing review documents; the new review must not duplicate them.
+    default: ""
+  bad_ideas:
+    description: Folder of rejected ideas plus the user's reasoning; avoid the same mistakes.
+    default: ""
+  tasks_dir:
+    description: >-
+      Project task directory holding to-do/, in-progress/, pending-review/, done/;
+      the new review must not re-flag work already queued, being worked, or implemented.
+    default: ""
+
+tasks:
+  - generate_review:
+      description: Generate a code review for the project via the review skill.
+      tool: harness:claude-code
+      depends_on: []
+      task: |
+        /review
+
+        Focus on the codebase at this path: {{inputs.path}}
+
+        Read this project document first to understand the project's goal and
+        constraints, and ground your review in it: {{inputs.project_document}}
+
+        Before reviewing, read prior context so you don't repeat work:
+        - Existing reviews live in this folder: {{inputs.current_reviews}}
+          Read the review_*.md files there. Your new review MUST cover different
+          ground, not restate findings already captured.
+        - Rejected ideas live in this folder: {{inputs.bad_ideas}}
+          Each file holds a bad idea and the user's reasoning for why it is bad.
+          Do NOT recommend changes of those kinds; respect the stated reasoning.
+        - Existing tasks live under this directory: {{inputs.tasks_dir}}
+          Read the .md files in its `to-do/`, `in-progress/`, `pending-review/`,
+          and `done/` subfolders — their `# What` sections describe work already
+          queued, being worked, implemented and awaiting review, or completed.
+          Do NOT re-flag findings already covered by any of them.
+        If a path is empty or the folder does not exist, treat it as "no prior
+        context" and continue.
+
+        Produce a single code review with severity-labeled findings and
+        file:line references across correctness, readability, architecture,
+        security, and performance.
+
+        Keep the severity labels and file:line references, but explain each
+        finding in plain, accessible language: say what is wrong and why it
+        matters in everyday terms. Avoid unnecessary jargon in the review text —
+        reserve technical depth for the plan, not the description.
+
+        Output format (strict):
+        - Do all exploration and reasoning first; NONE of that narration may
+          appear in the final review.
+        - Emit the review between the two marker lines below, on their own lines,
+          with ONLY the review text in between (no preamble, no tool commentary,
+          no closing remarks). Do not put a top-level "# ..." heading inside; use
+          "##" for any section headings:
+          ===REVIEW START===
+          ===REVIEW END===
+        - After the END marker, output one final line naming the review
+          (lowercase, kebab-case, no spaces):
+          REVIEW_SLUG: <kebab-case-name>
+
+  - generate_plan:
+      description: Produce a plan for the generated review, inline only.
+      tool: harness:claude-code
+      depends_on: [generate_review]
+      task: |
+        /plan
+
+        Create a plan to address the following review (use only the text between
+        the "===REVIEW START===" / "===REVIEW END===" markers; ignore everything
+        else):
+
+        ---
+        {{generate_review.output}}
+        ---
+
+        IMPORTANT: Output the full plan inline in your response only. Do NOT write
+        the plan to any file on disk.
+
+        Output format (strict):
+        - Do all reasoning first; NONE of that narration may appear in the plan.
+        - Emit the plan between the two marker lines below, with ONLY the plan in
+          between (no preamble, no narration). Do not put a top-level "# Plan"
+          heading inside; use "##" for any section headings:
+          ===PLAN START===
+          ===PLAN END===
+
+  - store_review:
+      description: Assemble the review document from the template and write it to path_review.
+      tool: harness:claude-code
+      depends_on: [generate_review, generate_plan]
+      task: |
+        Create one review document and write it to disk.
+
+        1. Read the template at:
+           .atelier/conduits/autonomous-projects/idea_template.md
+           It has three sections: "# Description", "# Plan", "# Comments from user".
+
+        2. Fill the sections:
+           - "# Description": ONLY the text between the "===REVIEW START===" and
+             "===REVIEW END===" markers in the review below. Discard everything
+             outside the markers (model narration, the markers themselves, and
+             the REVIEW_SLUG line).
+           - "# Plan": ONLY the text between the "===PLAN START===" and
+             "===PLAN END===" markers in the plan below. Strip a leading
+             top-level "# ..." heading if present (the template already provides
+             "# Plan"). Discard everything outside the markers.
+           - "# Comments from user": leave empty.
+
+        3. Determine the slug from the "REVIEW_SLUG:" line in the review below.
+
+        4. Run: mkdir -p "{{inputs.path_review}}"
+           Then write the filled document to:
+           {{inputs.path_review}}/review_<slug>.md
+           (literal prefix "review_" followed by the slug, e.g. review_auth-module.md).
+
+        Review:
+        ---
+        {{generate_review.output}}
+        ---
+
+        Plan:
+        ---
+        {{generate_plan.output}}
+        ---

--- a/.atelier/schedules/autonomous-projects-day.yaml
+++ b/.atelier/schedules/autonomous-projects-day.yaml
@@ -5,6 +5,7 @@ inputs:
   idle_hours: '0.1'
   max_pending_review: '20'
   token_limit: '19000000'
+  max_ideas: '20'
 run_path: /Users/ganga/Documents/personal_repos/flow-atelier
 schedule:
   mode: recurring
@@ -41,4 +42,4 @@ schedule:
   - '19:00'
   - '19:30'
 created_at: 1779778874
-runs_completed: 89
+runs_completed: 102

--- a/.atelier/schedules/autonomous-projects-night.yaml
+++ b/.atelier/schedules/autonomous-projects-night.yaml
@@ -5,6 +5,7 @@ inputs:
   idle_hours: '0.1'
   max_pending_review: '20'
   token_limit: '19000000'
+  max_ideas: '20'
 run_path: /Users/ganga/Documents/personal_repos/flow-atelier
 schedule:
   mode: recurring
@@ -45,4 +46,4 @@ schedule:
   - 08:00
   - 08:30
 created_at: 1779778874
-runs_completed: 30
+runs_completed: 49

--- a/.atelier/schedules/vault-organizer.yaml
+++ b/.atelier/schedules/vault-organizer.yaml
@@ -71,4 +71,4 @@ schedule:
   - '12:30'
   - '18:30'
 created_at: 1779781588
-runs_completed: 9
+runs_completed: 12

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,192 @@
+# Developing flow-atelier
+
+This document covers how to set up a development environment, run the
+tests, and find your way around the codebase. For what flow-atelier is
+and how to use it, see [README.md](./README.md).
+
+## Prerequisites
+
+- Python 3.13 or newer.
+- [uv](https://docs.astral.sh/uv/) for dependency and environment
+  management.
+
+The AI harnesses (`harness:claude-code`, `harness:codex`, etc.) are
+only needed to run conduits that use them or the `live` test suite.
+Unit tests do not require any harness installed.
+
+## Setup
+
+```bash
+git clone <repo-url>
+cd flow-atelier
+uv sync                       # create .venv and install runtime + dev deps
+uv run pre-commit install     # wire the pre-commit (lint) hook
+uv run pre-commit install --hook-type pre-push   # wire the pre-push (test) hook
+```
+
+`uv sync` installs the `dev` dependency group declared in
+`pyproject.toml` (pytest, ruff, pre-commit, and friends).
+
+Copy `.env.example` to `.env` if you need to override any
+`ATELIER_*` setting locally; every variable has a sensible default,
+so this is optional.
+
+## Running tests
+
+```bash
+uv run pytest                 # full suite, live harness tests excluded
+uv run pytest tests/modules   # a subdirectory
+uv run pytest -k templating   # by keyword
+```
+
+Test configuration lives in `pyproject.toml` under
+`[tool.pytest.ini_options]`:
+
+- `asyncio_mode = "auto"` — async tests run without explicit
+  decorators.
+- `addopts = "-m 'not live'"` — the `live` marker is excluded by
+  default.
+- `timeout = 300` — per-test timeout via `pytest-timeout`.
+
+### Live tests
+
+Tests marked `live` exercise the real AI harness CLIs. They are slow
+and cost tokens, so they are excluded by default. Run them explicitly
+only when you have the relevant harness installed and authenticated:
+
+```bash
+uv run pytest -m live
+```
+
+## Linting and formatting
+
+Ruff handles both lint and format (config in `pyproject.toml`,
+line length 100, target `py313`):
+
+```bash
+uv run ruff check .           # lint
+uv run ruff check --fix .     # lint and autofix
+uv run ruff format .          # format
+```
+
+## Git hooks
+
+Hooks are managed by [pre-commit](https://pre-commit.com)
+(`.pre-commit-config.yaml`):
+
+- **pre-commit** — runs `ruff --fix` on staged files.
+- **pre-push** — runs the full `uv run pytest` suite.
+
+The pre-push hook fails the push if the test run leaves the working
+tree dirty (for example, if `uv` re-syncs `uv.lock`). Commit the
+resulting changes rather than bypassing the hook.
+
+## Project layout
+
+The `flow_atelier` package is organized in layers: CLI on top, a
+`core` facade that wires everything together, an execution `engine`,
+and `services` for the pluggable pieces (executors, store, scheduler,
+API).
+
+```
+flow_atelier/
+├── main.py                     # console-script entry point -> cli app
+├── cli/
+│   ├── main.py                 # Typer app + sub-apps (list, schedule, scheduler)
+│   ├── commands/               # one module per command (run, init, check, ...)
+│   └── rendering/              # Rich output + multiline terminal input
+├── core/
+│   ├── atelier.py              # Atelier facade: wires store + executors + engine
+│   └── settings.py             # AtelierSettings (env-driven, ATELIER_ prefix)
+├── modules/
+│   ├── engine.py               # DAG validation + concurrent task execution
+│   ├── conditions.py           # depends_on parsing, match/not_match predicates
+│   ├── templating.py           # {{inputs.x}} / {{task.output}} resolution
+│   └── liveness.py             # detect hard-killed flows
+├── schemas/                    # Pydantic models
+│   ├── conduit.py              # Conduit, TaskDefinition, ToolType enum
+│   ├── flow.py                 # flow id generation/parsing
+│   ├── log.py / progress.py    # log entries, per-task progress
+│   └── api.py / ws.py          # REST + WebSocket schemas
+├── services/
+│   ├── executor/               # one executor per tool/harness
+│   │   ├── base.py             # ExecutorBase, FlowContext
+│   │   ├── bash.py             # tool:bash
+│   │   ├── hitl.py             # tool:hitl
+│   │   ├── conduit.py          # tool:conduit (recursive)
+│   │   └── harness.py          # the five ACP harnesses
+│   ├── store/                  # conduit/flow persistence
+│   │   ├── base.py             # StoreBase (abstract)
+│   │   └── filesystem.py       # FilesystemStore (project + global dirs)
+│   ├── scheduler/              # runner, schedule store, trigger evaluation
+│   └── api/                    # FastAPI server, WebSocket manager + HITL bridge
+└── routes/                     # HTTP/WS route handlers (conduits, flows, ...)
+
+tests/                          # mirrors the package layout
+├── cli/  core/  modules/  schemas/
+└── services/  test_api/  fixtures/
+```
+
+## Architecture notes
+
+### The facade
+
+`core/atelier.py` is the single entry point that the CLI and API both
+call. Its constructor builds:
+
+- a `FilesystemStore` over the project `.atelier/` and the global
+  `~/.atelier/` directories,
+- the executor registry (a dict keyed by tool string),
+- the `Engine`,
+- and the scheduler's `ScheduleStore`.
+
+### The engine
+
+`modules/engine.py` takes a validated `Conduit` and runs it:
+
+1. Validates the DAG — cycle detection, unknown dependency names, and
+   regex syntax in conditional dependencies.
+2. Resolves which tasks are ready (all `depends_on` satisfied) and
+   runs them concurrently, bounded by `max_concurrency`.
+3. Looks up an executor by the task's `tool` value and calls it.
+4. Handles templating, conditional skips, loops (`repeat` +
+   `until`/`while`), retries, and timeouts.
+
+A task whose condition is not met is **skipped**, and the skip
+propagates to its dependents.
+
+### Executors
+
+Each tool maps to an `ExecutorBase` subclass in `services/executor/`.
+Executors implement `execute(...)` and `is_available()` (the
+preflight readiness probe used by `atelier check` and at the start of
+`atelier run`). The registry is built in `core/atelier.py`; the set
+of valid tool names is the `ToolType` enum in `schemas/conduit.py`.
+
+The five AI harnesses share one implementation in `harness.py` that
+speaks the [Agent Client Protocol](https://agentclientprotocol.com)
+over stdio. They differ only in their launch command, which can be
+overridden via the `ATELIER_*_LAUNCH_CMD` environment variables (see
+`.env.example`). Each harness reuses its own CLI's login; flow-atelier
+never handles credentials.
+
+### Adding a new tool
+
+1. Add the value to `ToolType` in `schemas/conduit.py`.
+2. Implement an `ExecutorBase` subclass in `services/executor/`.
+3. Register it in the executor dict in `core/atelier.py`.
+
+### Storage
+
+`services/store/` abstracts all persistence behind `StoreBase`. The
+only implementation is `FilesystemStore`, which resolves conduits
+from the project directory first and the global directory second, and
+writes every run under `.atelier/flows/<flow_id>/`.
+
+### Scheduler and API
+
+`services/scheduler/` runs conduits on a wall-clock schedule, reading
+one YAML file per schedule. `services/api/` (FastAPI) exposes the REST
+and WebSocket surface that `atelier serve` hosts, including the
+WebSocket bridge that delivers human-in-the-loop prompts to a
+connected client. Route handlers live in `routes/`.

--- a/README.md
+++ b/README.md
@@ -1,332 +1,199 @@
 ![flow-atelier](./atelier.png)
 
-# flow-atelier
+# Flow Atelier:
 
-**flow-atelier** is a CLI and async workflow engine for running reproducible
-DAG-based workflows called **conduits**. A single run of a conduit is a
-**flow**. Tasks whose dependencies are satisfied run concurrently via
-`asyncio`, subject to a conduit-level concurrency cap.
+## Flow Atelier is built on a simple premise: the world doesn't run on people, it runs on processes that people execute.
+Ask someone to make anything, for example: the best yogurt in the world, what a person will do is that they'll research, experiment, and produce something average. The same is true of an AI agent. But give that person a clear, step-by-step recipe — and keep refining it over time — and you can reach the best yogurt in the world.
+That's what Flow Atelier does. We help you build simple, repeatable instructions for getting something done the same way every time, then let anyone improve on them. It mirrors how real businesses actually work. Coca-Cola and Pepsi don't differ because their managers, lawyers, or engineers are fundamentally different people — they differ because their processes are different.
+Flow Atelier gives you the tool to design and refine those processes. The difference: instead of people executing them, AI agents do the work.
 
-Each task is dispatched to one of eight executors:
+## The words we use
 
-| Tool                  | What it runs                                                     |
-|-----------------------|------------------------------------------------------------------|
-| `tool:bash`           | a shell command (via `asyncio.create_subprocess_shell`)          |
-| `tool:hitl`           | prompts a human on stdin for one or more named inputs            |
-| `tool:conduit`        | another conduit, as a nested flow                                |
-| `harness:claude-code` | Claude Code via the [ACP](https://agentclientprotocol.com) adapter |
-| `harness:codex`       | OpenAI Codex via the ACP adapter                                 |
-| `harness:opencode`    | [opencode](https://opencode.ai) via native `opencode acp`        |
-| `harness:copilot`     | GitHub Copilot CLI via native `copilot --acp`                    |
-| `harness:cursor`      | Cursor CLI via the `@blowmage/cursor-agent-acp` adapter          |
+A few terms show up everywhere in this document:
 
-Harnesses speak the **Agent Client Protocol** (ACP) over stdio, so they
-get real bidirectional interaction: the agent can ask for permission, ask
-the user a free-form question mid-turn, or run a multi-turn conversation.
-Each harness reuses the host CLI's own local configuration and auth —
-flow-atelier does not read, write, or proxy any of it.
+- **Conduit** — a recipe. An ordered set of steps written in a single
+  YAML file.
+- **Task** — one step in that recipe. A task runs a shell command,
+  asks a person a question, calls an AI tool, or runs another conduit.
+- **Flow** — one run of a conduit. Every run is saved to disk, so you
+  can always go back and see exactly what happened.
+- **Harness** — an AI coding tool (Claude Code, Codex, opencode,
+  Copilot, Cursor) that a task can hand work to.
+- **HITL** — "human in the loop": a step that pauses to ask a person a
+  typed question, then continues with the answer.
 
-In `interactive: true` mode, flow-atelier keeps the session open across
-turns: if the agent ends a turn without emitting the `[ATELIER_DONE]`
-marker, the executor prompts the user on the terminal for the next reply
-and sends it back as the next user message. The loop terminates when the
-marker appears in the agent's output.
+## What can you build with it?
+
+Any pipeline that can be described as an ordered sequence or graph of
+steps. The two examples further down — a one-line greeter and a deploy
+pipeline with a human approval gate — illustrate two possible shapes;
+they are not prescriptive templates.
+
+A non-exhaustive list of things people have built:
+
+- **Chatbots and AI agents** that chain multiple turns of conversation
+  with retries, branches, and fallbacks.
+- **Multi-AI pipelines** in which one assistant drafts a specification,
+  a second produces a plan, and a third executes it — or in which two
+  assistants review the same change and a third synthesizes their
+  feedback.
+- **CI/CD-style pipelines** that clone a repository, run tests with
+  retry, request an AI code review, ask a human for confirmation, and
+  then deploy or roll back based on the result.
+- **Scheduled jobs** such as daily reports, weekly syncs, or one-shot
+  reminders at a specific time.
+- **Polling loops with retry and backoff** that call an endpoint until
+  it returns a success status or a rate limit lifts.
+- **Human-in-the-loop automations** — flows that pause to ask the
+  operator a typed question and resume with the answer.
+- **Reusable building blocks** — one conduit invoking another, so a
+  `deploy` conduit written once can be called from many higher-level
+  pipelines.
+- **Pure-shell automation with no AI at all** — flow-atelier works as
+  a general-purpose task runner in this mode.
+
+If a task can be described as a sequence or graph of steps, it can be
+written as a conduit.
+
+## How a conduit runs
+
+You write a conduit YAML file and put it in
+`.atelier/conduits/<name>/conduit.yaml`. When you run
+`atelier run <name>`, flow-atelier:
+
+1. Reads the YAML.
+2. Looks at each task's `depends_on` list to figure out which tasks can
+   start now and which have to wait.
+3. Starts every ready task at the same time, up to a configurable
+   limit (`max_concurrency`).
+4. For each task, picks an executor based on the `tool:` field:
+
+   | Tool                  | What it runs                                                       |
+   |-----------------------|--------------------------------------------------------------------|
+   | `tool:bash`           | a shell command                                                    |
+   | `tool:hitl`           | prompts a human on the terminal for one or more named answers      |
+   | `tool:conduit`        | another conduit, as a nested run                                   |
+   | `harness:claude-code` | Claude Code (via the [ACP](https://agentclientprotocol.com) adapter)|
+   | `harness:codex`       | OpenAI Codex (via the ACP adapter)                                 |
+   | `harness:opencode`    | [opencode](https://opencode.ai)                                    |
+   | `harness:copilot`     | GitHub Copilot CLI                                                 |
+   | `harness:cursor`      | Cursor CLI                                                         |
+
+5. Saves everything to disk under `.atelier/flows/<flow_id>/` — what
+   ran, what each task printed, whether it succeeded, when it
+   finished.
+
+The five AI harnesses use each tool's **own login** that lives on your
+machine. flow-atelier never sees, stores, or proxies any credentials.
 
 ## Install
 
-### From PyPI
+### One-command install (no Python needed)
 
-Requires Python 3.13+. Install with [uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/):
+The quickest way. The script downloads a prebuilt `atelier` binary into
+`~/.atelier/bin`, verifies its SHA-256 checksum against the published
+release, and adds it to your `PATH`. It is safe to re-run to upgrade.
+
+**macOS (Apple Silicon) / Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LGuillermoAngaritaG/flow-atelier/main/install.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/LGuillermoAngaritaG/flow-atelier/main/install.ps1 | iex
+```
+
+Prebuilt binaries are published for **Linux x86_64**, **macOS arm64
+(Apple Silicon)**, and **Windows x86_64**. Intel Macs are not supported
+(no Rosetta fallback exists for an arm64 binary). Open a new terminal
+after installing so the updated `PATH` takes effect.
+
+### Install with uv (for Python users)
+
+If you have Python 3.13+ and [uv](https://docs.astral.sh/uv/), you can
+install from PyPI instead:
 
 ```bash
 uv tool install flow-atelier
-# or
-pipx install flow-atelier
+uv tool upgrade flow-atelier      # upgrade later
+uv tool uninstall flow-atelier    # remove
 ```
 
-To upgrade or uninstall later:
+Either way, you end up with an `atelier` command on your `PATH`.
 
-```bash
-uv tool upgrade flow-atelier
-uv tool uninstall flow-atelier
-```
+### Optional: AI harnesses
 
-### Standalone binary (no Python required)
-
-Download the appropriate file from the
-[latest release](https://github.com/LGuillermoAngaritaG/flow-atelier/releases/latest):
-
-- `atelier-linux-x86_64`
-- `atelier-macos-arm64`
-- `atelier-windows-x86_64.exe`
-
-Make it executable (Linux/macOS) and put it on your `PATH`:
-
-```bash
-chmod +x atelier-linux-x86_64
-sudo mv atelier-linux-x86_64 /usr/local/bin/atelier
-```
-
-### From source
-
-```bash
-git clone <this-repo> flow-atelier
-cd flow-atelier
-uv tool install .
-```
-
-Or directly from a remote:
-
-```bash
-uv tool install git+<repo-url>
-```
-
-For local development inside the repo, a plain `uv sync` + `uv run atelier`
-also works.
-
-### Harness prerequisites
-
-You only need the prerequisites for the harness(es) you actually plan
-to use. A user who only wants `harness:opencode` does not need `claude`,
-`codex`, `copilot`, or `cursor-agent` installed, and so on.
+You only need to install the harness(es) for the AI tools you actually
+plan to use. If you never use AI in your conduits, you can skip this
+entire section.
 
 - **`harness:claude-code`** — Node.js / `npx` on PATH, plus an
-  authenticated `claude` setup (`~/.claude`, skills, subagents, hooks,
-  MCP servers, CLAUDE.md). On first use `npx` downloads
-  `@zed-industries/claude-code-acp`.
+  authenticated `claude` setup (`~/.claude/...`). On first use `npx`
+  downloads `@zed-industries/claude-code-acp`.
 - **`harness:codex`** — Node.js / `npx` on PATH, plus an authenticated
-  `codex` setup (`~/.codex/config.toml`, auth, AGENTS.md). On first use
-  `npx` downloads `@zed-industries/codex-acp`.
-- **`harness:opencode`** — the `opencode` binary on PATH; ACP is
-  native. As an alternative, an npm-published adapter like
-  `josephschmitt/opencode-acp` can be swapped in via
-  `ATELIER_OPENCODE_LAUNCH_CMD` if you prefer an `npx`-launched flow
-  without a local `opencode` install.
-- **`harness:copilot`** — the `copilot` binary on PATH, from the
-  `@github/copilot` npm package (public preview as of Jan 2026). ACP
-  is native via `copilot --acp`.
+  `codex` setup (`~/.codex/...`). On first use `npx` downloads
+  `@zed-industries/codex-acp`.
+- **`harness:opencode`** — the `opencode` binary on PATH.
+- **`harness:copilot`** — the `copilot` binary on PATH (from the
+  `@github/copilot` npm package).
 - **`harness:cursor`** — Node.js / `npx` on PATH, plus the
-  `cursor-agent` binary on PATH (the community npm adapter
-  `@blowmage/cursor-agent-acp` is pinned exactly at `0.7.1` and shells
-  out to `cursor-agent`).
+  `cursor-agent` binary on PATH.
 
-Each harness reuses its host CLI's own config and auth — flow-atelier
-does not hard-code paths to, or proxy, any of that state.
+Each harness reuses its own CLI's config and login. To pin a custom
+version or point at a different adapter, set the matching
+`ATELIER_*_LAUNCH_CMD` environment variable to a JSON array of argv
+(see `.env.example`).
 
-To pin a custom version or point at a locally installed adapter, set
-the matching `ATELIER_*_LAUNCH_CMD` env var to a JSON array of argv:
-`ATELIER_CLAUDE_LAUNCH_CMD`, `ATELIER_CODEX_LAUNCH_CMD`,
-`ATELIER_OPENCODE_LAUNCH_CMD`, `ATELIER_COPILOT_LAUNCH_CMD`, or
-`ATELIER_CURSOR_LAUNCH_CMD` (see `.env.example`).
-
-## Quick start
-
-Scaffold a project-local `.atelier/` with a hello-world conduit:
+## Quickstart
 
 ```bash
-atelier init
+atelier init                                # creates .atelier/conduits/hello/
+atelier run hello --input name=world        # runs it
+atelier status <flow_id>                    # shows progress
+atelier list flows --conduit hello          # lists previous runs
 ```
 
-This creates `.atelier/conduits/hello/conduit.yaml`. If `.atelier/` already
-exists in the current directory, `init` leaves it alone.
+`atelier init` writes a one-line `hello` conduit that only runs a
+shell command, so this works end-to-end before you install any AI
+tool.
 
-Run it:
+## Examples
 
-```bash
-atelier run hello --input name=world
-# flow_id: hello_7a3c9f2e_20260412T153004Z
+The two conduits below are **illustrative, not prescriptive**. A
+conduit can have one step or fifty, and any combination of shell, AI,
+and human steps. The samples show one minimal conduit and one larger
+one to demonstrate the range; the conduits you write will look
+nothing like them.
+
+### A simple conduit (`hello`)
+
+The one-task conduit that `atelier init` creates. It runs a single
+shell command:
+
+```yaml
+name: hello
+description: Say hello
+inputs:
+  name: Who to greet
+tasks:
+  - greet:
+      description: greet someone
+      task: "echo hello {{inputs.name}}"
+      tool: tool:bash
+      depends_on: []
 ```
 
-If the flow fails, resume it (skips already-completed tasks):
+Run it with `atelier run hello --input name=world`.
 
-```bash
-atelier run --resume hello_7a3c9f2e_20260412T153004Z
-```
+### A bigger conduit (`deploy_pipeline`)
 
-Check status:
-
-```bash
-atelier status hello_7a3c9f2e_20260412T153004Z
-```
-
-List everything:
-
-```bash
-atelier list conduits
-atelier list flows --conduit hello
-```
-
-## Conduit scopes
-
-Conduits can live in two places:
-
-- **Project**: `./.atelier/conduits/` — scaffolded by `atelier init`.
-- **Global**: `~/.atelier/conduits/` — shared across all projects, auto-created
-  on first run of any `atelier` command.
-
-When you invoke `atelier run <name>`, atelier looks for the conduit in the
-project first, then falls back to global. A project conduit with the same
-name as a global one silently wins. `atelier list conduits` tags each entry
-with `[project]` or `[global]` so you can see which copy is in effect.
-
-Flows are **always project-local** — every `atelier run` writes to
-`./.atelier/flows/` in the current working directory, regardless of which
-scope the conduit came from.
-
-Example: keep a general-purpose `deploy` conduit globally and override it
-per project when a specific repo needs different steps.
-
-## Commands
-
-```
-atelier init
-atelier run <conduit> [--input key=value ...]
-atelier run --resume <flow_id>
-atelier status <flow_id>
-atelier list conduits
-atelier list flows [--conduit <name>]
-
-# scheduler
-atelier schedule add <file.{json,yaml}>
-atelier schedule list [--json]
-atelier schedule remove <id-or-name>
-atelier schedule run-now <id-or-name>
-atelier scheduler start [--reload-interval 30] [--log-level INFO]
-atelier scheduler status [--json]
-
-# server (HTTP + WebSocket)
-atelier serve [--host 127.0.0.1] [--port 8000] \
-              [--reload-interval 30] [--cors-origin URL]* \
-              [--log-level INFO]
-```
-
-## Server (`atelier serve`)
-
-`atelier serve` boots a single uvicorn process that hosts both the
-FastAPI HTTP API and the in-process scheduler daemon (one event loop,
-clean SIGTERM cascade). When a `dist/` directory is present (the built
-frontend dashboard), it is served as a SPA with catch-all fallback —
-API and WebSocket routes take priority over static files.
-
-- Binds to `127.0.0.1:8000` by default. Pass `--host 0.0.0.0` to expose
-  on the LAN.
-- `--cors-origin` is repeatable; absent means localhost origins only
-  (the API can run shell commands, so a wildcard would let any webpage
-  drive a local server cross-origin).
-- Optional auth: set `ATELIER_API_TOKEN=<secret>` and every REST request
-  must send `Authorization: Bearer <secret>`; WebSocket connections must
-  pass `?token=<secret>`. Unset means no auth (local trust). `serve`
-  warns when binding a non-loopback host without a token. Note: the
-  bundled dashboard does not send a token yet, so setting one breaks the
-  SPA until the frontend adds support — the token is for headless/API
-  use today.
-- All JSON payloads are snake_case; the frontend translates camelCase ↔
-  snake_case on its side.
-
-Endpoint surface:
-
-| Method   | Path                       | Notes |
-|----------|----------------------------|-------|
-| `GET`    | `/conduits`                | List conduits |
-| `GET`    | `/conduits/:name`          | Read one |
-| `POST`   | `/conduits`                | Create (409 on collision) |
-| `PATCH`  | `/conduits/:name`          | Partial update |
-| `DELETE` | `/conduits/:name`          | Delete |
-| `POST`   | `/conduits/open-path`      | Reveal flow run path in OS file explorer |
-| `POST`   | `/tasks/run`               | Run an ad-hoc one-task conduit |
-| `GET`    | `/schedules`               | List schedules |
-| `POST`   | `/schedules`               | Create (registers with the embedded daemon) |
-| `DELETE` | `/schedules/:id`           | Delete |
-| `GET`    | `/flows`                   | List prior flows |
-| `GET`    | `/flows/:id/logs`          | Per-flow log entries |
-| `WS`     | `/ws/run-conduit`          | Run/resume flows + HITL gates over a multiplexed socket |
-
-## Resuming failed flows
-
-A flow that ended in `failed` status can be resumed — already-completed
-tasks are skipped and their persisted outputs are reused:
-
-```bash
-# CLI
-atelier run --resume <flow_id>
-
-# prefix matching works too
-atelier run --resume hello_7a3c
-```
-
-Over the WebSocket, send a `resume` message instead of `run`:
-
-```json
-{"type": "resume", "flow_id": "hello_7a3c9f2e_20260412T153004Z"}
-```
-
-Resumed runs emit the same lifecycle envelopes (`started`, `step`,
-`step_status`, `log`, `flow_complete` / `flow_failed`) as a fresh run,
-so the dashboard treats them identically. The `step_status` envelope
-now also fires with `"running"` when a task begins execution, giving
-the frontend real-time visibility into in-progress work.
-
-## Scheduler
-
-`atelier scheduler` runs conduits on a wall-clock schedule. Each
-schedule is one YAML file under `.atelier/schedules/<slug>.yaml`
-(slug derived from `schedule.name`). The daemon
-(`atelier scheduler start` or, embedded, `atelier serve`) is a single
-foreground asyncio process that fires conduits identically on Linux,
-macOS, and Windows — put it under your preferred supervisor
-(`systemd --user`, `launchd`, NSSM, etc.).
-
-Schedules use the same shape that the HTTP API consumes:
-
-```json
-{
-  "conduit_name": "report",
-  "inputs": { "date": "today" },
-  "run_path": "/abs/path",
-  "schedule": {
-    "mode": "recurring",
-    "name": "weekday mornings",
-    "days": [1, 2, 3, 4, 5],
-    "times": ["06:00", "12:00"]
-  }
-}
-```
-
-`days` are ISO-8601 day-of-week ints (`1=Mon`..`7=Sun`); `times` are
-`"HH:mm"` 24h strings. One-shots use `mode: "once"` with a `run_at`
-ISO datetime instead of `days`/`times`.
-
-Behavior notes:
-
-- **Hot reload**: schedules added or removed via the CLI / HTTP API are
-  picked up on the next reload tick (`--reload-interval`, default 30s).
-  Creates and deletes via `POST`/`DELETE /schedules` trigger a sync
-  immediately.
-- **Delete is hard**: `DELETE /schedules/:id` and
-  `atelier schedule remove` unlink the YAML file. There is no
-  resurrect; recreating yields a fresh `SCH-…` id and resets
-  `runs_completed`.
-- **No update endpoint**: to change a schedule, delete and recreate.
-  That mints a new id and zeroes the run counter — by design, to keep
-  the store trivial.
-- **One-shot fires exactly once**, success or failure: after a `once`
-  schedule's executor returns (even when it raises), the daemon writes
-  its id into `.atelier/scheduler_state.json` so a restart never
-  re-runs it. Failures are logged with full traceback.
-- **Concurrency**: each schedule runs at most one instance at a time
-  (`max_instances=1`); missed fires are coalesced.
-- **`scheduler status` reads the store, not the daemon.** It shows the
-  next fire times for every persisted schedule whether or not a daemon
-  is alive. To confirm liveness, check the daemon process directly.
-- **Embedded mode broadcasts live.** When started under `atelier
-  serve`, scheduled fires fan out `scheduled_run_started`,
-  `scheduled_task_event`, and `scheduled_run_complete`/`_failed`
-  envelopes to every `/ws/run-conduit` client.
-- `atelier schedule run-now <id-or-name>` dispatches a schedule
-  immediately without going through the daemon and without touching
-  fired-state.
-
-## Conduit reference
+A six-step pipeline that combines shell commands, an AI review, a
+human approval gate, retry loops, conditional branches, and a nested
+sub-conduit. It illustrates what is possible — a chatbot, a daily
+report, or an agent loop would look entirely different.
 
 ```yaml
 name: deploy_pipeline           # must match the folder name
@@ -393,31 +260,59 @@ tasks:
         - code_review.output.not_match(VERDICT:\s*APPROVE)
 ```
 
+Step by step:
+
+- `clone_repo` runs first because nothing depends on it.
+- `run_tests` and `code_review` both wait on `clone_repo`, then run
+  in parallel.
+- `run_tests` retries up to 3 times, stopping as soon as the output
+  contains `PASS`.
+- `code_review` asks Claude Code to review the code and end with
+  either `VERDICT: APPROVE` or `VERDICT: REJECT`.
+- `approve` only runs if Claude approved (`...match(VERDICT:\s*APPROVE)`).
+  It asks the human two typed questions on the terminal.
+- `deploy` only runs after the human approves, and calls another
+  conduit (`deploy_to_env`) as a nested run.
+- `rollback` only runs if Claude rejected. The two branches are
+  mutually exclusive — the unmet branch is silently skipped, not
+  failed.
+
+## Conduit reference
+
+A conduit has a `name`, a short `description`, an optional `inputs`
+map, and a `tasks` list. Each task has a `name`, a `task` body, a
+`tool` value, and a `depends_on` list.
+
 ### Templating
 
-- `{{inputs.<name>}}` — conduit or HITL input, resolved at task start.
-- `{{<task_name>.output>}}` — the string output of an upstream task. The
-  referenced task must appear in `depends_on` so the engine has already
-  completed it by the time the template is rendered.
+- `{{inputs.<name>}}` — a conduit input or HITL answer.
+- `{{<task_name>.output}}` — the printed output of an earlier task.
+  The earlier task must appear in `depends_on`.
+- `{{loop.previous}}` — this task's output from its previous loop
+  iteration (empty before the first iteration completes). Only valid on
+  a looping task (`repeat > 1`).
+- `{{loop.history}}` — every prior iteration of this task, rendered as
+  numbered blocks. Only valid on a looping task (`repeat > 1`).
+
+A missing `{{inputs.x}}` fails the task immediately; a reference to a
+task that was skipped or hasn't completed skips the referencing task.
 
 ### Conditional dependencies
 
 ```
-<task>.output.match(<regex>)        # dependency met iff regex matches
-<task>.output.not_match(<regex>)    # dependency met iff regex does NOT match
+<task>.output.match(<regex>)        # dependency met if regex matches
+<task>.output.not_match(<regex>)    # dependency met if regex does NOT match
 ```
 
-The regex is everything between the leftmost `(` and the last `)` — no
-quoting required. Python's `re.search` is used.
+The regex is everything between the leftmost `(` and the last `)` —
+no quoting required. Python's `re.search` is used.
 
-If the condition is not met, the dependent task is **skipped** (not failed).
-A skip does not trigger fail-fast. Any task that references a skipped task's
-output — via `depends_on` or `{{task.output}}` — is also skipped.
+If a condition is not met, the task is **skipped**, not failed.
+Anything that depends on a skipped task is also skipped.
 
-### Loop predicates (`until` / `while`)
+### Loops (`repeat` + `until` / `while`)
 
-A task with `repeat > 1` can break out of its loop early via one of two
-predicates (mutually exclusive — set at most one):
+A task with `repeat > 1` can break out of its loop early:
 
 ```
 until: output.match(<regex>)       # break as soon as an output matches
@@ -426,19 +321,11 @@ while: output.match(<regex>)       # loop while an output matches; break otherwi
 while: output.not_match(<regex>)   # loop while no output matches; break otherwise
 ```
 
-Iteration 1 always runs before the predicate is evaluated. Both fields
-parse at conduit-load time — a malformed regex fails before the first
-task starts. The regex grammar is the same as the dependency DSL above:
-everything between the leftmost `(` and the final `)`, no quoting,
-matched with `re.search`.
+Set at most one of `until` / `while`. The first iteration always runs
+before the predicate is checked.
 
-**Predicate scope** depends on the task type:
-
-- Non-conduit tasks — the predicate sees the single iteration output.
-- `tool:conduit` tasks — the predicate sees **every nested sub-task
-  output of that iteration** and fires on any-match. This lets you wrap
-  a multi-step conduit, retry it, and break the moment any internal
-  step emits a signal — not just the conduit's aggregate output.
+For `tool:conduit` loops, the predicate sees **every nested sub-task
+output of that iteration** and fires on any match.
 
 ```yaml
 - retry_while_rate_limited:
@@ -454,95 +341,165 @@ matched with `re.search`.
     until: output.match("PASS")
 ```
 
-### HITL inputs
+### Retries and per-task timeout
 
-`tool:hitl` tasks define their own `inputs: {name: description}` map. At
-runtime the executor prints the task's prompt, then asks for each input by
-name with its description. The answers are:
+- `retries: <n>` — if a task *fails*, re-run it up to `n` more times
+  (default `0`). This is different from `repeat`, which loops a task
+  that is *succeeding*.
+- `timeout: <seconds>` — override the per-task time limit for one task.
+  When omitted, the conduit-level `timeout` applies.
 
-1. Appended to the flow's `input.yaml` as **top-level** keys (on collision
-   they overwrite existing values).
-2. Added to `context.inputs` so downstream tasks can use
-   `{{inputs.<name>}}` in addition to `{{<hitl_task>.output}}` (which is a
-   YAML dump of the collected map).
+### Asking a human (`tool:hitl`)
 
-### Harness interactive mode
+A `tool:hitl` task declares its own `inputs: {name: description}`
+map. At runtime flow-atelier prints the prompt, asks for each input
+by name on the terminal, and saves the answers so downstream tasks
+can use them as `{{inputs.<name>}}`.
 
-When a harness task sets `interactive: true`, flow-atelier appends the
-following instruction to every user message it sends to the agent:
+### Long AI conversations (`interactive: true`)
+
+When a harness task sets `interactive: true`, flow-atelier appends
+this line to every message it sends to the AI:
 
 > When — and only when — you are completely finished, output the exact
 > token `[ATELIER_DONE]` to signal completion.
 
-The executor keeps the ACP session open across turns:
+Then it keeps the conversation open: the AI replies, flow-atelier
+streams the reply to your terminal, and if the AI didn't write
+`[ATELIER_DONE]` yet, flow-atelier asks **you** for the next message
+to send back. The loop ends when `[ATELIER_DONE]` shows up.
 
-1. Sends the (resolved + suffixed) task prompt as a `session/prompt`.
-2. Streams the agent's response chunks to your terminal as they arrive.
-3. If the chunk buffer now contains the marker, the task completes.
-4. Otherwise it asks you for your next reply on the terminal and sends
-   that back as the next user message (marker suffix re-appended).
-5. Loop, bounded by an internal max-turns safety net.
+If the AI asks for permission to run a tool, you'll see a numbered
+menu on the terminal; your choice is sent back as the answer.
 
-Permission requests coming from the agent (e.g. "can I run this tool?")
-are presented to you as a numbered menu; your choice is returned to the
-agent as the permission outcome.
+Non-interactive tasks run one turn and stop.
 
-Non-interactive tasks run a single turn and return whatever the agent
-streamed before `stop_reason`.
+## Where conduits live
+
+Conduits can live in two places:
+
+- **Project**: `./.atelier/conduits/` — scaffolded by `atelier init`.
+- **Global**: `~/.atelier/conduits/` — shared across all projects.
+
+When you run a conduit, flow-atelier checks the project folder first,
+then the global folder. A project-level conduit silently overrides a
+global one with the same name.
+
+Flows are **always project-local** — every `atelier run` writes its
+flow folder under `.atelier/flows/` in the current working directory.
+
+## Commands
+
+```
+atelier init
+atelier check [<conduit>]                              # validate conduit(s) without running
+atelier run <conduit> [--input key=value ...] [--show-steps/--hide-steps]
+atelier run --resume <flow_id>                         # resume a failed/crashed flow
+atelier status <flow_id>
+atelier logs <flow_id> [--task <name>] [--follow] [--json]
+atelier list conduits
+atelier list flows [--conduit <name>]
+atelier rm <flow_id> [--force] [--yes]                 # delete one flow run
+atelier prune [--conduit <name>] [--older-than <days>] [--keep <n>]   # bulk-delete old flows
+
+# scheduling
+atelier schedule add <file.{json,yaml}>
+atelier schedule list [--json]
+atelier schedule remove <id-or-name>
+atelier schedule run-now <id-or-name>
+atelier scheduler start [--reload-interval 30] [--log-level INFO]
+atelier scheduler status [--json]
+
+# HTTP + WebSocket server
+atelier serve [--host 127.0.0.1] [--port 8000] \
+              [--reload-interval 30] [--cors-origin URL]* \
+              [--log-level INFO]
+```
+
+## Running on a schedule
+
+`atelier scheduler` runs conduits on a wall-clock schedule. Each
+schedule is one YAML file under `.atelier/schedules/<name>.yaml`. The
+daemon is one foreground process you can put under `systemd`,
+`launchd`, or any supervisor.
+
+To register a schedule, write a YAML file like the one below and run
+`atelier schedule add <file>`:
+
+```yaml
+conduit_name: report
+inputs:
+  date: today
+run_path: /abs/path
+schedule:
+  mode: recurring
+  name: weekday mornings
+  days: [1, 2, 3, 4, 5]
+  times: ["06:00", "12:00"]
+```
+
+`days` are `1=Mon` .. `7=Sun`; `times` are `"HH:mm"` 24-hour strings.
+One-shots use `mode: once` with a `run_at` ISO datetime instead of
+`days` / `times`. `atelier schedule add` also accepts the same shape
+in JSON if you prefer that format.
+
+- New or removed schedules are picked up on the next reload tick
+  (default 30s).
+- One-shot schedules remember they fired, so a daemon restart never
+  re-runs them.
+- Each schedule runs at most one instance at a time; missed fires
+  are coalesced.
+- `atelier schedule run-now <id-or-name>` fires a schedule
+  immediately, bypassing the daemon.
+
+## HTTP API (`atelier serve`)
+
+`atelier serve` boots a single process that hosts both the HTTP /
+WebSocket API and the scheduler daemon. It is the entry point the
+Flow Atelier visual frontend connects to.
+
+| Method   | Path                       | Notes |
+|----------|----------------------------|-------|
+| `GET`    | `/conduits`                | List conduits |
+| `GET`    | `/conduits/:name`          | Read one |
+| `POST`   | `/conduits`                | Create (201 on success, 409 on collision) |
+| `PATCH`  | `/conduits/:name`          | Partial update |
+| `DELETE` | `/conduits/:name`          | Delete |
+| `POST`   | `/conduits/open-path`      | Reveal flow run path in OS file explorer |
+| `POST`   | `/tasks/run`               | Run an ad-hoc one-task conduit |
+| `GET`    | `/schedules`               | List active schedules |
+| `POST`   | `/schedules`               | Create |
+| `DELETE` | `/schedules/:id`           | Soft-delete |
+| `GET`    | `/flows`                   | List prior flows |
+| `GET`    | `/flows/:id/logs`          | Per-flow log entries |
+| `WS`     | `/ws/run-conduit`          | Run flows + HITL gates over a socket |
+
+Binds to `127.0.0.1:8000` by default; pass `--host 0.0.0.0` to expose
+on the LAN. `--cors-origin` is repeatable.
 
 ## Folder layout
 
-The `.atelier` directory lives in the working directory where `atelier` is
-invoked.
+The `.atelier` directory lives in the working directory where
+`atelier` is invoked.
 
 ```
 .atelier/
 ├── conduits/
 │   └── <conduit_name>/conduit.yaml
 ├── schedules/
-│   ├── <schedule_name>.yaml             # one ScheduleDefinition per file
-│   └── .state.json                      # fired-once markers (managed by the daemon)
+│   └── <schedule_name>.yaml                # one YAML file per schedule
+├── scheduler_state.json                    # fired-once markers
 └── flows/
-    └── <flow_id>/                       # <conduit>_<uuid8>_<YYYYMMDDTHHMMSSZ>
-        ├── input.yaml
-        ├── logs.json                    # append-only task execution log
-        ├── progress.json                # live per-task status
+    └── <flow_id>/                          # <YYYYMMDD>_<uuid8>_<conduit>
+        ├── input.yaml                      # the inputs this run was given
+        ├── logs.jsonl                      # append-only log, one JSON object per line
+        ├── progress.json                   # live per-task status
+        ├── outputs.yaml                    # per-task outputs (written as tasks finish)
         └── flows/
-            └── <child_flow_id>/...      # nested tool:conduit runs
+            └── <child_flow_id>/...         # nested tool:conduit runs
 ```
 
-## Development
+## Contributing
 
-Run the test suite:
-
-```bash
-uv run pytest                                  # fast unit suite (live tests excluded)
-uv run pytest -m live tests/test_live_harness.py -v   # live ACP smoke tests
-```
-
-The live harness tests are gated behind the `live` pytest marker so a
-bare `pytest` never spends tokens by accident. They spawn the real Zed
-ACP adapters for Claude Code and Codex via `npx`, so they cost tokens
-and need network + valid auth. They're wrapped in a try/xfail so
-transient flakes don't break the suite.
-
-## Architecture
-
-```
-app/
-├── main.py                    # Typer CLI (thin)
-├── core/
-│   ├── atelier.py             # facade — wires everything
-│   └── settings.py            # pydantic-settings (ATELIER_* env)
-├── services/
-│   ├── executor/              # ExecutorBase + bash / hitl / conduit / harness
-│   └── store/                 # StoreBase + FilesystemStore
-├── modules/
-│   ├── engine.py              # async DAG engine
-│   ├── templating.py          # {{inputs.x}} / {{task.output}} resolver
-│   └── conditions.py          # depends_on parser + evaluator
-└── schemas/                   # pydantic models (Conduit, Flow, Progress, ...)
-```
-
-The engine only depends on base classes (`StoreBase`, `ExecutorBase`) so
-new tools or storage backends can be added without touching the engine.
+For test instructions, the project layout, and internal architecture
+notes, see [DEVELOPMENT.md](./DEVELOPMENT.md).

--- a/flow_atelier/cli/_shared.py
+++ b/flow_atelier/cli/_shared.py
@@ -152,6 +152,4 @@ def _schedule_store() -> ScheduleStore:
     :returns: a ScheduleStore bound to the current atelier directory.
     """
     settings = AtelierSettings()
-    return ScheduleStore(
-        settings.atelier_dir, global_dir=settings.global_atelier_dir
-    )
+    return ScheduleStore(settings.atelier_dir)

--- a/flow_atelier/cli/_shared.py
+++ b/flow_atelier/cli/_shared.py
@@ -152,4 +152,6 @@ def _schedule_store() -> ScheduleStore:
     :returns: a ScheduleStore bound to the current atelier directory.
     """
     settings = AtelierSettings()
-    return ScheduleStore(settings.atelier_dir)
+    return ScheduleStore(
+        settings.atelier_dir, global_dir=settings.global_atelier_dir
+    )

--- a/flow_atelier/cli/commands/check.py
+++ b/flow_atelier/cli/commands/check.py
@@ -14,19 +14,26 @@ from flow_atelier.modules.engine import ConduitValidationError, validate_conduit
 def _check_one(atelier: Atelier, name: str) -> str | None:
     """Validate one conduit fully without executing it.
 
+    Combines structural validation with a readiness probe: even a
+    structurally-valid conduit FAILs here if a referenced tool is unregistered
+    or its harness CLI is missing from PATH, so authors learn before a run.
+
     :param atelier: configured :class:`Atelier` providing the store.
     :param name: conduit name to load and validate.
-    :returns: ``None`` when valid, else a one-line failure message.
+    :returns: ``None`` when valid and runnable, else a one-line failure message.
     """
     try:
         conduit = atelier.store.read_conduit(name)
         validate_conduit(conduit)
-        return None
     except ValidationError as e:
         first = e.errors()[0]
         return first.get("msg", str(e))
     except (ConduitValidationError, ValueError) as e:
         return str(e)
+    problems = atelier.tool_readiness(conduit)
+    if problems:
+        return "; ".join(problems)
+    return None
 
 
 @app.command("check")
@@ -64,6 +71,11 @@ def check_cmd(
         label = rf"{escape(name)} \[{escape(source)}]"
         if error is None:
             console.print(f"{label} — [green]OK[/green]")
+            conduit = atelier.store.read_conduit(name)
+            required = [k for k, spec in conduit.inputs.items() if spec.default is None]
+            if required:
+                keys = ", ".join(escape(k) for k in required)
+                console.print(f"    [dim]requires --input: {keys}[/dim]")
         else:
             failed = True
             console.print(f"{label} — [red]FAIL: {escape(error)}[/red]")

--- a/flow_atelier/cli/commands/check.py
+++ b/flow_atelier/cli/commands/check.py
@@ -1,0 +1,72 @@
+"""`atelier check` command — validate conduits without running them."""
+from __future__ import annotations
+
+import typer
+from pydantic import ValidationError
+from rich.markup import escape
+
+from flow_atelier.cli._shared import console
+from flow_atelier.cli.main import app
+from flow_atelier.core.atelier import Atelier
+from flow_atelier.modules.engine import ConduitValidationError, validate_conduit
+
+
+def _check_one(atelier: Atelier, name: str) -> str | None:
+    """Validate one conduit fully without executing it.
+
+    :param atelier: configured :class:`Atelier` providing the store.
+    :param name: conduit name to load and validate.
+    :returns: ``None`` when valid, else a one-line failure message.
+    """
+    try:
+        conduit = atelier.store.read_conduit(name)
+        validate_conduit(conduit)
+        return None
+    except ValidationError as e:
+        first = e.errors()[0]
+        return first.get("msg", str(e))
+    except (ConduitValidationError, ValueError) as e:
+        return str(e)
+
+
+@app.command("check")
+def check_cmd(
+    conduit_name: str = typer.Argument(
+        None, help="Conduit to check; omit to check all."
+    ),
+) -> None:
+    """Validate hand-authored conduits without running any task.
+
+    :param conduit_name: a single conduit to check; when omitted, all
+        project and global conduits are checked.
+    """
+    atelier = Atelier()
+    sources = dict(atelier.store.list_conduits_with_source())
+
+    if conduit_name is not None:
+        if conduit_name not in sources:
+            console.print(
+                f"[red]unknown conduit:[/red] {conduit_name} "
+                f"— try 'atelier list conduits'"
+            )
+            raise typer.Exit(code=1)
+        targets = [(conduit_name, sources[conduit_name])]
+    else:
+        targets = atelier.store.list_conduits_with_source()
+
+    if not targets:
+        console.print("[yellow]no conduits found[/yellow]")
+        return
+
+    failed = False
+    for name, source in targets:
+        error = _check_one(atelier, name)
+        label = rf"{escape(name)} \[{escape(source)}]"
+        if error is None:
+            console.print(f"{label} — [green]OK[/green]")
+        else:
+            failed = True
+            console.print(f"{label} — [red]FAIL: {escape(error)}[/red]")
+
+    if failed:
+        raise typer.Exit(code=1)

--- a/flow_atelier/cli/commands/list.py
+++ b/flow_atelier/cli/commands/list.py
@@ -5,6 +5,7 @@ import json
 from collections import Counter
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 from flow_atelier.cli._shared import (
@@ -14,7 +15,11 @@ from flow_atelier.cli._shared import (
     console,
 )
 from flow_atelier.cli.main import list_app
-from flow_atelier.cli.rendering.render import _FLOW_STATUS_STYLE, _task_status_summary
+from flow_atelier.cli.rendering.render import (
+    _FLOW_STATUS_STYLE,
+    _task_status_summary,
+    format_conduit_error,
+)
 from flow_atelier.core.atelier import Atelier
 from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.progress import Progress
@@ -43,11 +48,13 @@ def list_conduits_cmd(
             num_tasks = len(conduit.tasks)
             num_inputs = len(conduit.inputs)
             readable = True
-        except Exception:  # noqa: BLE001 — broken yaml shouldn't break list
+            error = None
+        except Exception as exc:  # noqa: BLE001 — broken yaml shouldn't break list
             description = ""
             num_tasks = -1
             num_inputs = -1
             readable = False
+            error = format_conduit_error(exc)
         rows.append(
             {
                 "name": name,
@@ -56,6 +63,7 @@ def list_conduits_cmd(
                 "tasks": num_tasks,
                 "inputs": num_inputs,
                 "readable": readable,
+                "error": error,
             }
         )
 
@@ -73,7 +81,7 @@ def list_conduits_cmd(
     for r in rows:
         source_style = "cyan" if r["source"] == "project" else "magenta"
         if not r["readable"]:
-            description_cell = "[red](unreadable)[/red]"
+            description_cell = f"[red](invalid: {escape(str(r['error']))})[/red]"
             tasks_cell = "?"
             inputs_cell = "?"
         else:

--- a/flow_atelier/cli/commands/list.py
+++ b/flow_atelier/cli/commands/list.py
@@ -21,6 +21,7 @@ from flow_atelier.cli.rendering.render import (
     format_conduit_error,
 )
 from flow_atelier.core.atelier import Atelier
+from flow_atelier.modules.liveness import display_status, is_crashed
 from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.progress import Progress
 
@@ -147,6 +148,7 @@ def list_flows_cmd(
                 "flow_id": fid,
                 "conduit": conduit_name,
                 "status": progress.status.value,
+                "crashed": is_crashed(progress),
                 "started_at": progress.started_at,
                 "finished_at": progress.finished_at,
                 "duration_seconds": _flow_duration_seconds(progress),
@@ -172,11 +174,12 @@ def list_flows_cmd(
         if progress is None:
             table.add_row(str(r["flow_id"]), str(r["conduit"]), "[red]?[/red]", "—", "—", "—")
             continue
-        status_style = _FLOW_STATUS_STYLE.get(progress.status.value, "white")
+        effective = display_status(progress)
+        status_style = _FLOW_STATUS_STYLE.get(effective, "white")
         table.add_row(
             str(r["flow_id"]),
             str(r["conduit"]),
-            f"[{status_style}]{progress.status.value}[/{status_style}]",
+            f"[{status_style}]{effective}[/{status_style}]",
             _format_clock(progress.started_at),
             _format_duration_seconds(_flow_duration_seconds(progress)),
             _task_status_summary(progress),

--- a/flow_atelier/cli/commands/logs.py
+++ b/flow_atelier/cli/commands/logs.py
@@ -10,6 +10,7 @@ from flow_atelier.cli._shared import _resolve_flow_id, console
 from flow_atelier.cli.main import app
 from flow_atelier.cli.rendering.render import _render_log_entry
 from flow_atelier.core.atelier import Atelier
+from flow_atelier.modules.liveness import is_crashed
 from flow_atelier.schemas.progress import FlowStatus
 
 _LOG_SHOW_CHOICES = ("output", "stdout", "stderr", "steps", "all")
@@ -156,6 +157,14 @@ def _follow_logs(
                 # Final pass to capture any entries written between the last
                 # read and the terminal state transition.
                 _drain_and_render()
+                return
+            if is_crashed(progress):
+                # Runner is provably dead but progress.json is frozen at
+                # running; drain and stop rather than polling forever.
+                _drain_and_render()
+                console.print(
+                    "[dim]— flow runner is no longer alive (crashed) —[/dim]"
+                )
                 return
             time.sleep(poll_seconds)
     except KeyboardInterrupt:

--- a/flow_atelier/cli/commands/rm.py
+++ b/flow_atelier/cli/commands/rm.py
@@ -1,0 +1,159 @@
+"""`atelier rm` and `atelier prune` commands — flow-run retention."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import typer
+
+from flow_atelier.cli._shared import _resolve_flow_id, console
+from flow_atelier.cli.main import app
+from flow_atelier.core.atelier import Atelier
+from flow_atelier.schemas.flow import parse_flow_id
+from flow_atelier.schemas.progress import FlowStatus
+
+
+def _is_running(atelier: Atelier, flow_id: str) -> bool:
+    """Return whether ``flow_id`` is in the non-terminal ``running`` state.
+
+    Read errors are treated as running so an in-flight run is never reaped.
+
+    :param atelier: Atelier instance used to read progress.
+    :param flow_id: flow identifier.
+    :returns: True if the flow is running or its status can't be read.
+    """
+    try:
+        return atelier.get_status(flow_id).status == FlowStatus.running
+    except Exception:  # noqa: BLE001 — unreadable progress → treat as in-flight
+        return True
+
+
+@app.command("rm")
+def rm_cmd(
+    flow_id: str = typer.Argument(..., help="Flow id (or unique prefix) to delete."),
+    force: bool = typer.Option(
+        False, "--force", help="Delete even if the flow is still running."
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt."
+    ),
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of text."
+    ),
+) -> None:
+    """Delete a single flow run directory.
+
+    :param flow_id: flow id (or unique prefix) to delete.
+    :param force: delete even when the flow's status is ``running``.
+    :param yes: skip the interactive confirmation prompt.
+    :param json_mode: when true, emit machine-readable JSON instead of text.
+    """
+    atelier = Atelier()
+    flow_id = _resolve_flow_id(atelier, flow_id)
+    try:
+        progress = atelier.get_status(flow_id)
+    except FileNotFoundError:
+        console.print(f"[red]unknown flow:[/red] {flow_id}")
+        raise typer.Exit(code=1)
+
+    if progress.status == FlowStatus.running and not force:
+        console.print(
+            f"[red]flow is still running:[/red] {flow_id} "
+            "(pass --force to delete anyway)"
+        )
+        raise typer.Exit(code=1)
+
+    if not yes and not typer.confirm(f"delete flow {flow_id}?"):
+        console.print("aborted")
+        raise typer.Exit(code=1)
+
+    deleted = atelier.delete_flow(flow_id)
+    if json_mode:
+        typer.echo(json.dumps({"flow_id": flow_id, "deleted": deleted}))
+        return
+    console.print(f"deleted flow {flow_id}" if deleted else f"nothing to delete: {flow_id}")
+
+
+@app.command("prune")
+def prune_cmd(
+    conduit: str | None = typer.Option(
+        None, "--conduit", "-c", help="Only prune flows for this conduit."
+    ),
+    older_than: int | None = typer.Option(
+        None, "--older-than", help="Prune flows whose id date is older than N days."
+    ),
+    keep: int | None = typer.Option(
+        None, "--keep", help="Keep the N most-recent flows; prune the rest."
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Include running flows (off by default)."
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt."
+    ),
+    json_mode: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON instead of text."
+    ),
+) -> None:
+    """Bulk-delete terminal flow runs by age and/or keep-count.
+
+    :param conduit: restrict candidates to this conduit.
+    :param older_than: prune flows older than this many days (by id date prefix).
+    :param keep: retain the N most-recent flows, prune the older remainder.
+    :param force: include ``running`` flows instead of skipping them.
+    :param yes: skip the interactive confirmation prompt.
+    :param json_mode: when true, emit machine-readable JSON instead of text.
+    """
+    if older_than is None and keep is None:
+        console.print(
+            "[red]refusing to prune:[/red] pass --older-than and/or --keep "
+            "to select which flows to delete."
+        )
+        raise typer.Exit(code=1)
+
+    atelier = Atelier()
+    candidates = atelier.list_flows(conduit)  # sorted ascending (oldest first)
+
+    selected = set(candidates)
+    if older_than is not None:
+        cutoff = datetime.now(UTC).date() - timedelta(days=older_than)
+        older: set[str] = set()
+        for fid in candidates:
+            try:
+                _, _, date = parse_flow_id(fid)
+                fid_date = datetime.strptime(date, "%Y%m%d").date()
+            except ValueError:
+                continue
+            if fid_date < cutoff:
+                older.add(fid)
+        selected &= older
+    if keep is not None:
+        retained = set(candidates[-keep:]) if keep > 0 else set()
+        selected -= retained
+
+    if not force:
+        selected = {fid for fid in selected if not _is_running(atelier, fid)}
+
+    to_delete = sorted(selected)
+    if not to_delete:
+        if json_mode:
+            typer.echo(json.dumps({"deleted": []}))
+        else:
+            console.print("nothing to prune")
+        return
+
+    if json_mode:
+        for fid in to_delete:
+            atelier.delete_flow(fid)
+        typer.echo(json.dumps({"deleted": to_delete}))
+        return
+
+    console.print("will delete:")
+    for fid in to_delete:
+        console.print(f"  - {fid}")
+    if not yes and not typer.confirm(f"delete {len(to_delete)} flow(s)?"):
+        console.print("aborted")
+        raise typer.Exit(code=1)
+
+    count = sum(1 for fid in to_delete if atelier.delete_flow(fid))
+    console.print(f"deleted {count} flow(s)")

--- a/flow_atelier/cli/commands/rm.py
+++ b/flow_atelier/cli/commands/rm.py
@@ -142,18 +142,22 @@ def prune_cmd(
             console.print("nothing to prune")
         return
 
-    if json_mode:
-        for fid in to_delete:
-            atelier.delete_flow(fid)
-        typer.echo(json.dumps({"deleted": to_delete}))
+    # JSON mode is non-interactive: it cannot prompt, so it requires --yes to
+    # delete. Without --yes it returns a dry-run preview and deletes nothing.
+    if json_mode and not yes:
+        typer.echo(json.dumps({"would_delete": to_delete, "deleted": []}))
         return
 
-    console.print("will delete:")
-    for fid in to_delete:
-        console.print(f"  - {fid}")
-    if not yes and not typer.confirm(f"delete {len(to_delete)} flow(s)?"):
-        console.print("aborted")
-        raise typer.Exit(code=1)
+    if not json_mode:
+        console.print("will delete:")
+        for fid in to_delete:
+            console.print(f"  - {fid}")
+        if not yes and not typer.confirm(f"delete {len(to_delete)} flow(s)?"):
+            console.print("aborted")
+            raise typer.Exit(code=1)
 
-    count = sum(1 for fid in to_delete if atelier.delete_flow(fid))
-    console.print(f"deleted {count} flow(s)")
+    deleted = [fid for fid in to_delete if atelier.delete_flow(fid)]
+    if json_mode:
+        typer.echo(json.dumps({"deleted": deleted}))
+    else:
+        console.print(f"deleted {len(deleted)} flow(s)")

--- a/flow_atelier/cli/commands/run.py
+++ b/flow_atelier/cli/commands/run.py
@@ -134,6 +134,15 @@ def run_cmd(
         console.print(f"[dim]→ fix conduits/{conduit_name}/conduit.yaml[/dim]")
         raise typer.Exit(code=1)
 
+    # Readiness gate: refuse to start an unrunnable conduit (unregistered tool
+    # or a harness CLI missing from PATH) before prompting for inputs or
+    # spending any wall-clock/tokens.
+    problems = atelier.tool_readiness(conduit)
+    if problems:
+        for problem in problems:
+            console.print(f"[red]cannot run:[/red] {escape(problem)}")
+        raise typer.Exit(code=1)
+
     # Prompt for missing inputs when running interactively.
     missing = [
         k

--- a/flow_atelier/cli/commands/run.py
+++ b/flow_atelier/cli/commands/run.py
@@ -5,6 +5,9 @@ import asyncio
 import sys
 
 import typer
+import yaml
+from pydantic import ValidationError
+from rich.markup import escape
 
 from flow_atelier.cli._shared import _parse_inputs, _resolve_flow_id, console
 from flow_atelier.cli.main import app
@@ -12,8 +15,10 @@ from flow_atelier.cli.rendering.render import (
     _render_orchestration_msg,
     _render_run_footer,
     _render_task_event,
+    format_conduit_error,
 )
 from flow_atelier.core.atelier import Atelier
+from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.log import TaskEvent
 
 
@@ -58,6 +63,22 @@ def run_cmd(
     # --resume path: resolve the old flow, skip input prompts
     if resume_from is not None:
         flow_id = _resolve_flow_id(atelier, resume_from)
+        # Surface a malformed conduit with a readable message before resuming,
+        # so a YAML/schema/name error doesn't reach the generic `flow failed:`
+        # handler as a raw exception. read_conduit is the only conduit-load
+        # surface; resume_flow's own ValueError (e.g. "can only resume failed
+        # or crashed flows") is unrelated and must keep its generic handling.
+        resume_conduit = parse_flow_id(flow_id)[0]
+        try:
+            atelier.store.read_conduit(resume_conduit)
+        except FileNotFoundError:
+            pass
+        except (yaml.YAMLError, ValidationError, ValueError) as exc:
+            console.print(
+                f"[red]invalid conduit:[/red] {escape(format_conduit_error(exc))}"
+            )
+            console.print(f"[dim]→ fix conduits/{resume_conduit}/conduit.yaml[/dim]")
+            raise typer.Exit(code=1)
         collected_events: list[TaskEvent] = []
         captured_flow_id: dict[str, str | None] = {"id": flow_id}
 
@@ -105,6 +126,12 @@ def run_cmd(
             f"[red]unknown conduit:[/red] {conduit_name} "
             f"— try 'atelier list conduits'"
         )
+        raise typer.Exit(code=1)
+    except (yaml.YAMLError, ValidationError, ValueError) as exc:
+        console.print(
+            f"[red]invalid conduit:[/red] {escape(format_conduit_error(exc))}"
+        )
+        console.print(f"[dim]→ fix conduits/{conduit_name}/conduit.yaml[/dim]")
         raise typer.Exit(code=1)
 
     # Prompt for missing inputs when running interactively.

--- a/flow_atelier/cli/commands/schedule.py
+++ b/flow_atelier/cli/commands/schedule.py
@@ -70,13 +70,18 @@ def schedule_add_cmd(
 
     :param file: path to a schedule JSON or YAML file to install.
     """
-    store = _schedule_store()
     try:
         payload = _load_schedule_payload(file)
     except Exception as e:  # noqa: BLE001
         console.print(f"[red]invalid schedule:[/red] {e}")
         raise typer.Exit(code=1)
-    job = store.create(payload)
+    # Route through the facade so conduit_name is validated against the store
+    # (a typo'd conduit otherwise installs cleanly and only fails at fire time).
+    try:
+        job = Atelier().create_schedule(payload)
+    except (ValueError, FileExistsError) as e:
+        console.print(f"[red]invalid schedule:[/red] {e}")
+        raise typer.Exit(code=1)
     console.print(f"[green]installed[/green] {job.id}")
 
 

--- a/flow_atelier/cli/commands/scheduler.py
+++ b/flow_atelier/cli/commands/scheduler.py
@@ -59,9 +59,8 @@ def scheduler_start_cmd(
     "status",
     help=(
         "List schedules and their next fire times. "
-        "Reads the project and global schedules dirs directly — does NOT "
-        "contact a running daemon. To confirm the daemon is alive, check "
-        "the process."
+        "Reads .atelier/schedules/ directly — does NOT contact a running "
+        "daemon. To confirm the daemon is alive, check the process."
     ),
 )
 def scheduler_status_cmd(

--- a/flow_atelier/cli/commands/scheduler.py
+++ b/flow_atelier/cli/commands/scheduler.py
@@ -59,8 +59,9 @@ def scheduler_start_cmd(
     "status",
     help=(
         "List schedules and their next fire times. "
-        "Reads .atelier/schedules/ directly — does NOT contact a running "
-        "daemon. To confirm the daemon is alive, check the process."
+        "Reads the project and global schedules dirs directly — does NOT "
+        "contact a running daemon. To confirm the daemon is alive, check "
+        "the process."
     ),
 )
 def scheduler_status_cmd(

--- a/flow_atelier/cli/commands/serve.py
+++ b/flow_atelier/cli/commands/serve.py
@@ -75,17 +75,26 @@ def serve_cmd(
         }
         scheduled_atelier = Atelier(base_dir=settings.global_atelier_dir)
         captured: dict[str, str | None] = {"flow_id": None}
+        # Strong references for fire-and-forget broadcasts — the loop keeps
+        # only a weak reference to a bare create_task, which can be GC'd
+        # mid-flight and drop the envelope.
+        pending: set[asyncio.Task] = set()
+
+        def _spawn(coro) -> None:
+            task = asyncio.create_task(coro)
+            pending.add(task)
+            task.add_done_callback(pending.discard)
 
         def _on_started(flow_id: str) -> None:
             captured["flow_id"] = flow_id
-            asyncio.create_task(
+            _spawn(
                 bus.broadcast(
                     {"type": "scheduled_run_started", "flow_id": flow_id, **base}
                 )
             )
 
         def _on_task_event(event: TaskEvent) -> None:
-            asyncio.create_task(
+            _spawn(
                 bus.broadcast(
                     {
                         "type": "scheduled_task_event",

--- a/flow_atelier/cli/commands/serve.py
+++ b/flow_atelier/cli/commands/serve.py
@@ -63,12 +63,7 @@ def serve_cmd(
     bus = SchedulerEventBus()
     atelier.scheduler_bus = bus  # type: ignore[attr-defined]
 
-    # Read both the project and global schedule dirs so a schedule installed
-    # via `atelier schedule add` (project) is seen by the embedded daemon,
-    # which previously read the global dir only.
-    schedule_store = ScheduleStore(
-        settings.atelier_dir, global_dir=settings.global_atelier_dir
-    )
+    global_schedule_store = ScheduleStore(settings.global_atelier_dir)
 
     async def _broadcasting_executor(job: ScheduledJob, working_dir: Path) -> None:
         """Run the conduit and fan lifecycle envelopes out to the bus."""
@@ -133,7 +128,7 @@ def serve_cmd(
         )
 
     daemon = SchedulerDaemon(
-        schedule_store,
+        global_schedule_store,
         executor=_broadcasting_executor,
         default_zone=default_local_zone(),
         default_working_dir=Path.cwd(),

--- a/flow_atelier/cli/commands/serve.py
+++ b/flow_atelier/cli/commands/serve.py
@@ -63,7 +63,12 @@ def serve_cmd(
     bus = SchedulerEventBus()
     atelier.scheduler_bus = bus  # type: ignore[attr-defined]
 
-    global_schedule_store = ScheduleStore(settings.global_atelier_dir)
+    # Read both the project and global schedule dirs so a schedule installed
+    # via `atelier schedule add` (project) is seen by the embedded daemon,
+    # which previously read the global dir only.
+    schedule_store = ScheduleStore(
+        settings.atelier_dir, global_dir=settings.global_atelier_dir
+    )
 
     async def _broadcasting_executor(job: ScheduledJob, working_dir: Path) -> None:
         """Run the conduit and fan lifecycle envelopes out to the bus."""
@@ -128,7 +133,7 @@ def serve_cmd(
         )
 
     daemon = SchedulerDaemon(
-        global_schedule_store,
+        schedule_store,
         executor=_broadcasting_executor,
         default_zone=default_local_zone(),
         default_working_dir=Path.cwd(),

--- a/flow_atelier/cli/commands/status.py
+++ b/flow_atelier/cli/commands/status.py
@@ -16,6 +16,7 @@ from flow_atelier.cli._shared import (
 from flow_atelier.cli.main import app
 from flow_atelier.cli.rendering.render import _FLOW_STATUS_STYLE, _task_status_summary
 from flow_atelier.core.atelier import Atelier
+from flow_atelier.modules.liveness import display_status, is_crashed
 
 
 @app.command("status")
@@ -42,18 +43,22 @@ def status_cmd(
         payload = progress.model_dump(mode="json")
         payload["flow_id"] = flow_id
         payload["duration_seconds"] = _flow_duration_seconds(progress)
+        payload["crashed"] = is_crashed(progress)
         typer.echo(json.dumps(payload, indent=2))
         return
 
-    flow_status_style = _FLOW_STATUS_STYLE.get(progress.status.value, "white")
+    effective = display_status(progress)
+    flow_status_style = _FLOW_STATUS_STYLE.get(effective, "white")
     duration = _flow_duration_seconds(progress)
     header = (
         f"[bold]flow[/bold] {flow_id}  "
-        f"status=[{flow_status_style}]{progress.status.value}[/{flow_status_style}]  "
+        f"status=[{flow_status_style}]{effective}[/{flow_status_style}]  "
         f"started={_format_clock(progress.started_at)}  "
         f"duration={_format_duration_seconds(duration)}"
     )
     console.print(header)
+    if is_crashed(progress):
+        console.print(f"[dim]→ atelier run --resume {flow_id}[/dim]")
 
     show_iteration = any(tp.of > 1 for tp in progress.tasks.values())
     columns = ["task", "status"]

--- a/flow_atelier/cli/main.py
+++ b/flow_atelier/cli/main.py
@@ -71,6 +71,7 @@ from flow_atelier.cli.commands import (  # noqa: E402, F401
     check,
     init,
     logs,
+    rm,
     run,
     schedule,
     scheduler,

--- a/flow_atelier/cli/main.py
+++ b/flow_atelier/cli/main.py
@@ -68,6 +68,7 @@ app.add_typer(scheduler_app, name="scheduler")
 # the appropriate Typer instance above. Order matches the original
 # decoration order in app/main.py so --help layout stays byte-identical.
 from flow_atelier.cli.commands import (  # noqa: E402, F401
+    check,
     init,
     logs,
     run,

--- a/flow_atelier/cli/rendering/render.py
+++ b/flow_atelier/cli/rendering/render.py
@@ -249,6 +249,7 @@ _FLOW_STATUS_STYLE: dict[str, str] = {
     FlowStatus.completed.value: "green",
     FlowStatus.failed.value: "red",
     FlowStatus.running.value: "yellow",
+    "crashed": "magenta",
 }
 
 _TASK_STATUS_GLYPHS: list[tuple[TaskStatus, str, str]] = [

--- a/flow_atelier/cli/rendering/render.py
+++ b/flow_atelier/cli/rendering/render.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from collections import Counter
 
+import yaml
+from pydantic import ValidationError
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -365,6 +367,51 @@ def _render_log_entry(entry, show: str, console: Console) -> None:
             padding=(0, 1),
         )
     )
+
+
+def _format_error_loc(loc: tuple[object, ...]) -> str:
+    """Render a pydantic error ``loc`` tuple as e.g. ``tasks[2].tool``.
+
+    Integer elements become ``[i]`` (list indices); string elements become
+    ``.key`` (field names). The leading dot is stripped.
+
+    :param loc: the ``loc`` tuple from a pydantic error dict.
+    """
+    out = ""
+    for part in loc:
+        out += f"[{part}]" if isinstance(part, int) else f".{part}"
+    return out.lstrip(".")
+
+
+def format_conduit_error(exc: Exception) -> str:
+    """Translate a conduit-load failure into one compact, plain-text line.
+
+    Covers the failure modes ``read_conduit`` surfaces: pydantic
+    ``ValidationError`` (rendered as ``field.path: message``, first error only),
+    ``yaml.YAMLError`` (with a line number when the mark is available), and any
+    other error — notably the ``ValueError`` raised for a wrapped YAML parse
+    error or a conduit-name/folder mismatch. Returns plain text with no Rich
+    markup; callers add color and escape it.
+
+    :param exc: the exception raised while loading a conduit.
+    """
+    if isinstance(exc, ValidationError):
+        errors = exc.errors()
+        if not errors:
+            return " ".join(str(exc).split())
+        first = errors[0]
+        path = _format_error_loc(tuple(first.get("loc", ())))
+        msg = first.get("msg", "")
+        text = f"{path}: {msg}" if path else msg
+        if len(errors) > 1:
+            text += f" (+{len(errors) - 1} more)"
+        return " ".join(text.split())
+    if isinstance(exc, yaml.YAMLError):
+        problem = getattr(exc, "problem", None)
+        mark = getattr(exc, "problem_mark", None)
+        if problem and mark is not None:
+            return f"invalid YAML: {problem} (line {mark.line + 1})"
+    return " ".join(str(exc).split())
 
 
 def _render_planned_table(planned: list[PlannedJob]) -> Table:

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -343,9 +343,16 @@ class Atelier:
     def create_schedule(self, payload: CreateScheduleInput) -> ScheduledJob:
         """Persist a new schedule and return it.
 
+        Validates that ``conduit_name`` resolves to a known conduit (in the
+        same store the fire will use), so a typo fails loudly here instead of
+        silently at fire time via a swallowed exception.
+
         :param payload: validated :class:`CreateScheduleInput`
         :returns: the new :class:`ScheduledJob`
+        :raises ValueError: if ``conduit_name`` is not a known conduit
         """
+        if payload.conduit_name not in self.store.list_conduits():
+            raise ValueError(f"unknown conduit: {payload.conduit_name!r}")
         return self.schedule_store.create(payload)
 
     def delete_schedule(self, schedule_id: str) -> ScheduledJob:

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -408,12 +408,34 @@ class Atelier:
             logs.extend(tagged)
         return logs
 
+    def _known_run_paths(self) -> set[Path]:
+        """Return the resolved ``run_path`` of every known flow.
+
+        :returns: set of resolved run-path directories recorded in flow inputs.
+        """
+        known: set[Path] = set()
+        for flow_id in self.store.list_flows():
+            try:
+                rp = self.store.read_input(flow_id).get("run_path")
+            except (FileNotFoundError, ValueError):
+                continue
+            if rp:
+                known.add(Path(rp).resolve())
+        return known
+
     def open_conduit_path(self, run_path: str) -> bool:
         """Reveal ``run_path`` in the host's file explorer.
+
+        Only paths recorded as a flow's ``run_path`` are opened: the OS opener
+        can launch arbitrary apps/documents, so an unconstrained caller (the
+        default deployment has no token) must not be able to point it anywhere.
 
         :param run_path: absolute path to open
         :returns: True if the platform opener was launched, False otherwise
         """
+        if Path(run_path).resolve() not in self._known_run_paths():
+            logger.warning("open_conduit_path refused unknown path: %s", run_path)
+            return False
         target = str(Path(run_path))
         cmd: list[str]
         if sys.platform == "darwin":

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -128,6 +128,35 @@ class Atelier:
         )
         self.schedule_store = ScheduleStore(self.settings.atelier_dir)
 
+    def tool_readiness(self, conduit: Conduit) -> list[str]:
+        """Report why a conduit can't run, before any task executes.
+
+        Walks ``conduit.tasks`` and, for each, confirms its tool is registered
+        and its executor's :meth:`ExecutorBase.is_available` probe passes (e.g.
+        a harness CLI present on PATH). This is the preflight gate used by
+        ``atelier check`` and the top of ``atelier run`` so an unrunnable
+        conduit fails in second one rather than mid-DAG. Structural validation
+        stays in :func:`validate_conduit`; this layer owns runnability because
+        it is the only one holding both the conduit and the executor registry.
+
+        :param conduit: the loaded conduit to probe.
+        :returns: ordered, de-duplicated problem messages; ``[]`` when ready.
+        """
+        problems: list[str] = []
+        for task in conduit.tasks:
+            tool = task.tool.value
+            executor = self.executors.get(tool)
+            if executor is None:
+                msg = f"task {task.name!r}: no executor registered for tool {tool!r}"
+            else:
+                ok, reason = executor.is_available()
+                if ok:
+                    continue
+                msg = f"task {task.name!r} [{tool}]: {reason}"
+            if msg not in problems:
+                problems.append(msg)
+        return problems
+
     async def run_conduit(
         self,
         name: str,

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -126,10 +126,7 @@ class Atelier:
             loop_history_limit=self.settings.loop_history_limit,
             loop_history_entry_chars=self.settings.loop_history_entry_chars,
         )
-        self.schedule_store = ScheduleStore(
-            self.settings.atelier_dir,
-            global_dir=self.settings.global_atelier_dir,
-        )
+        self.schedule_store = ScheduleStore(self.settings.atelier_dir)
 
     async def run_conduit(
         self,

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -126,7 +126,10 @@ class Atelier:
             loop_history_limit=self.settings.loop_history_limit,
             loop_history_entry_chars=self.settings.loop_history_entry_chars,
         )
-        self.schedule_store = ScheduleStore(self.settings.atelier_dir)
+        self.schedule_store = ScheduleStore(
+            self.settings.atelier_dir,
+            global_dir=self.settings.global_atelier_dir,
+        )
 
     async def run_conduit(
         self,

--- a/flow_atelier/core/atelier.py
+++ b/flow_atelier/core/atelier.py
@@ -289,6 +289,14 @@ class Atelier:
         """
         return self.store.delete_conduit(name)
 
+    def delete_flow(self, flow_id: str) -> bool:
+        """Remove a flow directory and its nested child subtree.
+
+        :param flow_id: flow identifier
+        :returns: True if it existed and was deleted, False otherwise
+        """
+        return self.store.delete_flow(flow_id)
+
     async def run_single_task(self, payload: RunTaskInput) -> RunTaskOutput:
         """Run an ad-hoc one-task conduit and return the resulting logs.
 

--- a/flow_atelier/modules/conditions.py
+++ b/flow_atelier/modules/conditions.py
@@ -22,6 +22,16 @@ _NOT_MATCH_MARKER = ".output.not_match("
 _OUTPUT_MATCH_PREFIX = "output.match("
 _OUTPUT_NOT_MATCH_PREFIX = "output.not_match("
 
+# Task names share the schema grammar (see schemas.conduit._TASK_NAME_RE).
+# ``.isalnum()`` would also accept Unicode letters/digits, so a dependency
+# string could be accepted that no schema-valid task name could ever match.
+_TASK_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+# Author regexes are matched against task/agent output on the shared event
+# loop. Bounding the candidate length caps the work an adversarial *output*
+# (matched by an otherwise-benign author regex) can impose before matching.
+MATCH_INPUT_CHAR_CAP = 1_000_000
+
 
 @dataclass(frozen=True)
 class PlainDependency:
@@ -68,7 +78,7 @@ def parse_dependency(dep: str) -> Dependency:
         if idx == -1:
             continue
         task = dep[:idx]
-        if not task or not task.replace("_", "").isalnum():
+        if not _TASK_NAME_RE.match(task):
             raise DependencyParseError(f"invalid task name in dependency: {dep!r}")
         rest = dep[idx + len(marker):]
         if not rest.endswith(")"):
@@ -85,7 +95,7 @@ def parse_dependency(dep: str) -> Dependency:
         return ConditionalDependency(task=task, pattern=pattern, negate=negate)
 
     # plain dependency — must be a bare task name
-    if not dep.replace("_", "").isalnum():
+    if not _TASK_NAME_RE.match(dep):
         raise DependencyParseError(f"invalid dependency syntax: {dep!r}")
     return PlainDependency(task=dep)
 
@@ -188,7 +198,9 @@ def evaluate_loop_predicate(
     if not outputs:
         return False
     pattern, negate = predicate
-    matches = [pattern.search(out) is not None for out in outputs]
+    matches = [
+        pattern.search(out[:MATCH_INPUT_CHAR_CAP]) is not None for out in outputs
+    ]
     any_match = any(matches)
     if mode == "until":
         return (not any_match) if negate else any_match
@@ -235,7 +247,7 @@ def evaluate(
 
     assert isinstance(dep, ConditionalDependency)
     output = outputs.get(dep.task, "")
-    match = dep.regex().search(output)
+    match = dep.regex().search(output[:MATCH_INPUT_CHAR_CAP])
     ok = (match is None) if dep.negate else (match is not None)
     if ok:
         return "satisfied", None

--- a/flow_atelier/modules/conditions.py
+++ b/flow_atelier/modules/conditions.py
@@ -10,6 +10,7 @@ and the *last* `)` in the string — no quoting required.
 """
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass
 from typing import Literal
@@ -27,10 +28,27 @@ _OUTPUT_NOT_MATCH_PREFIX = "output.not_match("
 # string could be accepted that no schema-valid task name could ever match.
 _TASK_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
-# Author regexes are matched against task/agent output on the shared event
-# loop. Bounding the candidate length caps the work an adversarial *output*
-# (matched by an otherwise-benign author regex) can impose before matching.
+# Author regexes are matched against task/agent output. Bounding the candidate
+# length caps the work an adversarial *output* (matched by an otherwise-benign
+# author regex) can impose before matching.
 MATCH_INPUT_CHAR_CAP = 1_000_000
+
+
+async def _search_off_loop(pattern: re.Pattern[str], text: str) -> re.Match[str] | None:
+    """Run ``pattern.search`` on a worker thread, off the event loop.
+
+    Author regexes evaluate against agent/bash output while the engine runs
+    flows concurrently on one event loop. A catastrophic-backtracking pattern
+    (or a benign pattern against adversarial output) is CPU-bound and would
+    otherwise block every concurrent flow, HITL prompt, and WS send for its
+    whole duration. Running it via :func:`asyncio.to_thread` keeps the loop
+    responsive; the input is first capped at :data:`MATCH_INPUT_CHAR_CAP`.
+
+    :param pattern: compiled regex to evaluate.
+    :param text: candidate output (truncated before matching).
+    :returns: the :class:`re.Match` or ``None``.
+    """
+    return await asyncio.to_thread(pattern.search, text[:MATCH_INPUT_CHAR_CAP])
 
 
 @dataclass(frozen=True)
@@ -164,7 +182,7 @@ def parse_output_predicate(expr: str) -> tuple[re.Pattern[str], bool]:
 LoopMode = Literal["until", "while"]
 
 
-def evaluate_loop_predicate(
+async def evaluate_loop_predicate(
     predicate: tuple[re.Pattern[str], bool],
     outputs: list[str],
     mode: LoopMode,
@@ -199,7 +217,7 @@ def evaluate_loop_predicate(
         return False
     pattern, negate = predicate
     matches = [
-        pattern.search(out[:MATCH_INPUT_CHAR_CAP]) is not None for out in outputs
+        (await _search_off_loop(pattern, out)) is not None for out in outputs
     ]
     any_match = any(matches)
     if mode == "until":
@@ -211,7 +229,7 @@ def evaluate_loop_predicate(
 EvalResult = Literal["satisfied", "wait", "skip"]
 
 
-def evaluate(
+async def evaluate(
     dep: Dependency,
     statuses: dict[str, TaskStatus],
     outputs: dict[str, str],
@@ -247,7 +265,7 @@ def evaluate(
 
     assert isinstance(dep, ConditionalDependency)
     output = outputs.get(dep.task, "")
-    match = dep.regex().search(output[:MATCH_INPUT_CHAR_CAP])
+    match = await _search_off_loop(dep.regex(), output)
     ok = (match is None) if dep.negate else (match is not None)
     if ok:
         return "satisfied", None

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -718,7 +718,7 @@ class Engine:
                                 # iterations via {{loop.history}} and
                                 # false-positive the predicate.
                                 scope_outputs = [last_output]
-                            if evaluate_loop_predicate(
+                            if await evaluate_loop_predicate(
                                 loop_predicate, scope_outputs, loop_mode
                             ):
                                 predicate_matched = True
@@ -768,7 +768,7 @@ class Engine:
                     decision = "satisfied"
                     skip_reason: str | None = None
                     for d in deps:
-                        r, reason = evaluate(d, statuses, outputs)
+                        r, reason = await evaluate(d, statuses, outputs)
                         if r == "skip":
                             decision = "skip"
                             skip_reason = reason

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import socket
 import sys
 import traceback
 from collections.abc import Callable
@@ -324,6 +326,8 @@ class Engine:
                 for t in conduit.tasks
             },
             started_at=_now(),
+            runner_pid=os.getpid(),
+            runner_host=socket.gethostname(),
         )
         self.store.write_progress(flow_id, progress)
 

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -626,57 +626,71 @@ class Engine:
                                     )
                                 return
                         mark_running(t.name, iteration, start_iteration)
-                        started = _now()
-                        start_ts = datetime.now(UTC)
-                        try:
-                            # Grace margin: executors that self-enforce
-                            # ctx.timeout (bash, harness) return a graceful
-                            # result preserving output; this outer wrapper is
-                            # the backstop for those that don't, and must not
-                            # win the race against them. HITL is exempt: a
-                            # human stepping away is not a timeout.
-                            result = await asyncio.wait_for(
-                                executor.execute(t, resolved, ctx),
-                                timeout=(
-                                    None
-                                    if is_hitl
-                                    else conduit.timeout + BACKSTOP_GRACE_SECONDS
+                        # A transient non-zero exit is re-attempted in place up
+                        # to `retries` extra times before tripping fail-fast.
+                        # HITL is exempt: a human declining a prompt is not a
+                        # transient failure, so it never auto-retries.
+                        max_attempts = 1 if is_hitl else 1 + t.retries
+                        for attempt in range(1, max_attempts + 1):
+                            started = _now()
+                            start_ts = datetime.now(UTC)
+                            try:
+                                # Grace margin: executors that self-enforce
+                                # ctx.timeout (bash, harness) return a graceful
+                                # result preserving output; this outer wrapper is
+                                # the backstop for those that don't, and must not
+                                # win the race against them. HITL is exempt: a
+                                # human stepping away is not a timeout.
+                                result = await asyncio.wait_for(
+                                    executor.execute(t, resolved, ctx),
+                                    timeout=(
+                                        None
+                                        if is_hitl
+                                        else conduit.timeout + BACKSTOP_GRACE_SECONDS
+                                    ),
+                                )
+                            except TimeoutError:
+                                result = ExecutionResult(
+                                    exit_code=124,
+                                    stderr=f"engine timeout after {conduit.timeout}s",
+                                )
+                            except Exception as exc:  # noqa: BLE001
+                                result = ExecutionResult(
+                                    exit_code=1, stderr=f"{type(exc).__name__}: {exc}"
+                                )
+                            finished = _now()
+                            duration = (
+                                datetime.now(UTC) - start_ts
+                            ).total_seconds()
+                            await self.store.append_log(
+                                flow_id,
+                                LogEntry(
+                                    task=t.name,
+                                    tool=t.tool.value,
+                                    iteration=iteration,
+                                    of=t.repeat,
+                                    command=resolved,
+                                    stdout=result.stdout,
+                                    stderr=result.stderr,
+                                    exit_code=result.exit_code,
+                                    output=result.output,
+                                    last_turn_output=result.last_turn_output,
+                                    started_at=started,
+                                    finished_at=finished,
+                                    duration_seconds=round(duration, 3),
+                                    extra={
+                                        "attempt": attempt,
+                                        "of_attempts": max_attempts,
+                                    },
+                                    steps=result.steps,
                                 ),
                             )
-                        except TimeoutError:
-                            result = ExecutionResult(
-                                exit_code=124,
-                                stderr=f"engine timeout after {conduit.timeout}s",
-                            )
-                        except Exception as exc:  # noqa: BLE001
-                            result = ExecutionResult(
-                                exit_code=1, stderr=f"{type(exc).__name__}: {exc}"
-                            )
-                        finished = _now()
-                        duration = (
-                            datetime.now(UTC) - start_ts
-                        ).total_seconds()
-                        await self.store.append_log(
-                            flow_id,
-                            LogEntry(
-                                task=t.name,
-                                tool=t.tool.value,
-                                iteration=iteration,
-                                of=t.repeat,
-                                command=resolved,
-                                stdout=result.stdout,
-                                stderr=result.stderr,
-                                exit_code=result.exit_code,
-                                output=result.output,
-                                last_turn_output=result.last_turn_output,
-                                started_at=started,
-                                finished_at=finished,
-                                duration_seconds=round(duration, 3),
-                                steps=result.steps,
-                            ),
-                        )
-                        emit_event(t, iteration, result, duration)
-                        if not result.success:
+                            emit_event(t, iteration, result, duration)
+                            if result.success:
+                                break
+                            if attempt < max_attempts:
+                                await asyncio.sleep(t.retry_backoff)
+                                continue
                             mark_failed(t.name)
                             if not failed:
                                 failed = True

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -34,7 +34,7 @@ from flow_atelier.modules.conditions import (
 from flow_atelier.modules.templating import (
     SkipSignal,
     TemplateError,
-    extract_task_refs,
+    extract_template_refs,
     resolve,
 )
 from flow_atelier.schemas.conduit import Conduit, TaskDefinition, ToolType
@@ -136,16 +136,36 @@ def validate_conduit(conduit: Conduit) -> dict[str, list]:
 
     for t in conduit.tasks:
         allowed = reachable(t.name)
-        for ref in sorted(extract_task_refs(t.task)):
-            if ref not in task_names:
-                raise ConduitValidationError(
-                    f"task {t.name!r} references unknown task {ref!r}"
-                )
-            if ref not in allowed:
-                raise ConduitValidationError(
-                    f"task {t.name!r} references {ref!r} which is not in its "
-                    f"depends_on chain; add it as a dependency"
-                )
+        targets = [t.task]
+        if t.tool == ToolType.conduit:
+            targets += [v for v in t.inputs.values() if isinstance(v, str)]
+        for template in targets:
+            for ref in extract_template_refs(template):
+                if ref.kind == "task":
+                    if ref.value not in task_names:
+                        raise ConduitValidationError(
+                            f"task {t.name!r} references unknown task "
+                            f"{ref.value!r}"
+                        )
+                    if ref.value not in allowed:
+                        raise ConduitValidationError(
+                            f"task {t.name!r} references {ref.value!r} which is "
+                            f"not in its depends_on chain; add it as a dependency"
+                        )
+                elif ref.kind == "loop":
+                    if t.repeat <= 1:
+                        raise ConduitValidationError(
+                            f"task {t.name!r} uses {{{{{ref.raw}}}}} but does "
+                            f"not loop (repeat is 1); loop.* is only available "
+                            f"when repeat > 1"
+                        )
+                elif ref.kind == "unknown":
+                    raise ConduitValidationError(
+                        f"task {t.name!r} has an unrecognized template "
+                        f"expression {{{{{ref.raw}}}}}"
+                    )
+                # ref.kind == "input": not validated — inputs may be supplied
+                # at run time via --input or HITL, so they need not be declared.
 
     return parsed
 

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -662,6 +662,14 @@ class Engine:
                             duration = (
                                 datetime.now(UTC) - start_ts
                             ).total_seconds()
+                            # Only stamp attempt metadata when retries are
+                            # actually in play; with no retries the log entry
+                            # stays byte-for-byte identical to pre-retry behavior.
+                            attempt_extra = (
+                                {"attempt": attempt, "of_attempts": max_attempts}
+                                if max_attempts > 1
+                                else {}
+                            )
                             await self.store.append_log(
                                 flow_id,
                                 LogEntry(
@@ -678,10 +686,7 @@ class Engine:
                                     started_at=started,
                                     finished_at=finished,
                                     duration_seconds=round(duration, 3),
-                                    extra={
-                                        "attempt": attempt,
-                                        "of_attempts": max_attempts,
-                                    },
+                                    extra=attempt_extra,
                                     steps=result.steps,
                                 ),
                             )

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -70,7 +70,7 @@ _current_task_ctx: ContextVar[str] = ContextVar("current_task_name", default="")
 _current_flow_ctx: ContextVar[str] = ContextVar("current_flow_id", default="")
 
 
-def _validate_dag(conduit: Conduit) -> dict[str, list]:
+def validate_conduit(conduit: Conduit) -> dict[str, list]:
     """Return {task_name: [parsed deps]}. Raises on cycle/unknown/invalid regex.
 
     :param conduit: parsed conduit whose tasks/dependencies to validate.
@@ -231,7 +231,7 @@ class Engine:
         if missing:
             raise ValueError(f"missing required inputs: {missing}")
 
-        parsed_deps = _validate_dag(conduit)
+        parsed_deps = validate_conduit(conduit)
 
         if resume_from is not None:
             flow_id = resume_from

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -564,12 +564,18 @@ class Engine:
                         )
                     return
 
+                # An explicit per-task timeout supersedes the conduit-wide
+                # ceiling for this task only; None inherits conduit.timeout.
+                effective_timeout = (
+                    t.timeout if t.timeout is not None else conduit.timeout
+                )
+
                 ctx = FlowContext(
                     flow_id=flow_id,
                     store=self.store,
                     inputs=runtime_inputs,
                     task_outputs=outputs,
-                    timeout=conduit.timeout,
+                    timeout=effective_timeout,
                     working_dir=working_dir,
                     show_steps=show_steps,
                     run_nested_conduit=self._make_nested_runner(
@@ -646,13 +652,13 @@ class Engine:
                                     timeout=(
                                         None
                                         if is_hitl
-                                        else conduit.timeout + BACKSTOP_GRACE_SECONDS
+                                        else effective_timeout + BACKSTOP_GRACE_SECONDS
                                     ),
                                 )
                             except TimeoutError:
                                 result = ExecutionResult(
                                     exit_code=124,
-                                    stderr=f"engine timeout after {conduit.timeout}s",
+                                    stderr=f"engine timeout after {effective_timeout}s",
                                 )
                             except Exception as exc:  # noqa: BLE001
                                 result = ExecutionResult(

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -40,13 +40,13 @@ from flow_atelier.modules.templating import (
 from flow_atelier.schemas.conduit import Conduit, TaskDefinition, ToolType
 from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.log import ExecutionResult, LogEntry, TaskEvent
+from flow_atelier.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
+from flow_atelier.services.executor.base import ExecutorBase, FlowContext
+from flow_atelier.services.store.base import StoreBase
 
 TaskEventCallback = Callable[[TaskEvent], None]
 FlowStartedCallback = Callable[[str], None]
 TaskStartingCallback = Callable[[str, str], None]
-from flow_atelier.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
-from flow_atelier.services.executor.base import ExecutorBase, FlowContext
-from flow_atelier.services.store.base import StoreBase
 
 
 class ConduitValidationError(ValueError):

--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -37,7 +37,12 @@ from flow_atelier.modules.templating import (
     extract_template_refs,
     resolve,
 )
-from flow_atelier.schemas.conduit import Conduit, TaskDefinition, ToolType
+from flow_atelier.schemas.conduit import (
+    _CONDUIT_NAME_RE,
+    Conduit,
+    TaskDefinition,
+    ToolType,
+)
 from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.log import ExecutionResult, LogEntry, TaskEvent
 from flow_atelier.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
@@ -53,9 +58,17 @@ class ConduitValidationError(ValueError):
     pass
 
 
+class ConduitCycleError(ConduitValidationError):
+    """Raised when nested ``tool:conduit`` runs form a cycle or exceed depth."""
+
+
 # Margin added to conduit.timeout for the engine's backstop wait_for, so
 # executors that self-enforce ctx.timeout always finish gracefully first.
 BACKSTOP_GRACE_SECONDS = 5
+
+# Hard ceiling on nested tool:conduit recursion as a backstop for chains
+# that are acyclic-by-name yet still pathologically deep.
+MAX_NESTED_CONDUIT_DEPTH = 25
 
 
 def _now() -> str:
@@ -135,6 +148,19 @@ def validate_conduit(conduit: Conduit) -> dict[str, list]:
         return closure[name]
 
     for t in conduit.tasks:
+        # A literal tool:conduit target becomes a single filesystem path
+        # component at read time; reject traversal at author time. Templated
+        # targets are skipped here (resolved/validated at run time).
+        if (
+            t.tool == ToolType.conduit
+            and "{{" not in t.task
+            and not _CONDUIT_NAME_RE.match(t.task.strip())
+        ):
+            raise ConduitValidationError(
+                f"task {t.name!r}: tool:conduit target {t.task!r} is not a valid "
+                "conduit name (letters, digits, '_' and '-' only)"
+            )
+
         allowed = reachable(t.name)
         targets = [t.task]
         if t.tool == ToolType.conduit:
@@ -212,6 +238,7 @@ class Engine:
         working_dir: Path | None = None,
         flow_id: str | None = None,
         resume_from: str | None = None,
+        ancestor_conduits: tuple[str, ...] = (),
     ) -> str:
         """Execute a conduit to completion, returning the flow id.
 
@@ -233,11 +260,27 @@ class Engine:
             store generates one. Ignored when ``resume_from`` is set.
         :param resume_from: flow id of a prior failed run to resume; skips
             already-completed tasks and reuses their persisted outputs.
+        :param ancestor_conduits: names of the conduits already on the nested
+            ``tool:conduit`` call stack above this run; used to detect cycles
+            and bound recursion depth. Empty for a top-level run.
         :returns: the new flow id on success
         :raises ConduitValidationError: DAG is invalid (cycle, unknown dep, bad regex)
+        :raises ConduitCycleError: nested conduits form a cycle or exceed depth
         :raises ValueError: required inputs are missing
         :raises Exception: first task failure propagates after fail-fast cancel
         """
+        # Guard nested tool:conduit recursion before any flow dir is created:
+        # a self- or mutually-referential conduit would otherwise recurse
+        # until the host exhausts the stack or the disk fills.
+        if conduit.name in ancestor_conduits:
+            chain = " -> ".join((*ancestor_conduits, conduit.name))
+            raise ConduitCycleError(f"nested conduit cycle detected: {chain}")
+        if len(ancestor_conduits) >= MAX_NESTED_CONDUIT_DEPTH:
+            chain = " -> ".join((*ancestor_conduits, conduit.name))
+            raise ConduitCycleError(
+                f"nested conduit depth exceeded {MAX_NESTED_CONDUIT_DEPTH}: {chain}"
+            )
+
         # Apply declared defaults, then require inputs that have none.
         inputs = {
             **{
@@ -531,6 +574,7 @@ class Engine:
                         on_task_starting=on_task_starting,
                         show_steps=show_steps,
                         working_dir=working_dir,
+                        ancestor_conduits=(*ancestor_conduits, conduit.name),
                     ),
                     loop_history=loop_history,
                     loop_history_limit=self.loop_history_limit,
@@ -857,6 +901,7 @@ class Engine:
         on_task_starting: TaskStartingCallback | None = None,
         show_steps: bool = True,
         working_dir: Path | None = None,
+        ancestor_conduits: tuple[str, ...] = (),
     ):
         """Build the nested-conduit runner passed to executors via FlowContext.
 
@@ -865,6 +910,8 @@ class Engine:
         :param on_task_starting: optional task-starting callback forwarded to the child.
         :param show_steps: whether the nested run should surface per-step progress.
         :param working_dir: working directory forwarded to nested runs.
+        :param ancestor_conduits: conduit names already on the nested-run stack,
+            forwarded to each child run so cycles/depth are caught.
         :returns: an async callable ``(conduit_name, child_inputs, parent_flow_id)``
             that loads and runs the named child conduit.
         """
@@ -891,6 +938,7 @@ class Engine:
                     on_task_starting=on_task_starting,
                     show_steps=show_steps,
                     working_dir=working_dir,
+                    ancestor_conduits=ancestor_conduits,
                 )
 
             return await self.run(
@@ -902,6 +950,7 @@ class Engine:
                 on_task_starting=on_task_starting,
                 show_steps=show_steps,
                 working_dir=working_dir,
+                ancestor_conduits=ancestor_conduits,
             )
 
         return _run_nested

--- a/flow_atelier/modules/liveness.py
+++ b/flow_atelier/modules/liveness.py
@@ -1,0 +1,50 @@
+"""Derive a ``crashed`` display sense for flows whose runner process died.
+
+A flow that is hard-killed (SIGKILL, OOM, reboot, lid-close) never runs the
+engine's failure handler, so its ``progress.json`` stays frozen at
+``status: running`` forever. These helpers reclassify such a flow as
+``crashed`` for display only — never mutating the persisted status — and only
+when the runner is *provably* dead on this same host. Every uncertain case
+(foreign host, missing pid, live pid, permission error) stays ``running``, so a
+genuinely-live or remote flow is never false-accused.
+"""
+from __future__ import annotations
+
+import os
+import socket
+
+from flow_atelier.schemas.progress import FlowStatus, Progress
+
+
+def is_crashed(progress: Progress) -> bool:
+    """Return True only when a ``running`` flow's local runner is provably dead.
+
+    :param progress: the flow's progress snapshot.
+    :returns: True iff status is ``running``, the runner pid/host are recorded,
+        the host matches this machine, and ``os.kill(pid, 0)`` proves the pid
+        is gone. Any other case returns False (treated as still running).
+    """
+    if progress.status != FlowStatus.running:
+        return False
+    if progress.runner_pid is None:
+        return False
+    if progress.runner_host != socket.gethostname():
+        return False
+    try:
+        os.kill(progress.runner_pid, 0)
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError):
+        # Pid exists (possibly owned by another user) or the probe failed for
+        # another reason — stay conservative and report still running.
+        return False
+    return False
+
+
+def display_status(progress: Progress) -> str:
+    """Return the display status string, mapping a dead runner to ``crashed``.
+
+    :param progress: the flow's progress snapshot.
+    :returns: ``"crashed"`` when :func:`is_crashed`, else the raw status value.
+    """
+    return "crashed" if is_crashed(progress) else progress.status.value

--- a/flow_atelier/modules/templating.py
+++ b/flow_atelier/modules/templating.py
@@ -14,7 +14,7 @@ Rules:
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 _TEMPLATE_RE = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
 
@@ -75,6 +75,37 @@ def extract_task_refs(template: str) -> set[str]:
             continue
         if expr.endswith(".output"):
             refs.add(expr[: -len(".output")])
+    return refs
+
+
+class TemplateRef(NamedTuple):
+    """One ``{{...}}`` expression classified against the resolve grammar."""
+
+    kind: str   # "input" | "loop" | "task" | "unknown"
+    value: str  # input name / loop expr / task name / raw expr
+    raw: str    # original expression, for error messages
+
+
+def extract_template_refs(template: str) -> list[TemplateRef]:
+    """Classify every ``{{...}}`` expression in ``template``.
+
+    Mirrors :func:`resolve`'s check order exactly so validation and runtime
+    never disagree on what a template expression means.
+
+    :param template: the raw task/template string to scan.
+    :returns: refs in source-appearance order (may be empty).
+    """
+    refs: list[TemplateRef] = []
+    for match in _TEMPLATE_RE.finditer(template):
+        expr = match.group(1).strip()
+        if expr.startswith("inputs."):
+            refs.append(TemplateRef("input", expr[len("inputs."):], expr))
+        elif expr in ("loop.previous", "loop.history"):
+            refs.append(TemplateRef("loop", expr, expr))
+        elif expr.endswith(".output"):
+            refs.append(TemplateRef("task", expr[: -len(".output")], expr))
+        else:
+            refs.append(TemplateRef("unknown", expr, expr))
     return refs
 
 

--- a/flow_atelier/routes/schedules.py
+++ b/flow_atelier/routes/schedules.py
@@ -33,7 +33,10 @@ async def create_schedule(
     :param atelier: injected :class:`Atelier` facade.
     :returns: the created :class:`ScheduledJob`.
     """
-    job = atelier.create_schedule(payload)
+    try:
+        job = atelier.create_schedule(payload)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     # Hot-register with the embedded daemon if one is attached.
     daemon = getattr(atelier, "scheduler_daemon", None)
     if daemon is not None:

--- a/flow_atelier/routes/ws.py
+++ b/flow_atelier/routes/ws.py
@@ -79,6 +79,11 @@ async def run_conduit_ws(websocket: WebSocket) -> None:
         """
         if websocket.application_state == WebSocketState.CONNECTED:
             await websocket.send_json(payload)
+        else:
+            logger.debug(
+                "dropping %s envelope: socket not connected",
+                payload.get("type", "?"),
+            )
 
     broker = WebSocketBroker(send=_send)
     scheduler_bus = getattr(base_atelier, "scheduler_bus", None)
@@ -362,6 +367,12 @@ async def _spawn_run(
     message: RunMessage,
 ) -> None:
     """Wire a per-flow Atelier and start the run task.
+
+    Trust model: ``message.run_path`` becomes the execution ``working_dir``
+    verbatim, so a caller who can post a ``RunMessage`` chooses where bash and
+    harness tasks run. This is the same boundary as ``tool:bash`` and
+    ``open-path`` — anyone who can reach this endpoint can already run shell —
+    so it grants no new privilege, but the cwd is intentionally unconstrained.
 
     :param base_atelier: connection-scoped :class:`Atelier` used as template.
     :param broker: :class:`WebSocketBroker` that fans envelopes out.

--- a/flow_atelier/routes/ws.py
+++ b/flow_atelier/routes/ws.py
@@ -155,6 +155,20 @@ def _wire_atelier(
         broker=broker, flow_id=flow_id
     )
 
+    # Hold strong references to fire-and-forget broadcast tasks: the event
+    # loop keeps only a weak reference to a bare create_task, so without this
+    # a send can be garbage-collected mid-flight and silently dropped.
+    pending: set[asyncio.Task] = set()
+
+    def _spawn(coro: Awaitable[None]) -> None:
+        """Schedule a broadcast coroutine while retaining a strong reference.
+
+        :param coro: the broadcast coroutine to run detached.
+        """
+        task = asyncio.create_task(coro)
+        pending.add(task)
+        task.add_done_callback(pending.discard)
+
     async def _on_task_event(event: TaskEvent) -> None:
         """Emit per-step and step-status envelopes for a task event.
 
@@ -188,7 +202,7 @@ def _wire_atelier(
 
         :param event: task event produced by the engine.
         """
-        asyncio.create_task(_on_task_event(event))
+        _spawn(_on_task_event(event))
 
     def on_task_starting(name: str, tool: str) -> None:
         """Emit a step_status=running envelope when a task starts.
@@ -200,7 +214,7 @@ def _wire_atelier(
         :param tool: tool kind string for the task.
         """
         fid = _current_flow_ctx.get(flow_id)
-        asyncio.create_task(
+        _spawn(
             broker.send(
                 {
                     "type": "step_status",
@@ -227,7 +241,7 @@ def _wire_atelier(
         except ValueError:
             pass
         parent_task = _current_task_ctx.get("") or None
-        asyncio.create_task(
+        _spawn(
             broker.send(
                 {
                     "type": "started",

--- a/flow_atelier/routes/ws.py
+++ b/flow_atelier/routes/ws.py
@@ -121,6 +121,10 @@ async def run_conduit_ws(websocket: WebSocket) -> None:
             elif isinstance(message, CancelMessage):
                 broker.cancel(message.flow_id)
     finally:
+        # A client going away must not leave its runs executing detached: cancel
+        # every tracked run task, which also unblocks any tool:hitl task waiting
+        # on an answer that can no longer be delivered over this dead socket.
+        broker.cancel_all()
         if scheduler_bus is not None:
             scheduler_bus.unsubscribe(_send)
         try:

--- a/flow_atelier/schemas/api.py
+++ b/flow_atelier/schemas/api.py
@@ -44,6 +44,8 @@ class OpenPathInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Accepted but unused server-side; the bundled frontend still transmits it,
+    # so removing it under extra="forbid" would 422 the live open-path button.
     conduit_name: str
     run_path: str
 

--- a/flow_atelier/schemas/api.py
+++ b/flow_atelier/schemas/api.py
@@ -170,6 +170,29 @@ class CreateScheduleInput(BaseModel):
     run_path: str
     schedule: ScheduleConfig
 
+    @model_validator(mode="after")
+    def _reject_past_run_at(self) -> CreateScheduleInput:
+        """Reject a one-shot whose ``run_at`` is already in the past.
+
+        A past ``run_at`` yields a ``DateTrigger`` that never fires, so the
+        schedule installs cleanly but becomes a zombie indistinguishable from
+        one that already ran. The check lives here, not on
+        :class:`ScheduleConfig`, so persisted :class:`ScheduledJob` records
+        (whose ``run_at`` is naturally in the past once fired) still load.
+
+        :returns: the validated input instance.
+        """
+        run_at = self.schedule.run_at
+        if self.schedule.mode == "once" and run_at is not None:
+            now = (
+                datetime.now(run_at.tzinfo)
+                if run_at.tzinfo is not None
+                else datetime.now()
+            )
+            if run_at <= now:
+                raise ValueError("once schedule run_at must be in the future")
+        return self
+
 
 class ScheduledJob(BaseModel):
     """Server-side representation of a persisted schedule (per SPEC §7)."""

--- a/flow_atelier/schemas/conduit.py
+++ b/flow_atelier/schemas/conduit.py
@@ -60,6 +60,7 @@ class TaskDefinition(BaseModel):
     stagnation_limit: int | None = None
     retries: int = 0
     retry_backoff: float = 0.0
+    timeout: int | None = None
     interactive: bool = False
     inputs: dict[str, Any] = Field(default_factory=dict)
 
@@ -112,6 +113,18 @@ class TaskDefinition(BaseModel):
         """
         if v < 0:
             raise ValueError("retry_backoff must be >= 0")
+        return v
+
+    @field_validator("timeout")
+    @classmethod
+    def _timeout_positive(cls, v: int | None) -> int | None:
+        """Ensure an explicit per-task ``timeout`` is at least one second.
+
+        :param v: the proposed ``timeout`` value, or ``None`` to inherit.
+        :returns: the validated ``timeout`` value unchanged.
+        """
+        if v is not None and v < 1:
+            raise ValueError("timeout must be >= 1")
         return v
 
     @model_validator(mode="after")

--- a/flow_atelier/schemas/conduit.py
+++ b/flow_atelier/schemas/conduit.py
@@ -58,6 +58,8 @@ class TaskDefinition(BaseModel):
     while_: str | None = Field(default=None, alias="while")
     on_exhaust: Literal["complete", "fail"] = "complete"
     stagnation_limit: int | None = None
+    retries: int = 0
+    retry_backoff: float = 0.0
     interactive: bool = False
     inputs: dict[str, Any] = Field(default_factory=dict)
 
@@ -86,6 +88,30 @@ class TaskDefinition(BaseModel):
         """
         if v < 1:
             raise ValueError("repeat must be >= 1")
+        return v
+
+    @field_validator("retries")
+    @classmethod
+    def _retries_non_negative(cls, v: int) -> int:
+        """Ensure ``retries`` is zero or positive.
+
+        :param v: the proposed ``retries`` value.
+        :returns: the validated ``retries`` value unchanged.
+        """
+        if v < 0:
+            raise ValueError("retries must be >= 0")
+        return v
+
+    @field_validator("retry_backoff")
+    @classmethod
+    def _retry_backoff_non_negative(cls, v: float) -> float:
+        """Ensure ``retry_backoff`` is zero or positive.
+
+        :param v: the proposed ``retry_backoff`` value in seconds.
+        :returns: the validated ``retry_backoff`` value unchanged.
+        """
+        if v < 0:
+            raise ValueError("retry_backoff must be >= 0")
         return v
 
     @model_validator(mode="after")

--- a/flow_atelier/schemas/conduit.py
+++ b/flow_atelier/schemas/conduit.py
@@ -8,6 +8,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 _TASK_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+# Conduit names become a single filesystem path component (conduits/<name>/),
+# so they must reject "/", ".", ".." to prevent path traversal on write/delete.
+# Hyphens are allowed because real conduits on disk use them (autonomous-projects).
+_CONDUIT_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class ToolType(str, Enum):
@@ -132,6 +136,21 @@ class Conduit(BaseModel):
     max_concurrency: int = Field(default=3, ge=1)
     inputs: dict[str, InputSpec] = Field(default_factory=dict)
     tasks: list[TaskDefinition]
+
+    @field_validator("name")
+    @classmethod
+    def _name_valid(cls, v: str) -> str:
+        """Restrict conduit names to a safe single filesystem path component.
+
+        :param v: the proposed conduit name.
+        :returns: the validated name unchanged.
+        """
+        if not _CONDUIT_NAME_RE.match(v):
+            raise ValueError(
+                f"invalid conduit name {v!r}: only letters, digits, "
+                "underscores and hyphens are allowed"
+            )
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/flow_atelier/schemas/progress.py
+++ b/flow_atelier/schemas/progress.py
@@ -34,3 +34,5 @@ class Progress(BaseModel):
     tasks: dict[str, TaskProgress] = Field(default_factory=dict)
     started_at: str | None = None
     finished_at: str | None = None
+    runner_pid: int | None = None
+    runner_host: str | None = None

--- a/flow_atelier/services/api/scheduler_bus.py
+++ b/flow_atelier/services/api/scheduler_bus.py
@@ -25,9 +25,15 @@ class SchedulerEventBus:
     subscriber whose send raises (treated as a disconnect).
     """
 
-    def __init__(self) -> None:
-        """Initialise with an empty subscriber set."""
+    def __init__(self, send_timeout: float = 5.0) -> None:
+        """Initialise with an empty subscriber set.
+
+        :param send_timeout: max seconds to wait on a subscriber's send before
+            treating it as a disconnect; bounds head-of-line blocking on the
+            scheduler fire path so one stuck client can't pace dispatch.
+        """
         self._subscribers: set[SendCallable] = set()
+        self._send_timeout = send_timeout
 
     def subscribe(self, send: SendCallable) -> None:
         """Register ``send`` as a subscriber. Idempotent.
@@ -63,19 +69,22 @@ class SchedulerEventBus:
             if not ok:
                 self._subscribers.discard(sub)
 
-    @staticmethod
-    async def _safe_send(send: SendCallable, envelope: dict[str, Any]) -> bool:
-        """Invoke ``send`` and return True on success, False on any raise.
+    async def _safe_send(self, send: SendCallable, envelope: dict[str, Any]) -> bool:
+        """Invoke ``send`` (bounded by the timeout); True on success else False.
+
+        A send that raises or exceeds ``send_timeout`` is treated as a dead
+        subscriber and dropped, so a slow/backpressured socket can't stall the
+        fire path.
 
         :param send: subscriber send callable
         :param envelope: envelope to deliver
         """
         try:
-            await send(envelope)
+            await asyncio.wait_for(send(envelope), timeout=self._send_timeout)
             return True
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001 — includes TimeoutError
             logger.debug(
-                "scheduler bus: dropping subscriber after send error",
+                "scheduler bus: dropping subscriber after send error/timeout",
                 exc_info=True,
             )
             return False

--- a/flow_atelier/services/api/ws_manager.py
+++ b/flow_atelier/services/api/ws_manager.py
@@ -104,3 +104,15 @@ class WebSocketBroker:
         task = self._tasks.get(flow_id)
         if task is not None and not task.done():
             task.cancel()
+
+    def cancel_all(self) -> None:
+        """Cancel every tracked run task (best-effort).
+
+        Called when the WebSocket disconnects: without this an in-flight run
+        keeps executing detached, and a ``tool:hitl`` task blocked on an answer
+        that can no longer arrive would pin the run forever. Cancelling the
+        driving task unwinds ``engine.run`` and unblocks that await.
+        """
+        for task in list(self._tasks.values()):
+            if not task.done():
+                task.cancel()

--- a/flow_atelier/services/executor/base.py
+++ b/flow_atelier/services/executor/base.py
@@ -66,3 +66,16 @@ class ExecutorBase(ABC):
         :param context: runtime :class:`FlowContext` for the execution.
         :returns: :class:`ExecutionResult` describing the outcome.
         """
+
+    def is_available(self) -> tuple[bool, str]:
+        """Report whether this executor can actually run right now.
+
+        A preflight probe used by readiness checks (``atelier check`` and the
+        top of ``atelier run``) to fail fast on an unrunnable conduit instead
+        of dying mid-DAG. The default is always-ready; executors backed by an
+        external CLI override this to confirm the binary is on PATH.
+
+        :returns: ``(ready, reason)`` — ``reason`` is empty when ready, else a
+            short human cause (e.g. ``"`npx` not found on PATH"``).
+        """
+        return (True, "")

--- a/flow_atelier/services/executor/bash.py
+++ b/flow_atelier/services/executor/bash.py
@@ -9,7 +9,14 @@ from flow_atelier.services.executor.base import ExecutorBase, FlowContext
 
 
 class BashExecutor(ExecutorBase):
-    """Executes ``tool:bash`` tasks via ``asyncio.create_subprocess_shell``."""
+    """Executes ``tool:bash`` tasks via ``asyncio.create_subprocess_shell``.
+
+    Trust model: ``{{inputs.x}}`` values are interpolated into the command
+    string unescaped, so inputs are as trusted as the conduit author. A party
+    who can only *supply* inputs (a scheduled job, a WS ``run`` message, a HITL
+    answer) can inject shell metacharacters into an author's command. Authors
+    should quote interpolations they don't control (e.g. ``"{{inputs.x}}"``).
+    """
 
     async def execute(
         self,

--- a/flow_atelier/services/executor/harness.py
+++ b/flow_atelier/services/executor/harness.py
@@ -566,39 +566,47 @@ class AcpHarnessExecutor(ExecutorBase):
             prompt=[TextContentBlock(type="text", text=prompt_text)],
             session_id=session_id,
         )
-        await self._drain_pending_notifications(client)
+        await self._drain_pending_notifications(conn)
         await client.flush_pending()
         return self._result_for_turn(client, resp.stop_reason)
 
     @staticmethod
-    async def _drain_pending_notifications(client: _BufferingClient) -> None:
-        """Wait for supervised notification handlers to finish.
+    async def _drain_pending_notifications(conn) -> None:
+        """Deterministically wait for all session-update handlers to finish.
 
-        The ACP dispatcher runs each notification handler as a background
-        task, so session_update handlers for the last few chunks may still
-        be running when ``conn.prompt`` returns. We wait for the client's
-        buffer to stabilize (no growth for two consecutive short yields)
-        or until ``max_wait`` seconds have passed.
+        The agent streams ``session/update`` notifications and then the
+        ``prompt`` response. The response resolves ``conn.prompt`` directly,
+        bypassing the notification queue, while each notification is consumed
+        from that queue and run as a background task by the ACP dispatcher. So
+        when ``conn.prompt`` returns, the handlers for the final chunks may
+        still be queued or in flight, and a buffer-stability poll can sample
+        the buffer before they land and drop the last chunk.
 
-        :param client: buffering client whose ``buffer`` is polled for growth.
+        Instead of guessing with a timing window we drain deterministically:
+        ``queue.join()`` blocks until every notification received before the
+        response has had its handler task spawned, then we await those handler
+        tasks so their buffer writes are guaranteed complete.
+
+        Reaches into the low-level :class:`acp.Connection` (``conn._conn``) and
+        its dispatcher's queue/supervisor because the library exposes no public
+        drain hook. Degrades to a no-op if that internal shape ever changes.
+
+        :param conn: the active ACP client-side connection.
         """
-        max_wait = 0.5
-        stable_yields_required = 2
-        deadline = asyncio.get_running_loop().time() + max_wait
-        last_len = -1
-        stable = 0
-        while True:
-            await asyncio.sleep(0.01)
-            cur_len = len(client.buffer)
-            if cur_len == last_len:
-                stable += 1
-                if stable >= stable_yields_required:
-                    return
-            else:
-                stable = 0
-                last_len = cur_len
-            if asyncio.get_running_loop().time() >= deadline:
-                return
+        connection = getattr(conn, "_conn", None)
+        queue = getattr(connection, "_queue", None)
+        supervisor = getattr(connection, "_tasks", None)
+        if queue is None or supervisor is None:
+            logger.debug("ACP connection lacks queue/supervisor; skipping drain")
+            return
+        await queue.join()
+        pending = [
+            task
+            for task in list(getattr(supervisor, "_tasks", ()))
+            if task.get_name() == "acp.Dispatcher.notification" and not task.done()
+        ]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def _run_interactive(
         self,
@@ -629,7 +637,7 @@ class AcpHarnessExecutor(ExecutorBase):
                 prompt=[TextContentBlock(type="text", text=next_prompt)],
                 session_id=session_id,
             )
-            await self._drain_pending_notifications(client)
+            await self._drain_pending_notifications(conn)
             await client.flush_pending()
             last_stop = resp.stop_reason
             buffer_text = "".join(client.buffer)

--- a/flow_atelier/services/executor/harness.py
+++ b/flow_atelier/services/executor/harness.py
@@ -400,7 +400,7 @@ class AcpHarnessExecutor(ExecutorBase):
     """Executor that drives an ACP agent subprocess.
 
     :param launch_cmd: argv to spawn the ACP agent (e.g.
-        ``["npx", "-y", "@zed-industries/claude-code-acp"]``)
+        ``["npx", "-y", "@agentclientprotocol/claude-agent-acp"]``)
     :param sink: :class:`PromptSink` for user I/O and permission requests
     :param done_marker: substring that terminates an interactive loop
     """
@@ -712,7 +712,7 @@ class AcpHarnessExecutor(ExecutorBase):
 
 
 class ClaudeHarness(AcpHarnessExecutor):
-    """`harness:claude-code` — drives ``@zed-industries/claude-code-acp``."""
+    """`harness:claude-code` — drives ``@agentclientprotocol/claude-agent-acp``."""
 
     def __init__(
         self,

--- a/flow_atelier/services/executor/harness.py
+++ b/flow_atelier/services/executor/harness.py
@@ -425,6 +425,21 @@ class AcpHarnessExecutor(ExecutorBase):
         self.sink = sink if sink is not None else TerminalPromptSink()
         self.done_marker = done_marker or DEFAULT_DONE_MARKER
 
+    def is_available(self) -> tuple[bool, str]:
+        """Probe whether the harness's launch binary is on PATH.
+
+        Checks ``launch_cmd[0]`` (the ``npx``/``opencode``/``copilot`` binary
+        the subprocess will spawn) with :func:`shutil.which`, the
+        cross-platform PATH lookup. Presence only — no auth/version checks.
+
+        :returns: ``(True, "")`` when found, else ``(False, reason)`` naming
+            the missing binary.
+        """
+        binary = self.launch_cmd[0]
+        if shutil.which(binary) is None:
+            return (False, f"`{binary}` not found on PATH")
+        return (True, "")
+
     async def execute(
         self,
         task: TaskDefinition,

--- a/flow_atelier/services/scheduler/runner.py
+++ b/flow_atelier/services/scheduler/runner.py
@@ -30,6 +30,22 @@ _RELOAD_JOB_ID = "__atelier_sync__"
 ScheduleExecutor = Callable[[ScheduledJob, Path], Awaitable[None]]
 
 
+def _resolve_run_path(run_path: str, base: Path) -> Path:
+    """Resolve a schedule's ``run_path`` against ``base``.
+
+    Empty → ``base``; absolute → used verbatim; relative → resolved under
+    ``base``. Shared by the daemon's fire path and the planned-view preview so
+    "where it will fire" can never disagree with where it actually fires.
+
+    :param run_path: the schedule's ``run_path`` (possibly empty)
+    :param base: default working directory (already resolved)
+    """
+    if not run_path:
+        return base
+    wd = Path(run_path)
+    return wd if wd.is_absolute() else (base / wd).resolve()
+
+
 async def _default_executor(job: ScheduledJob, working_dir: Path) -> None:
     """Default fire action: instantiate ``Atelier(base_dir=working_dir/.atelier)``
     and ``await run_conduit(...)``. Imported lazily to avoid a circular import.
@@ -235,12 +251,7 @@ class SchedulerDaemon:
 
         :param job: schedule whose working directory should be resolved
         """
-        if not job.run_path:
-            return self.default_working_dir
-        wd = Path(job.run_path)
-        if not wd.is_absolute():
-            wd = (self.default_working_dir / wd).resolve()
-        return wd
+        return _resolve_run_path(job.run_path, self.default_working_dir)
 
     # ------------------------------------------------------------------ fire
 
@@ -320,12 +331,7 @@ def compute_planned_view(
     base = default_working_dir.resolve()
     planned: list[PlannedJob] = []
     for job in store.list():
-        run_path = job.run_path
-        if run_path:
-            wd = Path(run_path)
-            working_dir = wd if wd.is_absolute() else (base / wd).resolve()
-        else:
-            working_dir = base
+        working_dir = _resolve_run_path(job.run_path, base)
         if job.schedule.mode == "once" and store.fired_at(job.id):
             planned.append(
                 PlannedJob(

--- a/flow_atelier/services/scheduler/store.py
+++ b/flow_atelier/services/scheduler/store.py
@@ -64,18 +64,44 @@ class ScheduleStore:
     :param atelier_dir: project ``.atelier/`` directory; created if missing
     """
 
-    def __init__(self, atelier_dir: Path | str) -> None:
+    def __init__(
+        self, atelier_dir: Path | str, global_dir: Path | str | None = None
+    ) -> None:
         """Initialise the store rooted at ``atelier_dir``.
 
+        Mirrors :class:`FilesystemStore`: reads union the project and (optional)
+        global schedules dirs so a schedule installed via the CLI (project) is
+        visible to ``atelier serve`` (which roots at the global dir) and vice
+        versa. Writes and fired-state always go to the project dir.
+
         :param atelier_dir: project ``.atelier/`` directory; created if missing
+        :param global_dir: optional user-level ``.atelier/`` directory; its
+            ``schedules/`` is included in reads only
         """
         self.atelier_dir = Path(atelier_dir)
         self.atelier_dir.mkdir(parents=True, exist_ok=True)
         self.schedules_dir = self.atelier_dir / "schedules"
         self.schedules_dir.mkdir(parents=True, exist_ok=True)
         self.state_path = self.atelier_dir / "scheduler_state.json"
+        self.global_schedules_dir: Path | None = None
+        if global_dir is not None:
+            global_schedules = Path(global_dir) / "schedules"
+            if global_schedules.resolve() != self.schedules_dir.resolve():
+                try:
+                    global_schedules.mkdir(parents=True, exist_ok=True)
+                    self.global_schedules_dir = global_schedules
+                except OSError:
+                    # Read-only HOME / sandbox — degrade to project-only.
+                    self.global_schedules_dir = None
 
     # --------------------------------------------------------------- internals
+
+    def _read_dirs(self) -> list[Path]:
+        """Return the schedule dirs to read from, project first (precedence)."""
+        dirs = [self.schedules_dir]
+        if self.global_schedules_dir is not None:
+            dirs.append(self.global_schedules_dir)
+        return dirs
 
     def _path_for_name(self, name: str) -> Path:
         """Return the YAML path for ``name``.
@@ -89,15 +115,16 @@ class ScheduleStore:
 
         Resolves by reading each file's ``id`` rather than recomputing the
         filename, so pre-existing files written under an older slug scheme are
-        still found.
+        still found. Searches the project dir first, then the global dir.
 
         :param schedule_id: schedule identifier
         :returns: ``(path, job)`` or ``None`` if no file matches
         """
-        for path in self.schedules_dir.glob("*.yaml"):
-            job = self._load_file(path)
-            if job is not None and job.id == schedule_id:
-                return path, job
+        for directory in self._read_dirs():
+            for path in directory.glob("*.yaml"):
+                job = self._load_file(path)
+                if job is not None and job.id == schedule_id:
+                    return path, job
         return None
 
     def _load_file(self, path: Path) -> ScheduledJob | None:
@@ -134,14 +161,21 @@ class ScheduleStore:
         os.replace(tmp, path)
 
     def _iter_jobs(self) -> list[ScheduledJob]:
-        """Return every persisted schedule, sorted by ``created_at`` ascending."""
-        if not self.schedules_dir.exists():
-            return []
+        """Return every persisted schedule, sorted by ``created_at`` ascending.
+
+        Unions the project and global schedule dirs; on an id collision the
+        project copy wins (project shadows global, like conduits).
+        """
         jobs: list[ScheduledJob] = []
-        for path in self.schedules_dir.glob("*.yaml"):
-            job = self._load_file(path)
-            if job is not None:
-                jobs.append(job)
+        seen: set[str] = set()
+        for directory in self._read_dirs():
+            if not directory.exists():
+                continue
+            for path in directory.glob("*.yaml"):
+                job = self._load_file(path)
+                if job is not None and job.id not in seen:
+                    seen.add(job.id)
+                    jobs.append(job)
         jobs.sort(key=lambda j: j.created_at)
         return jobs
 

--- a/flow_atelier/services/scheduler/store.py
+++ b/flow_atelier/services/scheduler/store.py
@@ -64,44 +64,18 @@ class ScheduleStore:
     :param atelier_dir: project ``.atelier/`` directory; created if missing
     """
 
-    def __init__(
-        self, atelier_dir: Path | str, global_dir: Path | str | None = None
-    ) -> None:
+    def __init__(self, atelier_dir: Path | str) -> None:
         """Initialise the store rooted at ``atelier_dir``.
 
-        Mirrors :class:`FilesystemStore`: reads union the project and (optional)
-        global schedules dirs so a schedule installed via the CLI (project) is
-        visible to ``atelier serve`` (which roots at the global dir) and vice
-        versa. Writes and fired-state always go to the project dir.
-
         :param atelier_dir: project ``.atelier/`` directory; created if missing
-        :param global_dir: optional user-level ``.atelier/`` directory; its
-            ``schedules/`` is included in reads only
         """
         self.atelier_dir = Path(atelier_dir)
         self.atelier_dir.mkdir(parents=True, exist_ok=True)
         self.schedules_dir = self.atelier_dir / "schedules"
         self.schedules_dir.mkdir(parents=True, exist_ok=True)
         self.state_path = self.atelier_dir / "scheduler_state.json"
-        self.global_schedules_dir: Path | None = None
-        if global_dir is not None:
-            global_schedules = Path(global_dir) / "schedules"
-            if global_schedules.resolve() != self.schedules_dir.resolve():
-                try:
-                    global_schedules.mkdir(parents=True, exist_ok=True)
-                    self.global_schedules_dir = global_schedules
-                except OSError:
-                    # Read-only HOME / sandbox — degrade to project-only.
-                    self.global_schedules_dir = None
 
     # --------------------------------------------------------------- internals
-
-    def _read_dirs(self) -> list[Path]:
-        """Return the schedule dirs to read from, project first (precedence)."""
-        dirs = [self.schedules_dir]
-        if self.global_schedules_dir is not None:
-            dirs.append(self.global_schedules_dir)
-        return dirs
 
     def _path_for_name(self, name: str) -> Path:
         """Return the YAML path for ``name``.
@@ -115,16 +89,15 @@ class ScheduleStore:
 
         Resolves by reading each file's ``id`` rather than recomputing the
         filename, so pre-existing files written under an older slug scheme are
-        still found. Searches the project dir first, then the global dir.
+        still found.
 
         :param schedule_id: schedule identifier
         :returns: ``(path, job)`` or ``None`` if no file matches
         """
-        for directory in self._read_dirs():
-            for path in directory.glob("*.yaml"):
-                job = self._load_file(path)
-                if job is not None and job.id == schedule_id:
-                    return path, job
+        for path in self.schedules_dir.glob("*.yaml"):
+            job = self._load_file(path)
+            if job is not None and job.id == schedule_id:
+                return path, job
         return None
 
     def _load_file(self, path: Path) -> ScheduledJob | None:
@@ -161,21 +134,14 @@ class ScheduleStore:
         os.replace(tmp, path)
 
     def _iter_jobs(self) -> list[ScheduledJob]:
-        """Return every persisted schedule, sorted by ``created_at`` ascending.
-
-        Unions the project and global schedule dirs; on an id collision the
-        project copy wins (project shadows global, like conduits).
-        """
+        """Return every persisted schedule, sorted by ``created_at`` ascending."""
+        if not self.schedules_dir.exists():
+            return []
         jobs: list[ScheduledJob] = []
-        seen: set[str] = set()
-        for directory in self._read_dirs():
-            if not directory.exists():
-                continue
-            for path in directory.glob("*.yaml"):
-                job = self._load_file(path)
-                if job is not None and job.id not in seen:
-                    seen.add(job.id)
-                    jobs.append(job)
+        for path in self.schedules_dir.glob("*.yaml"):
+            job = self._load_file(path)
+            if job is not None:
+                jobs.append(job)
         jobs.sort(key=lambda j: j.created_at)
         return jobs
 

--- a/flow_atelier/services/scheduler/store.py
+++ b/flow_atelier/services/scheduler/store.py
@@ -2,16 +2,19 @@
 
 Layout under ``<atelier>/``:
 
-- ``schedules/<slug(name)>.yaml``: one file per :class:`ScheduledJob`.
+- ``schedules/<slug(name)>-<hash>.yaml``: one file per :class:`ScheduledJob`.
   Deletes remove the file. The original ``schedule.name`` is preserved
-  inside the YAML; the filename is a filesystem-safe slug of that name.
+  inside the YAML; the filename is a filesystem-safe slug of that name plus a
+  short hash of the full name so distinct names that slug alike don't collide.
 - ``scheduler_state.json``: fired-once markers keyed by schedule ``id``.
 
 Atomic writes via ``os.replace``.
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import os
 import re
 import time
@@ -23,6 +26,8 @@ from typing import Any
 import yaml
 
 from flow_atelier.schemas.api import CreateScheduleInput, ScheduledJob
+
+logger = logging.getLogger(__name__)
 
 _SLUG_RE = re.compile(r"[^a-z0-9._-]+")
 
@@ -37,6 +42,20 @@ def _slug(name: str) -> str:
     if not slug:
         raise ValueError(f"schedule name has no filesystem-safe characters: {name!r}")
     return slug
+
+
+def _filename_for_name(name: str) -> str:
+    """Return an injective ``*.yaml`` filename for ``name``.
+
+    The readable slug is kept as a prefix; a short hash of the *full* original
+    name disambiguates distinct names that slug identically (``"My Job"`` vs
+    ``"my-job"``), so they can no longer collide on one file.
+
+    :param name: human-readable schedule name
+    :raises ValueError: when the slug would be empty
+    """
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:8]
+    return f"{_slug(name)}-{digest}.yaml"
 
 
 class ScheduleStore:
@@ -63,7 +82,23 @@ class ScheduleStore:
 
         :param name: schedule name
         """
-        return self.schedules_dir / f"{_slug(name)}.yaml"
+        return self.schedules_dir / _filename_for_name(name)
+
+    def _find_job_file(self, schedule_id: str) -> tuple[Path, ScheduledJob] | None:
+        """Locate the on-disk file backing ``schedule_id``.
+
+        Resolves by reading each file's ``id`` rather than recomputing the
+        filename, so pre-existing files written under an older slug scheme are
+        still found.
+
+        :param schedule_id: schedule identifier
+        :returns: ``(path, job)`` or ``None`` if no file matches
+        """
+        for path in self.schedules_dir.glob("*.yaml"):
+            job = self._load_file(path)
+            if job is not None and job.id == schedule_id:
+                return path, job
+        return None
 
     def _load_file(self, path: Path) -> ScheduledJob | None:
         """Load and validate one schedule YAML; return None on failure.
@@ -72,23 +107,29 @@ class ScheduleStore:
         """
         try:
             raw = yaml.safe_load(path.read_text())
-        except (yaml.YAMLError, OSError):
+        except (yaml.YAMLError, OSError) as e:
+            logger.warning("skipping unreadable schedule %s: %s", path.name, e)
             return None
         if not isinstance(raw, dict):
+            logger.warning("skipping malformed schedule %s: not a mapping", path.name)
             return None
         try:
             return ScheduledJob.model_validate(raw)
-        except Exception:  # noqa: BLE001 — skip malformed rows
+        except Exception as e:  # noqa: BLE001 — skip malformed rows
+            logger.warning("skipping invalid schedule %s: %s", path.name, e)
             return None
 
-    def _save_job(self, job: ScheduledJob) -> None:
+    def _save_job(self, job: ScheduledJob, path: Path | None = None) -> None:
         """Atomically write ``job`` to its YAML file.
 
         :param job: schedule to persist
+        :param path: explicit destination; defaults to the name-derived path.
+            Pass the file a job was loaded from to update it in place.
         """
-        path = self._path_for_name(job.schedule.name)
+        if path is None:
+            path = self._path_for_name(job.schedule.name)
         payload = job.model_dump(mode="json", exclude_none=True)
-        tmp = path.with_suffix(".yaml.tmp")
+        tmp = path.with_suffix(f".yaml.tmp.{uuid.uuid4().hex}")
         tmp.write_text(yaml.safe_dump(payload, sort_keys=False))
         os.replace(tmp, path)
 
@@ -166,14 +207,13 @@ class ScheduleStore:
         :raises KeyError: if no schedule exists for ``schedule_id``
         :returns: the job as it was on disk just before removal
         """
-        for job in self._iter_jobs():
-            if job.id == schedule_id:
-                path = self._path_for_name(job.schedule.name)
-                if path.exists():
-                    path.unlink()
-                self.clear_fired(schedule_id)
-                return job
-        raise KeyError(f"schedule not found: {schedule_id}")
+        hit = self._find_job_file(schedule_id)
+        if hit is None:
+            raise KeyError(f"schedule not found: {schedule_id}")
+        path, job = hit
+        path.unlink(missing_ok=True)
+        self.clear_fired(schedule_id)
+        return job
 
     def increment_runs(self, schedule_id: str) -> None:
         """Bump ``runs_completed`` for ``schedule_id`` if it still exists.
@@ -184,14 +224,14 @@ class ScheduleStore:
 
         :param schedule_id: schedule identifier
         """
-        for job in self._iter_jobs():
-            if job.id == schedule_id:
-                if not self._path_for_name(job.schedule.name).exists():
-                    return
-                self._save_job(
-                    job.model_copy(update={"runs_completed": job.runs_completed + 1})
-                )
-                return
+        hit = self._find_job_file(schedule_id)
+        if hit is None:
+            return
+        path, job = hit
+        self._save_job(
+            job.model_copy(update={"runs_completed": job.runs_completed + 1}),
+            path=path,
+        )
 
     # --------------------------------------------------------------- fired state
 

--- a/flow_atelier/services/store/base.py
+++ b/flow_atelier/services/store/base.py
@@ -85,6 +85,15 @@ class StoreBase(ABC):
         """
         ...
 
+    @abstractmethod
+    def delete_flow(self, flow_id: str) -> bool:
+        """Delete a flow directory and its nested children. Returns False if absent.
+
+        :param flow_id: flow identifier
+        :returns: True if it existed and was deleted, False otherwise
+        """
+        ...
+
     # --- logs ---
     @abstractmethod
     async def append_log(self, flow_id: str, entry: LogEntry) -> None:

--- a/flow_atelier/services/store/filesystem.py
+++ b/flow_atelier/services/store/filesystem.py
@@ -76,12 +76,27 @@ class FilesystemStore(StoreBase):
 
     # ------------------------------------------------------------------ paths
 
+    @staticmethod
+    def _safe_conduit_name(name: str) -> str:
+        """Reject conduit names that aren't a single safe path component.
+
+        Defense-in-depth behind :class:`Conduit`'s name validator: guards any
+        caller that builds a conduit path without going through the schema.
+
+        :param name: conduit name to check.
+        :returns: the name unchanged when safe.
+        :raises ValueError: if the name contains a path separator or is ``.``/``..``.
+        """
+        if name in ("", ".", "..") or "/" in name or "\\" in name or os.sep in name:
+            raise ValueError(f"unsafe conduit name: {name!r}")
+        return name
+
     def _conduit_dir(self, name: str) -> Path:
         """Return the project-level directory for conduit ``name``.
 
         :param name: conduit name
         """
-        return self.base_dir / "conduits" / name
+        return self.base_dir / "conduits" / self._safe_conduit_name(name)
 
     def _conduit_yaml(self, name: str) -> Path:
         """Return the project-level ``conduit.yaml`` path for ``name``.
@@ -97,7 +112,7 @@ class FilesystemStore(StoreBase):
         """
         if self.global_dir is None:
             return None
-        return self.global_dir / "conduits" / name
+        return self.global_dir / "conduits" / self._safe_conduit_name(name)
 
     def _global_conduit_yaml(self, name: str) -> Path | None:
         """Return the global ``conduit.yaml`` path for ``name`` or ``None``.

--- a/flow_atelier/services/store/filesystem.py
+++ b/flow_atelier/services/store/filesystem.py
@@ -427,7 +427,7 @@ class FilesystemStore(StoreBase):
         :param progress: progress snapshot to persist
         """
         path = self._flow_dir(flow_id) / "progress.json"
-        tmp = path.with_suffix(".json.tmp")
+        tmp = path.with_suffix(f".json.tmp.{uuid.uuid4().hex}")
         tmp.write_text(progress.model_dump_json(indent=2))
         _atomic_replace(tmp, path)
 

--- a/flow_atelier/services/store/filesystem.py
+++ b/flow_atelier/services/store/filesystem.py
@@ -450,7 +450,8 @@ class FilesystemStore(StoreBase):
         path = self._flow_dir(flow_id) / "outputs.yaml"
         if not path.exists():
             return {}
-        return yaml.safe_load(path.read_text()) or {}
+        loaded = yaml.safe_load(path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
 
     def write_outputs(self, flow_id: str, outputs: dict[str, Any]) -> None:
         """Atomically write ``outputs.yaml`` for ``flow_id``.

--- a/flow_atelier/services/store/filesystem.py
+++ b/flow_atelier/services/store/filesystem.py
@@ -354,6 +354,27 @@ class FilesystemStore(StoreBase):
             p.name for p in children_dir.iterdir() if p.is_dir()
         )
 
+    def delete_flow(self, flow_id: str) -> bool:
+        """Remove a flow directory and its nested child subtree.
+
+        :param flow_id: flow identifier
+        :returns: True if deleted, False if it didn't exist
+        """
+        try:
+            flow_dir = self._flow_dir(flow_id)
+        except FileNotFoundError:
+            return False
+        shutil.rmtree(flow_dir)
+        # Evict the flow itself and any cached children that lived under it,
+        # so no stale handles survive in the path/lock caches.
+        self._flow_paths.pop(flow_id, None)
+        self._log_locks.pop(flow_id, None)
+        for cached_id, cached_path in list(self._flow_paths.items()):
+            if cached_path.is_relative_to(flow_dir):
+                self._flow_paths.pop(cached_id, None)
+                self._log_locks.pop(cached_id, None)
+        return True
+
     # ------------------------------------------------------------------ logs
 
     def _lock_for(self, flow_id: str) -> asyncio.Lock:

--- a/flow_atelier/services/store/filesystem.py
+++ b/flow_atelier/services/store/filesystem.py
@@ -142,7 +142,10 @@ class FilesystemStore(StoreBase):
             path = global_path
         else:
             raise FileNotFoundError(f"conduit not found: {name} ({project_path})")
-        data = yaml.safe_load(path.read_text())
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as e:
+            raise ValueError(f"{name}: invalid YAML — {e}") from e
         conduit = Conduit.model_validate(data)
         if conduit.name != name:
             raise ValueError(

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,10 @@ ARCH="$(uname -m)"
 case "${OS}-${ARCH}" in
     linux-x86_64)   ASSET="atelier-linux-x86_64" ;;
     darwin-arm64)   ASSET="atelier-macos-arm64" ;;
-    darwin-x86_64)  ASSET="atelier-macos-arm64" ;;
+    darwin-x86_64)
+        echo "Intel macOS (x86_64) is not supported: only an arm64 build is" >&2
+        echo "published, and Rosetta 2 cannot run arm64 binaries on Intel." >&2
+        exit 1 ;;
     *) echo "Unsupported platform: ${OS}-${ARCH}" >&2; exit 1 ;;
 esac
 

--- a/tests/cli/test_check_cmd.py
+++ b/tests/cli/test_check_cmd.py
@@ -1,0 +1,87 @@
+"""CLI tests for `atelier check` readiness gating + required-input listing."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from flow_atelier.cli import app
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    """Isolated cwd with an empty `.atelier` tree and isolated global dir.
+
+    :param tmp_path: pytest temp directory fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    (tmp_path / ".atelier" / "conduits").mkdir(parents=True)
+    global_dir = tmp_path / "global"
+    (global_dir / "conduits").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    for k in list(os.environ):
+        if k.startswith("ATELIER_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("ATELIER_GLOBAL_ATELIER_DIR", str(global_dir))
+    monkeypatch.setenv("ATELIER_NO_UPDATE_CHECK", "1")
+    return tmp_path
+
+
+def _write_conduit(workdir, name: str, body: str) -> None:
+    """Write a conduit.yaml under the project `.atelier/conduits/<name>/`.
+
+    :param workdir: working directory path.
+    :param name: conduit name (also the folder name).
+    :param body: full YAML document for the conduit.
+    """
+    cdir = workdir / ".atelier" / "conduits" / name
+    cdir.mkdir(parents=True)
+    (cdir / "conduit.yaml").write_text(body)
+
+
+def test_check_ok_for_bash_only(workdir):
+    """A bash-only conduit checks OK and lists no required inputs."""
+    _write_conduit(
+        workdir,
+        "bashy",
+        "name: bashy\ndescription: d\n"
+        "tasks:\n  - name: a\n    description: a\n    task: echo hi\n    tool: tool:bash\n",
+    )
+    result = CliRunner().invoke(app, ["check", "bashy"])
+    assert result.exit_code == 0
+    assert "OK" in result.stdout
+    assert "requires --input" not in result.stdout
+
+
+def test_check_lists_required_inputs(workdir):
+    """An OK conduit with a no-default input shows the requires line."""
+    _write_conduit(
+        workdir,
+        "needy",
+        "name: needy\ndescription: d\n"
+        "inputs:\n  topic:\n    description: the topic\n"
+        "tasks:\n  - name: a\n    description: a\n    task: echo {{inputs.topic}}\n    tool: tool:bash\n",
+    )
+    result = CliRunner().invoke(app, ["check", "needy"])
+    assert result.exit_code == 0
+    assert "requires --input" in result.stdout
+    assert "topic" in result.stdout
+
+
+def test_check_fails_when_harness_binary_missing(workdir, monkeypatch):
+    """A harness whose CLI is absent from PATH makes check FAIL with exit 1."""
+    monkeypatch.setattr(
+        "flow_atelier.services.executor.harness.shutil.which",
+        lambda _binary: None,
+    )
+    _write_conduit(
+        workdir,
+        "agentic",
+        "name: agentic\ndescription: d\n"
+        "tasks:\n  - name: build\n    description: b\n    task: do it\n    tool: harness:claude-code\n",
+    )
+    result = CliRunner().invoke(app, ["check", "agentic"])
+    assert result.exit_code == 1
+    assert "FAIL" in result.stdout
+    assert "build" in result.stdout

--- a/tests/cli/test_format_conduit_error.py
+++ b/tests/cli/test_format_conduit_error.py
@@ -1,0 +1,42 @@
+"""Unit tests for the conduit-error formatting helper."""
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from flow_atelier.cli.rendering.render import format_conduit_error
+from flow_atelier.schemas.conduit import TaskDefinition
+
+
+def test_validation_error_is_one_line_with_field_path():
+    """A pydantic ValidationError renders as a single line naming the field."""
+    with pytest.raises(ValidationError) as ei:
+        TaskDefinition.model_validate(
+            {"name": "t", "description": "d", "task": "echo", "tool": "tool:nope"}
+        )
+    msg = format_conduit_error(ei.value)
+    assert "\n" not in msg
+    assert "tool" in msg
+
+
+def test_yaml_error_is_one_line_with_line_number():
+    """A yaml.YAMLError with a mark renders one line including the line number."""
+    try:
+        yaml.safe_load("a: [1, 2\nb: 3\n")
+    except yaml.YAMLError as e:
+        msg = format_conduit_error(e)
+    assert "\n" not in msg
+    assert "line" in msg
+
+
+def test_value_error_is_passed_through_one_line():
+    """A plain ValueError (e.g. name/folder mismatch) is surfaced verbatim."""
+    msg = format_conduit_error(
+        ValueError("conduit.yaml name 'a' != folder name 'b'")
+    )
+    assert msg == "conduit.yaml name 'a' != folder name 'b'"
+
+
+def test_value_error_collapses_newlines():
+    """Multi-line error text collapses to a single line."""
+    msg = format_conduit_error(ValueError("line one\nline two"))
+    assert msg == "line one line two"

--- a/tests/cli/test_rm_prune.py
+++ b/tests/cli/test_rm_prune.py
@@ -121,6 +121,51 @@ def test_prune_declined_confirm_keeps_dir(workdir):
     assert f.exists()
 
 
+def test_prune_json_without_yes_is_dry_run(workdir):
+    """`prune --json` without --yes previews and deletes nothing.
+
+    JSON mode is non-interactive and must not delete without explicit --yes.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--older-than", "1", "--json"])
+    assert result.exit_code == 0, result.output
+    assert f.exists()
+    payload = json.loads(result.output)
+    assert payload["deleted"] == []
+    assert payload["would_delete"] == ["20200101_aaaaaaaa_hello"]
+
+
+def test_prune_json_with_yes_deletes(workdir):
+    """`prune --json --yes` deletes the selected flows and reports them.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--older-than", "1", "--json", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not f.exists()
+    payload = json.loads(result.output)
+    assert payload["deleted"] == ["20200101_aaaaaaaa_hello"]
+
+
+def test_rm_json_without_yes_declined_keeps_dir(workdir):
+    """`rm --json` still honors the confirmation gate; declining keeps the dir.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["rm", "20200101_aaaaaaaa_hello", "--json"], input="n\n"
+    )
+    assert result.exit_code != 0
+    assert f.exists()
+
+
 def test_rm_running_refused_without_force(workdir):
     """`rm` on a running flow is refused (non-zero) and leaves the dir.
 

--- a/tests/cli/test_rm_prune.py
+++ b/tests/cli/test_rm_prune.py
@@ -1,0 +1,172 @@
+"""CLI tests for `atelier rm` and `atelier prune` (flow-run retention)."""
+import json
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from flow_atelier.cli import app
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    """Provide an isolated working dir with a `.atelier/flows` tree.
+
+    :param tmp_path: pytest temp directory fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    (tmp_path / ".atelier" / "flows").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    for k in list(os.environ):
+        if k.startswith("ATELIER_") and k not in (
+            "ATELIER_GLOBAL_ATELIER_DIR",
+            "ATELIER_NO_UPDATE_CHECK",
+        ):
+            monkeypatch.delenv(k, raising=False)
+    return tmp_path
+
+
+def _make_flow(workdir, flow_id, status="completed"):
+    """Create a flow dir on disk with a progress.json of the given status.
+
+    :param workdir: working directory path.
+    :param flow_id: full flow id (``YYYYMMDD_<uuid8>_<conduit>``).
+    :param status: FlowStatus value to persist (default ``completed``).
+    :returns: the flow's directory Path.
+    """
+    flow_dir = workdir / ".atelier" / "flows" / flow_id
+    flow_dir.mkdir(parents=True)
+    (flow_dir / "progress.json").write_text(
+        json.dumps(
+            {
+                "status": status,
+                "current_tasks": [],
+                "tasks": {},
+                "started_at": "2026-01-01T00:00:00Z",
+                "finished_at": None,
+            }
+        )
+    )
+    return flow_dir
+
+
+def test_prune_older_than_selects_old_only(workdir):
+    """`prune --older-than` deletes ids older than the cutoff, keeps newer.
+
+    :param workdir: isolated working directory fixture.
+    """
+    old = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    new = _make_flow(workdir, "20990101_bbbbbbbb_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--older-than", "1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not old.exists()
+    assert new.exists()
+
+
+def test_prune_keep_retains_most_recent(workdir):
+    """`prune --keep N` retains the N most-recent ids and deletes the rest.
+
+    :param workdir: isolated working directory fixture.
+    """
+    a = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    b = _make_flow(workdir, "20210101_bbbbbbbb_hello")
+    c = _make_flow(workdir, "20220101_cccccccc_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--keep", "1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not a.exists()
+    assert not b.exists()
+    assert c.exists()
+
+
+def test_prune_skips_running_without_force(workdir):
+    """`prune` never deletes a running flow unless --force is given.
+
+    :param workdir: isolated working directory fixture.
+    """
+    running = _make_flow(workdir, "20200101_aaaaaaaa_hello", status="running")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--older-than", "1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert running.exists()
+
+    forced = runner.invoke(app, ["prune", "--older-than", "1", "--force", "--yes"])
+    assert forced.exit_code == 0, forced.output
+    assert not running.exists()
+
+
+def test_prune_bare_refuses(workdir):
+    """A bare `prune` with no selector refuses and deletes nothing.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune"])
+    assert result.exit_code != 0
+    assert "refusing to prune" in result.output
+    assert f.exists()
+
+
+def test_prune_declined_confirm_keeps_dir(workdir):
+    """Declining the prune confirmation leaves the flow dir intact.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["prune", "--older-than", "1"], input="n\n")
+    assert result.exit_code != 0
+    assert f.exists()
+
+
+def test_rm_running_refused_without_force(workdir):
+    """`rm` on a running flow is refused (non-zero) and leaves the dir.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello", status="running")
+    runner = CliRunner()
+    result = runner.invoke(app, ["rm", "20200101_aaaaaaaa_hello", "--yes"])
+    assert result.exit_code != 0
+    assert "still running" in result.output
+    assert f.exists()
+
+
+def test_rm_running_with_force_deletes(workdir):
+    """`rm --force` deletes a running flow.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello", status="running")
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["rm", "20200101_aaaaaaaa_hello", "--force", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert not f.exists()
+
+
+def test_rm_declined_confirm_keeps_dir(workdir):
+    """Declining the rm confirmation leaves the flow dir intact.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["rm", "20200101_aaaaaaaa_hello"], input="n\n")
+    assert result.exit_code != 0
+    assert f.exists()
+
+
+def test_rm_yes_skips_prompt_and_deletes(workdir):
+    """`rm --yes` deletes a terminal flow without prompting.
+
+    :param workdir: isolated working directory fixture.
+    """
+    f = _make_flow(workdir, "20200101_aaaaaaaa_hello")
+    runner = CliRunner()
+    result = runner.invoke(app, ["rm", "20200101_aaaaaaaa_hello", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not f.exists()

--- a/tests/cli/test_run_readiness.py
+++ b/tests/cli/test_run_readiness.py
@@ -1,0 +1,46 @@
+"""CLI test: `atelier run` refuses an unrunnable conduit before starting."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from flow_atelier.cli import app
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    """Isolated cwd with an empty `.atelier` tree and isolated global dir.
+
+    :param tmp_path: pytest temp directory fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    (tmp_path / ".atelier" / "conduits").mkdir(parents=True)
+    global_dir = tmp_path / "global"
+    (global_dir / "conduits").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    for k in list(os.environ):
+        if k.startswith("ATELIER_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("ATELIER_GLOBAL_ATELIER_DIR", str(global_dir))
+    monkeypatch.setenv("ATELIER_NO_UPDATE_CHECK", "1")
+    return tmp_path
+
+
+def test_run_refuses_unrunnable_conduit(workdir, monkeypatch):
+    """`run` exits 1 with the readiness message and never starts the flow."""
+    monkeypatch.setattr(
+        "flow_atelier.services.executor.harness.shutil.which",
+        lambda _binary: None,
+    )
+    cdir = workdir / ".atelier" / "conduits" / "agentic"
+    cdir.mkdir(parents=True)
+    (cdir / "conduit.yaml").write_text(
+        "name: agentic\ndescription: d\n"
+        "tasks:\n  - name: build\n    description: b\n    task: do it\n    tool: harness:claude-code\n"
+    )
+    result = CliRunner().invoke(app, ["run", "agentic"])
+    assert result.exit_code == 1
+    assert "cannot run" in result.stdout
+    assert "starting flow" not in result.stdout

--- a/tests/core/test_atelier_conduit_crud.py
+++ b/tests/core/test_atelier_conduit_crud.py
@@ -136,6 +136,7 @@ def test_open_conduit_path_invokes_platform_opener(tmp_path, atelier):
     atelier.create_conduit(_payload())
     run_path = tmp_path / "runs"
     run_path.mkdir()
+    atelier.store.create_flow("release_notes", {"run_path": str(run_path)})
     with patch("subprocess.Popen") as popen:
         popen.return_value.poll.return_value = None
         ok = atelier.open_conduit_path(str(run_path))
@@ -156,6 +157,20 @@ def test_open_conduit_path_returns_false_on_failure(tmp_path, atelier):
     :param atelier: Atelier facade fixture.
     """
     atelier.create_conduit(_payload())
+    atelier.store.create_flow("release_notes", {"run_path": str(tmp_path)})
     with patch("subprocess.Popen", side_effect=FileNotFoundError("no opener")):
         ok = atelier.open_conduit_path(str(tmp_path))
     assert ok is False
+
+
+def test_open_conduit_path_refuses_unknown_path(tmp_path, atelier):
+    """Verify open_conduit_path refuses a path not recorded for any flow.
+
+    :param tmp_path: pytest temp directory fixture.
+    :param atelier: Atelier facade fixture.
+    """
+    atelier.create_conduit(_payload())
+    with patch("subprocess.Popen") as popen:
+        ok = atelier.open_conduit_path(str(tmp_path / "not-a-flow-run"))
+    assert ok is False
+    popen.assert_not_called()

--- a/tests/core/test_atelier_readiness.py
+++ b/tests/core/test_atelier_readiness.py
@@ -1,0 +1,74 @@
+"""Atelier.tool_readiness — preflight runnability probe."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flow_atelier.core.atelier import Atelier
+from flow_atelier.core.settings import AtelierSettings
+from flow_atelier.schemas.conduit import Conduit
+
+
+@pytest.fixture
+def atelier(tmp_path, _isolate_global_atelier_dir):
+    """Construct an Atelier rooted under tmp_path with an isolated global dir.
+
+    :param tmp_path: pytest temp directory fixture.
+    :param _isolate_global_atelier_dir: isolated global atelier dir fixture.
+    """
+    global_dir: Path = _isolate_global_atelier_dir
+    return Atelier(
+        base_dir=tmp_path / ".atelier",
+        settings=AtelierSettings(
+            atelier_dir=tmp_path / ".atelier",
+            global_atelier_dir=global_dir,
+        ),
+    )
+
+
+def _conduit(tasks: list[dict]) -> Conduit:
+    """Build a minimal Conduit from a list of task dicts.
+
+    :param tasks: task payloads (each with name/description/task/tool).
+    """
+    return Conduit.model_validate(
+        {"name": "c", "description": "d", "tasks": tasks}
+    )
+
+
+def test_all_bash_conduit_is_ready(atelier):
+    """A conduit using only always-available tools reports no problems."""
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "a", "task": "echo hi", "tool": "tool:bash"},
+            {"name": "b", "description": "b", "task": "echo bye", "tool": "tool:bash"},
+        ]
+    )
+    assert atelier.tool_readiness(conduit) == []
+
+
+def test_unavailable_harness_is_reported(atelier):
+    """A task whose harness probe fails surfaces a message naming task+tool."""
+    atelier.executors["harness:claude-code"].is_available = lambda: (False, "no npx")
+    conduit = _conduit(
+        [
+            {"name": "build", "description": "b", "task": "do", "tool": "harness:claude-code"},
+        ]
+    )
+    problems = atelier.tool_readiness(conduit)
+    assert problems == ["task 'build' [harness:claude-code]: no npx"]
+
+
+def test_unregistered_tool_is_reported(atelier):
+    """Removing an executor key surfaces a 'no executor registered' message."""
+    del atelier.executors["harness:codex"]
+    conduit = _conduit(
+        [
+            {"name": "x", "description": "x", "task": "do", "tool": "harness:codex"},
+        ]
+    )
+    problems = atelier.tool_readiness(conduit)
+    assert problems == [
+        "task 'x': no executor registered for tool 'harness:codex'"
+    ]

--- a/tests/core/test_atelier_schedules.py
+++ b/tests/core/test_atelier_schedules.py
@@ -15,7 +15,22 @@ def atelier(tmp_path, monkeypatch):
     :param monkeypatch: pytest monkeypatch fixture.
     """
     monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
-    return Atelier(base_dir=tmp_path / ".atelier")
+    atelier = Atelier(base_dir=tmp_path / ".atelier")
+    # create_schedule validates conduit_name against the store, so the
+    # conduit the fixtures schedule must exist on disk.
+    conduit_dir = tmp_path / ".atelier" / "conduits" / "report"
+    conduit_dir.mkdir(parents=True)
+    (conduit_dir / "conduit.yaml").write_text(
+        "name: report\n"
+        "description: test conduit\n"
+        "tasks:\n"
+        "  - greet:\n"
+        "      description: say hi\n"
+        '      task: "echo hi"\n'
+        "      tool: tool:bash\n"
+        "      depends_on: []\n"
+    )
+    return atelier
 
 
 def _payload(**overrides) -> CreateScheduleInput:
@@ -55,6 +70,16 @@ def test_create_schedule_returns_scheduled_job(atelier):
     assert isinstance(job, ScheduledJob)
     assert job.conduit_name == "report"
     assert job.id.startswith("SCH-")
+
+
+def test_create_schedule_rejects_unknown_conduit(atelier):
+    """Verify create_schedule rejects a conduit_name with no conduit on disk.
+
+    :param atelier: Atelier facade fixture.
+    """
+    with pytest.raises(ValueError, match="unknown conduit"):
+        atelier.create_schedule(_payload(conduit_name="does-not-exist"))
+    assert atelier.list_schedules() == []
 
 
 def test_list_schedules_includes_created(atelier):

--- a/tests/modules/test_conditions.py
+++ b/tests/modules/test_conditions.py
@@ -60,6 +60,22 @@ def test_parse_empty():
         parse_dependency("")
 
 
+def test_parse_plain_rejects_unicode_name():
+    """Verify a plain dependency with a Unicode name is rejected.
+
+    ``str.isalnum()`` would accept ``café``, but no schema-valid task name
+    (ASCII ``[A-Za-z0-9_]+``) could ever match it, so it must be rejected.
+    """
+    with pytest.raises(DependencyParseError):
+        parse_dependency("café")
+
+
+def test_parse_conditional_rejects_unicode_task_name():
+    """Verify a conditional dependency with a Unicode task name is rejected."""
+    with pytest.raises(DependencyParseError):
+        parse_dependency("café.output.match(ok)")
+
+
 def test_evaluate_plain_completed():
     """Verify evaluate() returns satisfied for a completed plain dep."""
     dep = parse_dependency("a")
@@ -288,6 +304,40 @@ def test_evaluate_loop_predicate_invalid_mode_raises():
 
     with pytest.raises(ValueError):
         evaluate_loop_predicate(_pred("output.match(x)"), ["x"], "forever")  # type: ignore[arg-type]
+
+
+def test_evaluate_loop_predicate_truncates_oversized_output():
+    """Verify the matcher only sees the first MATCH_INPUT_CHAR_CAP chars.
+
+    A pattern anchored past the cap must not match, so an adversarial output
+    cannot force unbounded matching work on the shared event loop.
+    """
+    from flow_atelier.modules.conditions import (
+        MATCH_INPUT_CHAR_CAP,
+        evaluate_loop_predicate,
+    )
+
+    beyond_cap = "a" * MATCH_INPUT_CHAR_CAP + "DONE"
+    assert (
+        evaluate_loop_predicate(_pred("output.match(DONE)"), [beyond_cap], "until")
+        is False
+    )
+    within_cap = "DONE" + "a" * 10
+    assert (
+        evaluate_loop_predicate(_pred("output.match(DONE)"), [within_cap], "until")
+        is True
+    )
+
+
+def test_evaluate_conditional_dep_truncates_oversized_output():
+    """Verify evaluate() bounds the candidate output before matching."""
+    from flow_atelier.modules.conditions import MATCH_INPUT_CHAR_CAP
+
+    dep = parse_dependency("a.output.match(DONE)")
+    statuses = {"a": TaskStatus.completed}
+    beyond_cap = "a" * MATCH_INPUT_CHAR_CAP + "DONE"
+    result, _ = evaluate(dep, statuses, {"a": beyond_cap})
+    assert result == "skip"
 
 
 def test_sink_task_names_returns_undepended_tasks_in_order():

--- a/tests/modules/test_conditions.py
+++ b/tests/modules/test_conditions.py
@@ -1,4 +1,7 @@
 """Unit tests for the conditions module."""
+import asyncio
+import time
+
 import pytest
 
 from flow_atelier.modules.conditions import (
@@ -76,49 +79,49 @@ def test_parse_conditional_rejects_unicode_task_name():
         parse_dependency("café.output.match(ok)")
 
 
-def test_evaluate_plain_completed():
+async def test_evaluate_plain_completed():
     """Verify evaluate() returns satisfied for a completed plain dep."""
     dep = parse_dependency("a")
     status = {"a": TaskStatus.completed}
-    assert evaluate(dep, status, {"a": "ok"}) == ("satisfied", None)
+    assert await evaluate(dep, status, {"a": "ok"}) == ("satisfied", None)
 
 
-def test_evaluate_plain_running():
+async def test_evaluate_plain_running():
     """Verify evaluate() returns wait for a running plain dep."""
     dep = parse_dependency("a")
-    assert evaluate(dep, {"a": TaskStatus.running}, {}) == ("wait", None)
+    assert await evaluate(dep, {"a": TaskStatus.running}, {}) == ("wait", None)
 
 
-def test_evaluate_plain_failed():
+async def test_evaluate_plain_failed():
     """Verify evaluate() returns skip with a 'failed' reason for failed dep."""
     dep = parse_dependency("a")
-    result, reason = evaluate(dep, {"a": TaskStatus.failed}, {})
+    result, reason = await evaluate(dep, {"a": TaskStatus.failed}, {})
     assert result == "skip"
     assert "failed" in reason
 
 
-def test_evaluate_plain_skipped():
+async def test_evaluate_plain_skipped():
     """Verify evaluate() returns skip with a 'skipped' reason for skipped dep."""
     dep = parse_dependency("a")
-    result, reason = evaluate(dep, {"a": TaskStatus.skipped}, {})
+    result, reason = await evaluate(dep, {"a": TaskStatus.skipped}, {})
     assert result == "skip"
     assert "skipped" in reason
 
 
-def test_evaluate_conditional_match_satisfied():
+async def test_evaluate_conditional_match_satisfied():
     """Verify evaluate() returns satisfied when the match pattern hits."""
     dep = parse_dependency("a.output.match(VERDICT:\\s*APPROVE)")
-    assert evaluate(
+    assert await evaluate(
         dep,
         {"a": TaskStatus.completed},
         {"a": "blah\nVERDICT: APPROVE\n"},
     ) == ("satisfied", None)
 
 
-def test_evaluate_conditional_match_not_met_skips():
+async def test_evaluate_conditional_match_not_met_skips():
     """Verify evaluate() skips when the match pattern is absent."""
     dep = parse_dependency("a.output.match(VERDICT:\\s*APPROVE)")
-    result, reason = evaluate(
+    result, reason = await evaluate(
         dep,
         {"a": TaskStatus.completed},
         {"a": "VERDICT: REJECT"},
@@ -127,20 +130,20 @@ def test_evaluate_conditional_match_not_met_skips():
     assert "condition not met" in reason
 
 
-def test_evaluate_not_match_satisfied():
+async def test_evaluate_not_match_satisfied():
     """Verify evaluate() returns satisfied when the not_match pattern is absent."""
     dep = parse_dependency("a.output.not_match(CRITICAL)")
-    assert evaluate(
+    assert await evaluate(
         dep,
         {"a": TaskStatus.completed},
         {"a": "all good"},
     ) == ("satisfied", None)
 
 
-def test_evaluate_not_match_triggers_skip():
+async def test_evaluate_not_match_triggers_skip():
     """Verify evaluate() skips when not_match pattern is present."""
     dep = parse_dependency("a.output.not_match(CRITICAL)")
-    result, _ = evaluate(
+    result, _ = await evaluate(
         dep,
         {"a": TaskStatus.completed},
         {"a": "CRITICAL vuln"},
@@ -148,10 +151,10 @@ def test_evaluate_not_match_triggers_skip():
     assert result == "skip"
 
 
-def test_evaluate_unknown_task_skips():
+async def test_evaluate_unknown_task_skips():
     """Verify evaluate() skips when the dependency target is unknown."""
     dep = parse_dependency("ghost")
-    result, reason = evaluate(dep, {"a": TaskStatus.completed}, {})
+    result, reason = await evaluate(dep, {"a": TaskStatus.completed}, {})
     assert result == "skip"
     assert "unknown" in reason
 
@@ -248,7 +251,7 @@ def _pred(expr: str):
         ("output.not_match(RETRY)", ["RETRY", "clean"], False),
     ],
 )
-def test_evaluate_loop_predicate_until(expr, outputs, expected):
+async def test_evaluate_loop_predicate_until(expr, outputs, expected):
     """Verify evaluate_loop_predicate() in until mode for parametrized cases.
 
     :param expr: predicate expression under test.
@@ -257,7 +260,7 @@ def test_evaluate_loop_predicate_until(expr, outputs, expected):
     """
     from flow_atelier.modules.conditions import evaluate_loop_predicate
 
-    assert evaluate_loop_predicate(_pred(expr), outputs, "until") is expected
+    assert await evaluate_loop_predicate(_pred(expr), outputs, "until") is expected
 
 
 @pytest.mark.parametrize(
@@ -276,7 +279,7 @@ def test_evaluate_loop_predicate_until(expr, outputs, expected):
         ("output.not_match(ready)", ["ready", "pending"], False),
     ],
 )
-def test_evaluate_loop_predicate_while(expr, outputs, expected):
+async def test_evaluate_loop_predicate_while(expr, outputs, expected):
     """Verify evaluate_loop_predicate() in while mode for parametrized cases.
 
     :param expr: predicate expression under test.
@@ -285,28 +288,32 @@ def test_evaluate_loop_predicate_while(expr, outputs, expected):
     """
     from flow_atelier.modules.conditions import evaluate_loop_predicate
 
-    assert evaluate_loop_predicate(_pred(expr), outputs, "while") is expected
+    assert await evaluate_loop_predicate(_pred(expr), outputs, "while") is expected
 
 
-def test_evaluate_loop_predicate_empty_outputs_does_not_break():
+async def test_evaluate_loop_predicate_empty_outputs_does_not_break():
     """Verify evaluate_loop_predicate() returns False on empty outputs."""
     from flow_atelier.modules.conditions import evaluate_loop_predicate
 
-    assert evaluate_loop_predicate(_pred("output.match(x)"), [], "until") is False
-    assert evaluate_loop_predicate(_pred("output.match(x)"), [], "while") is False
-    assert evaluate_loop_predicate(_pred("output.not_match(x)"), [], "until") is False
-    assert evaluate_loop_predicate(_pred("output.not_match(x)"), [], "while") is False
+    assert await evaluate_loop_predicate(_pred("output.match(x)"), [], "until") is False
+    assert await evaluate_loop_predicate(_pred("output.match(x)"), [], "while") is False
+    assert (
+        await evaluate_loop_predicate(_pred("output.not_match(x)"), [], "until") is False
+    )
+    assert (
+        await evaluate_loop_predicate(_pred("output.not_match(x)"), [], "while") is False
+    )
 
 
-def test_evaluate_loop_predicate_invalid_mode_raises():
+async def test_evaluate_loop_predicate_invalid_mode_raises():
     """Verify evaluate_loop_predicate() raises on an unknown mode."""
     from flow_atelier.modules.conditions import evaluate_loop_predicate
 
     with pytest.raises(ValueError):
-        evaluate_loop_predicate(_pred("output.match(x)"), ["x"], "forever")  # type: ignore[arg-type]
+        await evaluate_loop_predicate(_pred("output.match(x)"), ["x"], "forever")  # type: ignore[arg-type]
 
 
-def test_evaluate_loop_predicate_truncates_oversized_output():
+async def test_evaluate_loop_predicate_truncates_oversized_output():
     """Verify the matcher only sees the first MATCH_INPUT_CHAR_CAP chars.
 
     A pattern anchored past the cap must not match, so an adversarial output
@@ -319,25 +326,65 @@ def test_evaluate_loop_predicate_truncates_oversized_output():
 
     beyond_cap = "a" * MATCH_INPUT_CHAR_CAP + "DONE"
     assert (
-        evaluate_loop_predicate(_pred("output.match(DONE)"), [beyond_cap], "until")
+        await evaluate_loop_predicate(
+            _pred("output.match(DONE)"), [beyond_cap], "until"
+        )
         is False
     )
     within_cap = "DONE" + "a" * 10
     assert (
-        evaluate_loop_predicate(_pred("output.match(DONE)"), [within_cap], "until")
+        await evaluate_loop_predicate(
+            _pred("output.match(DONE)"), [within_cap], "until"
+        )
         is True
     )
 
 
-def test_evaluate_conditional_dep_truncates_oversized_output():
+async def test_evaluate_conditional_dep_truncates_oversized_output():
     """Verify evaluate() bounds the candidate output before matching."""
     from flow_atelier.modules.conditions import MATCH_INPUT_CHAR_CAP
 
     dep = parse_dependency("a.output.match(DONE)")
     statuses = {"a": TaskStatus.completed}
     beyond_cap = "a" * MATCH_INPUT_CHAR_CAP + "DONE"
-    result, _ = evaluate(dep, statuses, {"a": beyond_cap})
+    result, _ = await evaluate(dep, statuses, {"a": beyond_cap})
     assert result == "skip"
+
+
+async def test_loop_predicate_match_runs_off_event_loop():
+    """A slow (CPU-bound) regex match must not block concurrent coroutines.
+
+    The matcher runs via ``asyncio.to_thread``, so a search that blocks its
+    worker thread leaves the event loop free: a concurrent ticker keeps
+    advancing. If the search ran inline on the loop, the ticker would be
+    frozen for the whole match and barely advance.
+    """
+    from flow_atelier.modules.conditions import evaluate_loop_predicate
+
+    class _BlockingPattern:
+        def search(self, _text: str):
+            # Stand-in for a catastrophic-backtracking match: blocks the
+            # calling thread (not the event loop) for a fixed duration.
+            time.sleep(0.2)
+            return None
+
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        for _ in range(40):
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    tick_task = asyncio.create_task(ticker())
+    try:
+        result = await evaluate_loop_predicate((_BlockingPattern(), False), ["x"], "until")
+    finally:
+        tick_task.cancel()
+
+    assert result is False
+    # ~0.2s of off-loop matching at one tick per 5ms -> well over 10 ticks.
+    assert ticks >= 10
 
 
 def test_sink_task_names_returns_undepended_tasks_in_order():

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -1675,3 +1675,142 @@ def test_validate_allows_templated_conduit_target():
         ]
     )
     validate_conduit(c)  # must not raise
+
+
+# ---------------------------------------------------------------- retry on failure
+
+
+class FailNThenSucceed(FakeExecutor):
+    """Fail the first ``fail_times`` executions, then succeed."""
+
+    def __init__(self, fail_times: int):
+        """Initialize the executor with a budget of failing calls.
+
+        :param fail_times: number of leading executions that should fail.
+        """
+        super().__init__()
+        self.fail_times = fail_times
+
+    async def execute(self, task, resolved_command, context):
+        """Fail until ``fail_times`` is exhausted, then succeed.
+
+        :param task: task definition being executed.
+        :param resolved_command: command string after template resolution.
+        :param context: flow context provided by the engine.
+        """
+        self.calls.append(task.name)
+        if len(self.calls) <= self.fail_times:
+            return ExecutionResult(exit_code=1, stderr="boom")
+        return ExecutionResult(exit_code=0, output="ok")
+
+
+async def test_retry_succeeds_after_failures(store):
+    """A task that fails N times then succeeds completes when retries >= N.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": [], "retries": 2},
+        ]
+    )
+    fake = FailNThenSucceed(fail_times=2)
+    engine = Engine({"tool:bash": fake}, store)
+    flow_id = await engine.run(conduit, {})
+    p = store.read_progress(flow_id)
+    assert p.status == FlowStatus.completed
+    assert p.tasks["a"].status == TaskStatus.completed
+    assert fake.calls == ["a", "a", "a"]  # 2 failures + 1 success
+
+
+async def test_retry_exhausted_fails(store):
+    """A task that always fails trips fail-fast after 1 + retries attempts.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": [], "retries": 2},
+        ]
+    )
+    fake = FakeExecutor(fail={"a"})
+    engine = Engine({"tool:bash": fake}, store)
+    with pytest.raises(RuntimeError):
+        await engine.run(conduit, {})
+    assert fake.calls == ["a", "a", "a"]  # exactly 3 attempts
+
+
+async def test_retry_logs_each_attempt(store):
+    """Every attempt is persisted as its own LogEntry with attempt metadata.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": [], "retries": 2},
+        ]
+    )
+    fake = FailNThenSucceed(fail_times=2)
+    engine = Engine({"tool:bash": fake}, store)
+    flow_id = await engine.run(conduit, {})
+    logs = [e for e in store.read_logs(flow_id) if e.task == "a"]
+    assert [e.exit_code for e in logs] == [1, 1, 0]
+    assert [e.extra["attempt"] for e in logs] == [1, 2, 3]
+    assert all(e.extra["of_attempts"] == 3 for e in logs)
+
+
+async def test_retries_zero_identical_to_current(store):
+    """retries: 0 fails after a single attempt, unchanged from today.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": []},
+        ]
+    )
+    fake = FakeExecutor(fail={"a"})
+    engine = Engine({"tool:bash": fake}, store)
+    with pytest.raises(RuntimeError):
+        await engine.run(conduit, {})
+    assert fake.calls == ["a"]  # exactly one call, no retry
+
+
+async def test_hitl_not_retried(store):
+    """A tool:hitl task never auto-retries even when retries is set.
+
+    :param store: FilesystemStore fixture.
+    """
+    conduit = _conduit(
+        [
+            {"name": "ask", "description": "d", "task": "x", "tool": "tool:hitl",
+             "depends_on": [], "retries": 3},
+        ]
+    )
+    fake = FakeExecutor(fail={"ask"})
+    engine = Engine({"tool:hitl": fake}, store)
+    with pytest.raises(RuntimeError):
+        await engine.run(conduit, {})
+    assert fake.calls == ["ask"]  # one attempt only, retries ignored
+
+
+def test_negative_retries_rejected():
+    """Conduit validation rejects a negative retries value."""
+    with pytest.raises(Exception, match="retries"):  # noqa: PT011
+        _conduit(
+            [{"name": "a", "description": "d", "task": "x",
+              "tool": "tool:bash", "retries": -1}]
+        )
+
+
+def test_negative_retry_backoff_rejected():
+    """Conduit validation rejects a negative retry_backoff value."""
+    with pytest.raises(Exception, match="retry_backoff"):  # noqa: PT011
+        _conduit(
+            [{"name": "a", "description": "d", "task": "x",
+              "tool": "tool:bash", "retry_backoff": -1}]
+        )

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -1778,6 +1778,12 @@ async def test_retries_zero_identical_to_current(store):
     with pytest.raises(RuntimeError):
         await engine.run(conduit, {})
     assert fake.calls == ["a"]  # exactly one call, no retry
+    # No retries configured: the persisted log entry must carry no attempt
+    # metadata, byte-for-byte identical to pre-retry behavior.
+    flow_id = store.list_flows()[0]
+    logs = [e for e in store.read_logs(flow_id) if e.task == "a"]
+    assert len(logs) == 1
+    assert logs[0].extra == {}
 
 
 async def test_hitl_not_retried(store):

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -1554,6 +1554,97 @@ async def test_backstop_timeout_still_kills_non_hitl(store, monkeypatch):
     assert logs[-1].exit_code == 124
 
 
+async def test_per_task_timeout_override_kills_early(store, monkeypatch):
+    """A per-task timeout supersedes the larger conduit ceiling for that task.
+
+    :param store: FilesystemStore fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    import flow_atelier.modules.engine as engine_mod
+
+    monkeypatch.setattr(engine_mod, "BACKSTOP_GRACE_SECONDS", 0)
+
+    class IgnoresTimeout(ExecutorBase):
+        async def execute(self, task, resolved_command, context):
+            await asyncio.sleep(1.3)
+            return ExecutionResult(exit_code=0, output="ok", stdout="ok")
+
+    # Conduit ceiling is huge (30s); the task's own 1s override drives the kill.
+    conduit = _conduit(
+        [
+            {"name": "slow", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": [], "timeout": 1},
+        ],
+        timeout=30,
+    )
+    engine = Engine({"tool:bash": IgnoresTimeout()}, store)
+    captured: dict[str, str] = {}
+    with pytest.raises(RuntimeError, match="exit=124"):
+        await engine.run(
+            conduit, {}, on_flow_started=lambda fid: captured.update(id=fid)
+        )
+    logs = store.read_logs(captured["id"])
+    assert logs[-1].exit_code == 124
+    assert "engine timeout after 1s" in logs[-1].stderr
+
+
+async def test_effective_timeout_override_vs_inheritance(store):
+    """ctx.timeout reflects a task's override when set, else the conduit value.
+
+    :param store: FilesystemStore fixture.
+    """
+    seen: dict[str, int] = {}
+
+    class CaptureTimeout(ExecutorBase):
+        async def execute(self, task, resolved_command, context):
+            seen[task.name] = context.timeout
+            return ExecutionResult(exit_code=0, output="ok", stdout="ok")
+
+    conduit = _conduit(
+        [
+            {"name": "over", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": [], "timeout": 7},
+            {"name": "inherit", "description": "d", "task": "x", "tool": "tool:bash",
+             "depends_on": []},
+        ],
+        timeout=42,
+    )
+    engine = Engine({"tool:bash": CaptureTimeout()}, store)
+    flow_id = await engine.run(conduit, {})
+    assert store.read_progress(flow_id).status == FlowStatus.completed
+    assert seen["over"] == 7
+    assert seen["inherit"] == 42
+
+
+async def test_hitl_ignores_configured_timeout(store, monkeypatch):
+    """A configured timeout on a hitl task is ignored — it stays unbounded.
+
+    :param store: FilesystemStore fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    import flow_atelier.modules.engine as engine_mod
+
+    monkeypatch.setattr(engine_mod, "BACKSTOP_GRACE_SECONDS", 0)
+
+    class SlowHitl(ExecutorBase):
+        async def execute(self, task, resolved_command, context):
+            await asyncio.sleep(1.3)
+            return ExecutionResult(exit_code=0, output="ok", stdout="ok")
+
+    conduit = _conduit(
+        [
+            {"name": "ask", "description": "d", "task": "x", "tool": "tool:hitl",
+             "depends_on": [], "timeout": 1},
+        ],
+        timeout=30,
+    )
+    engine = Engine({"tool:hitl": SlowHitl()}, store)
+    flow_id = await engine.run(conduit, {})
+    p = store.read_progress(flow_id)
+    assert p.status == FlowStatus.completed
+    assert p.tasks["ask"].status == TaskStatus.completed
+
+
 # --------------------------------------------------------------- nested cycle guard
 
 

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -14,6 +14,7 @@ from flow_atelier.schemas.conduit import Conduit
 from flow_atelier.schemas.log import ExecutionResult
 from flow_atelier.schemas.progress import FlowStatus, TaskStatus
 from flow_atelier.services.executor.base import ExecutorBase
+from flow_atelier.services.executor.conduit import ConduitExecutor
 from flow_atelier.services.store.filesystem import FilesystemStore
 
 
@@ -1551,3 +1552,126 @@ async def test_backstop_timeout_still_kills_non_hitl(store, monkeypatch):
     assert p.status == FlowStatus.failed
     logs = store.read_logs(captured["id"])
     assert logs[-1].exit_code == 124
+
+
+# --------------------------------------------------------------- nested cycle guard
+
+
+def _named_conduit(name, tasks):
+    """Build a Conduit with an explicit name (the _conduit helper hardcodes one).
+
+    :param name: conduit name.
+    :param tasks: list of task dicts each containing a ``name`` and task fields.
+    """
+    return Conduit.model_validate(
+        {
+            "name": name,
+            "description": "d",
+            "tasks": [
+                {t["name"]: {k: v for k, v in t.items() if k != "name"}}
+                for t in tasks
+            ],
+        }
+    )
+
+
+def _count_progress_files(store):
+    """Return how many flow ``progress.json`` files exist under the store.
+
+    :param store: FilesystemStore fixture.
+    """
+    return len(list((store.base_dir / "flows").rglob("progress.json")))
+
+
+async def test_nested_conduit_self_cycle_fails_fast(store):
+    """A conduit whose tool:conduit task targets itself fails with a cycle
+    error and creates no nested flow (only the top-level flow exists).
+
+    :param store: FilesystemStore fixture.
+    """
+    a = _named_conduit(
+        "selfcyc",
+        [{"name": "again", "description": "d", "task": "selfcyc",
+          "tool": "tool:conduit"}],
+    )
+    store.write_conduit(a)
+    engine = Engine({"tool:conduit": ConduitExecutor()}, store)
+    with pytest.raises(Exception) as ei:  # noqa: PT011
+        await engine.run(a, {})
+    assert "cycle" in str(ei.value).lower()
+    # Only the top-level flow's progress was written; the cycle is caught
+    # before any nested flow dir is created.
+    assert _count_progress_files(store) == 1
+
+
+async def test_nested_conduit_mutual_cycle_fails_fast(store):
+    """A -> B -> A mutual recursion is caught and bounded.
+
+    :param store: FilesystemStore fixture.
+    """
+    a = _named_conduit(
+        "muta",
+        [{"name": "callb", "description": "d", "task": "mutb",
+          "tool": "tool:conduit"}],
+    )
+    b = _named_conduit(
+        "mutb",
+        [{"name": "calla", "description": "d", "task": "muta",
+          "tool": "tool:conduit"}],
+    )
+    store.write_conduit(a)
+    store.write_conduit(b)
+    engine = Engine({"tool:conduit": ConduitExecutor()}, store)
+    with pytest.raises(Exception) as ei:  # noqa: PT011
+        await engine.run(a, {})
+    assert "cycle" in str(ei.value).lower()
+    # A and B each created one flow; the re-entry into A is rejected before
+    # a third flow dir is created.
+    assert _count_progress_files(store) == 2
+
+
+async def test_nested_conduit_legitimate_chain_completes(store):
+    """A legitimate A -> B (B has a non-conduit leaf task) still completes.
+
+    :param store: FilesystemStore fixture.
+    """
+    a = _named_conduit(
+        "parent",
+        [{"name": "callchild", "description": "d", "task": "child",
+          "tool": "tool:conduit"}],
+    )
+    b = _named_conduit(
+        "child",
+        [{"name": "leaf", "description": "d", "task": "echo hi",
+          "tool": "tool:bash"}],
+    )
+    store.write_conduit(a)
+    store.write_conduit(b)
+    engine = Engine(
+        {"tool:conduit": ConduitExecutor(), "tool:bash": FakeExecutor()}, store
+    )
+    flow_id = await engine.run(a, {})
+    p = store.read_progress(flow_id)
+    assert p.status == FlowStatus.completed
+
+
+def test_validate_rejects_literal_conduit_traversal_target():
+    """A literal tool:conduit target with path separators fails validation."""
+    c = _conduit(
+        [{"name": "n", "description": "d", "task": "../evil",
+          "tool": "tool:conduit"}]
+    )
+    with pytest.raises(ConduitValidationError):
+        validate_conduit(c)
+
+
+def test_validate_allows_templated_conduit_target():
+    """A templated tool:conduit target is deferred to runtime, not rejected."""
+    c = _conduit(
+        [
+            {"name": "pick", "description": "d", "task": "echo", "tool": "tool:bash"},
+            {"name": "n", "description": "d", "task": "{{pick.output}}",
+             "tool": "tool:conduit", "depends_on": ["pick"]},
+        ]
+    )
+    validate_conduit(c)  # must not raise

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -5,7 +5,11 @@ from typing import Any
 import pytest
 import yaml
 
-from flow_atelier.modules.engine import ConduitValidationError, Engine
+from flow_atelier.modules.engine import (
+    ConduitValidationError,
+    Engine,
+    validate_conduit,
+)
 from flow_atelier.schemas.conduit import Conduit
 from flow_atelier.schemas.log import ExecutionResult
 from flow_atelier.schemas.progress import FlowStatus, TaskStatus
@@ -464,6 +468,118 @@ async def test_validate_accepts_ref_via_conditional_dep(store):
     engine = Engine({"tool:bash": FakeExecutor()}, store)
     flow_id = await engine.run(conduit, {})
     assert store.read_progress(flow_id).status == FlowStatus.completed
+
+
+def test_validate_rejects_unrecognized_expression():
+    """A {{...}} matching none of the grammar forms is rejected at author time."""
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "use {{inputs}}",
+             "tool": "tool:bash", "depends_on": []},
+        ]
+    )
+    with pytest.raises(
+        ConduitValidationError,
+        match=r"task 'a' has an unrecognized template expression \{\{inputs\}\}",
+    ):
+        validate_conduit(conduit)
+
+
+def test_validate_rejects_misspelled_output():
+    """A misspelled `.output` ({{x.outpt}}) is unrecognized and rejected."""
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "use {{job.outpt}}",
+             "tool": "tool:bash", "depends_on": []},
+        ]
+    )
+    with pytest.raises(
+        ConduitValidationError, match=r"unrecognized template expression"
+    ):
+        validate_conduit(conduit)
+
+
+def test_validate_rejects_loop_ref_in_non_looping_task():
+    """{{loop.previous}}/{{loop.history}} in a repeat==1 task is rejected."""
+    for expr in ("loop.previous", "loop.history"):
+        conduit = _conduit(
+            [
+                {"name": "a", "description": "d", "task": f"use {{{{{expr}}}}}",
+                 "tool": "tool:bash", "depends_on": []},
+            ]
+        )
+        with pytest.raises(
+            ConduitValidationError, match=r"does not loop \(repeat is 1\)"
+        ):
+            validate_conduit(conduit)
+
+
+def test_validate_accepts_loop_ref_in_looping_task():
+    """{{loop.*}} is valid when the task actually loops (repeat > 1)."""
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "use {{loop.previous}}",
+             "tool": "tool:bash", "depends_on": [], "repeat": 3},
+        ]
+    )
+    validate_conduit(conduit)  # must not raise
+
+
+def test_validate_scans_conduit_input_unknown_task():
+    """A tool:conduit task's inputs value referencing an unknown task fails."""
+    conduit = _conduit(
+        [
+            {"name": "caller", "description": "d", "task": "child",
+             "tool": "tool:conduit", "depends_on": [],
+             "inputs": {"p": "{{ghost.output}}"}},
+        ]
+    )
+    with pytest.raises(
+        ConduitValidationError, match="references unknown task 'ghost'"
+    ):
+        validate_conduit(conduit)
+
+
+def test_validate_scans_conduit_input_out_of_deps():
+    """A tool:conduit inputs ref to a task outside its deps chain fails."""
+    conduit = _conduit(
+        [
+            {"name": "producer", "description": "d", "task": "x",
+             "tool": "tool:bash", "depends_on": []},
+            {"name": "caller", "description": "d", "task": "child",
+             "tool": "tool:conduit", "depends_on": [],
+             "inputs": {"p": "{{producer.output}}"}},
+        ]
+    )
+    with pytest.raises(
+        ConduitValidationError, match="not in its depends_on chain"
+    ):
+        validate_conduit(conduit)
+
+
+def test_validate_accepts_conduit_input_ref_in_deps():
+    """A tool:conduit inputs ref to an in-chain dependency is valid."""
+    conduit = _conduit(
+        [
+            {"name": "producer", "description": "d", "task": "x",
+             "tool": "tool:bash", "depends_on": []},
+            {"name": "caller", "description": "d", "task": "child",
+             "tool": "tool:conduit", "depends_on": ["producer"],
+             "inputs": {"p": "{{producer.output}}"}},
+        ]
+    )
+    validate_conduit(conduit)  # must not raise
+
+
+def test_validate_does_not_require_inputs_declared():
+    """Regression: {{inputs.x}} need not be declared (supplied at run time)."""
+    conduit = _conduit(
+        [
+            {"name": "a", "description": "d", "task": "use {{inputs.undeclared}}",
+             "tool": "tool:bash", "depends_on": []},
+        ]
+    )
+    validate_conduit(conduit)  # must not raise
 
 
 async def test_mid_loop_template_error_marks_task_failed(store):

--- a/tests/modules/test_liveness.py
+++ b/tests/modules/test_liveness.py
@@ -1,0 +1,91 @@
+"""Unit tests for read-side flow liveness reclassification."""
+import os
+import socket
+import subprocess
+import sys
+
+from flow_atelier.modules.liveness import display_status, is_crashed
+from flow_atelier.schemas.progress import FlowStatus, Progress
+
+
+def _dead_local_pid() -> int:
+    """Return a pid that has provably exited on this host.
+
+    Spawns a trivial child, waits for it to be reaped, and returns its pid.
+    On POSIX a reaped pid no longer refers to a live process, so
+    ``os.kill(pid, 0)`` raises ``ProcessLookupError``.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
+def test_dead_local_runner_is_crashed():
+    """A running flow with a dead local pid is reclassified crashed."""
+    p = Progress(
+        status=FlowStatus.running,
+        runner_pid=_dead_local_pid(),
+        runner_host=socket.gethostname(),
+    )
+    assert is_crashed(p) is True
+    assert display_status(p) == "crashed"
+
+
+def test_live_local_runner_stays_running():
+    """A running flow whose pid is alive (this process) stays running."""
+    p = Progress(
+        status=FlowStatus.running,
+        runner_pid=os.getpid(),
+        runner_host=socket.gethostname(),
+    )
+    assert is_crashed(p) is False
+    assert display_status(p) == "running"
+
+
+def test_foreign_host_stays_running():
+    """A running flow on another host is never probed and stays running."""
+    p = Progress(
+        status=FlowStatus.running,
+        runner_pid=_dead_local_pid(),
+        runner_host="some-other-box-that-is-not-us",
+    )
+    assert is_crashed(p) is False
+    assert display_status(p) == "running"
+
+
+def test_legacy_progress_without_pid_stays_running():
+    """A legacy progress.json with no runner_pid stays running."""
+    p = Progress(status=FlowStatus.running)
+    assert p.runner_pid is None
+    assert is_crashed(p) is False
+    assert display_status(p) == "running"
+
+
+def test_terminal_status_with_dead_pid_not_crashed():
+    """A completed/failed flow is never reclassified, even with a dead pid."""
+    host = socket.gethostname()
+    dead = _dead_local_pid()
+    for status in (FlowStatus.completed, FlowStatus.failed):
+        p = Progress(status=status, runner_pid=dead, runner_host=host)
+        assert is_crashed(p) is False
+        assert display_status(p) == status.value
+
+
+def test_runner_fields_round_trip():
+    """runner_pid/runner_host survive model_dump/model_validate."""
+    p = Progress(
+        status=FlowStatus.running, runner_pid=4242, runner_host="boxy"
+    )
+    dumped = p.model_dump(mode="json")
+    assert dumped["runner_pid"] == 4242
+    assert dumped["runner_host"] == "boxy"
+    restored = Progress.model_validate(dumped)
+    assert restored.runner_pid == 4242
+    assert restored.runner_host == "boxy"
+
+
+def test_legacy_progress_json_without_runner_fields_loads():
+    """A progress dict missing the runner fields loads with both None."""
+    restored = Progress.model_validate({"status": "running"})
+    assert restored.runner_pid is None
+    assert restored.runner_host is None

--- a/tests/modules/test_templating.py
+++ b/tests/modules/test_templating.py
@@ -4,7 +4,9 @@ import pytest
 from flow_atelier.modules.templating import (
     SkipSignal,
     TemplateError,
+    TemplateRef,
     extract_task_refs,
+    extract_template_refs,
     resolve,
 )
 
@@ -172,3 +174,34 @@ def test_extract_task_refs_ignores_inputs_and_loop():
 def test_extract_task_refs_empty_for_plain_text():
     """Verify extract_task_refs returns an empty set without templates."""
     assert extract_task_refs("echo plain") == set()
+
+
+def test_extract_template_refs_classifies_each_form():
+    """Verify each grammar form is classified with the right kind/value."""
+    refs = extract_template_refs(
+        "{{inputs.x}} {{loop.previous}} {{loop.history}} {{build.output}}"
+    )
+    assert refs == [
+        TemplateRef("input", "x", "inputs.x"),
+        TemplateRef("loop", "loop.previous", "loop.previous"),
+        TemplateRef("loop", "loop.history", "loop.history"),
+        TemplateRef("task", "build", "build.output"),
+    ]
+
+
+def test_extract_template_refs_flags_unrecognized():
+    """Verify malformed expressions are classified as 'unknown'."""
+    for expr in ("inputs", "job.outpt", "loop.histroy"):
+        refs = extract_template_refs(f"{{{{{expr}}}}}")
+        assert refs == [TemplateRef("unknown", expr, expr)]
+
+
+def test_extract_template_refs_empty_for_plain_text():
+    """Verify plain text yields no refs."""
+    assert extract_template_refs("echo plain") == []
+
+
+def test_extract_template_refs_preserves_source_order():
+    """Verify refs are returned in source-appearance order."""
+    refs = extract_template_refs("{{b.output}} {{inputs.a}}")
+    assert [r.value for r in refs] == ["b", "a"]

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -323,6 +323,40 @@ def test_repeat_must_be_positive():
         )
 
 
+@pytest.mark.parametrize("bad", [0, -1])
+def test_task_timeout_must_be_positive(bad):
+    """Verify an explicit per-task timeout below 1 is rejected.
+
+    :param bad: a non-positive timeout value expected to fail validation.
+    """
+    with pytest.raises(Exception, match="timeout must be >= 1"):
+        Conduit.model_validate(
+            {
+                "name": "x",
+                "description": "d",
+                "tasks": [
+                    {"a": {"description": "d", "task": "x", "tool": "tool:bash", "depends_on": [], "timeout": bad}}
+                ],
+            }
+        )
+
+
+def test_task_timeout_none_and_positive_ok():
+    """Verify an omitted timeout defaults to None and a positive value loads."""
+    c = Conduit.model_validate(
+        {
+            "name": "x",
+            "description": "d",
+            "tasks": [
+                {"a": {"description": "d", "task": "x", "tool": "tool:bash", "depends_on": []}},
+                {"b": {"description": "d", "task": "x", "tool": "tool:bash", "depends_on": [], "timeout": 60}},
+            ],
+        }
+    )
+    assert c.tasks[0].timeout is None
+    assert c.tasks[1].timeout == 60
+
+
 def _task_with_until(**overrides):
     """Build a Conduit payload with an `until` task, applying overrides.
 

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -256,6 +256,32 @@ def test_invalid_task_names_rejected(bad_name):
 
 
 @pytest.mark.parametrize(
+    "bad_name", ["../evil", "a/b", "..", ".", "a.b", "a b", ""]
+)
+def test_invalid_conduit_names_rejected(bad_name):
+    """Verify conduit names that escape a single path component are rejected.
+
+    :param bad_name: parametrized unsafe conduit name under test.
+    """
+    with pytest.raises(Exception, match="invalid conduit name"):
+        Conduit.model_validate(
+            {"name": bad_name, "description": "d", "tasks": []}
+        )
+
+
+@pytest.mark.parametrize("good_name", ["autonomous-projects", "x", "a_b-c1"])
+def test_hyphenated_conduit_names_allowed(good_name):
+    """Verify real dash-named conduits still validate.
+
+    :param good_name: parametrized safe conduit name under test.
+    """
+    conduit = Conduit.model_validate(
+        {"name": good_name, "description": "d", "tasks": []}
+    )
+    assert conduit.name == good_name
+
+
+@pytest.mark.parametrize(
     "tool_str",
     ["harness:opencode", "harness:copilot", "harness:cursor"],
 )

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -834,3 +834,25 @@ class TestDrainPendingNotifications:
         rather than raising."""
         conn = types.SimpleNamespace()  # no _conn
         await AcpHarnessExecutor._drain_pending_notifications(conn)
+
+
+def test_is_available_true_when_binary_on_path(monkeypatch) -> None:
+    """is_available returns (True, "") when the launch binary resolves."""
+    monkeypatch.setattr(
+        "flow_atelier.services.executor.harness.shutil.which",
+        lambda _binary: "/usr/bin/npx",
+    )
+    executor = AcpHarnessExecutor(launch_cmd=["npx", "-y", "pkg"])
+    assert executor.is_available() == (True, "")
+
+
+def test_is_available_false_when_binary_missing(monkeypatch) -> None:
+    """is_available returns (False, reason) naming the missing binary."""
+    monkeypatch.setattr(
+        "flow_atelier.services.executor.harness.shutil.which",
+        lambda _binary: None,
+    )
+    executor = AcpHarnessExecutor(launch_cmd=["npx", "-y", "pkg"])
+    ok, reason = executor.is_available()
+    assert ok is False
+    assert "npx" in reason

--- a/tests/services/executor/test_harness.py
+++ b/tests/services/executor/test_harness.py
@@ -1,8 +1,10 @@
 """HarnessExecutor unit tests using the fake ACP agent fixture."""
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -766,3 +768,69 @@ class TestLastTurnOutput:
         assert result.exit_code == 0
         assert result.last_turn_output is None
         assert "hi" in result.output
+
+
+class TestDrainPendingNotifications:
+    async def test_drain_awaits_queued_and_inflight_handlers(self) -> None:
+        """The drain must wait for every queued notification's handler to
+        finish — including handlers that only append after a scheduling
+        gap — so no streamed chunk is dropped from the buffered output.
+
+        Uses the real ACP dispatcher (queue -> supervisor.create(handler))
+        with slow handlers; a buffer-stability poll would sample the empty
+        buffer and return early, while the deterministic drain guarantees
+        every handler has completed before it returns.
+        """
+        from acp.task import (
+            DefaultMessageDispatcher,
+            InMemoryMessageQueue,
+            InMemoryMessageStateStore,
+            RpcTask,
+            RpcTaskKind,
+            TaskSupervisor,
+        )
+
+        queue = InMemoryMessageQueue()
+        supervisor = TaskSupervisor(source="test")
+        store = InMemoryMessageStateStore()
+        buffer: list[str] = []
+
+        async def notification_runner(message: dict[str, Any]) -> None:
+            # Append only after a scheduling gap: a 20ms stability poll
+            # would have already given up by the time this lands.
+            await asyncio.sleep(0.05)
+            buffer.append(message["params"]["text"])
+
+        async def request_runner(message: dict[str, Any]) -> Any:
+            return None
+
+        dispatcher = DefaultMessageDispatcher(
+            queue=queue,
+            supervisor=supervisor,
+            store=store,
+            request_runner=request_runner,
+            notification_runner=notification_runner,
+        )
+        dispatcher.start()
+        try:
+            for i in range(5):
+                await queue.publish(
+                    RpcTask(
+                        RpcTaskKind.NOTIFICATION,
+                        {"method": "session/update", "params": {"text": f"c{i}"}},
+                    )
+                )
+            conn = types.SimpleNamespace(
+                _conn=types.SimpleNamespace(_queue=queue, _tasks=supervisor)
+            )
+            await AcpHarnessExecutor._drain_pending_notifications(conn)
+            assert buffer == ["c0", "c1", "c2", "c3", "c4"]
+        finally:
+            await dispatcher.stop()
+            await supervisor.shutdown()
+
+    async def test_drain_noop_when_connection_shape_missing(self) -> None:
+        """Drain degrades to a no-op if the ACP internals aren't present,
+        rather than raising."""
+        conn = types.SimpleNamespace()  # no _conn
+        await AcpHarnessExecutor._drain_pending_notifications(conn)

--- a/tests/services/scheduler/test_runner.py
+++ b/tests/services/scheduler/test_runner.py
@@ -221,7 +221,7 @@ async def test_sync_replaces_when_config_changes(daemon, store):
     initial_hash = daemon._known[job.id]
     # Mutate the on-disk YAML through a round-trip so the new value stays
     # a string (PyYAML auto-quotes ambiguous scalars on safe_dump).
-    yaml_path = store.schedules_dir / "report.yaml"
+    (yaml_path,) = list(store.schedules_dir.glob("report-*.yaml"))
     payload = yaml.safe_load(yaml_path.read_text())
     payload["schedule"]["times"] = ["10:30"]
     yaml_path.write_text(yaml.safe_dump(payload, sort_keys=False))

--- a/tests/services/scheduler/test_runner.py
+++ b/tests/services/scheduler/test_runner.py
@@ -8,10 +8,35 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from flow_atelier.schemas.api import CreateScheduleInput, ScheduledJob
-from flow_atelier.services.scheduler.runner import _RELOAD_JOB_ID, SchedulerDaemon
+from flow_atelier.services.scheduler.runner import (
+    _RELOAD_JOB_ID,
+    SchedulerDaemon,
+    _resolve_run_path,
+    compute_planned_view,
+)
 from flow_atelier.services.scheduler.store import ScheduleStore
 
 UTC = ZoneInfo("UTC")
+
+
+@pytest.mark.parametrize(
+    "run_path",
+    ["", "relative/dir", "/abs/dir"],
+)
+def test_resolve_run_path_matches_between_daemon_and_view(run_path, tmp_path):
+    """The daemon's fire-path resolver and the planned-view preview must agree.
+
+    :param run_path: run_path variant (empty / relative / absolute).
+    :param tmp_path: pytest temp directory fixture.
+    """
+    base = tmp_path.resolve()
+    store = ScheduleStore(tmp_path / ".atelier")
+    store.create(_recurring(conduit="report", run_path=run_path))
+    daemon = SchedulerDaemon(store, default_working_dir=base)
+    job = store.list()[0]
+    view = compute_planned_view(store, default_zone=UTC, default_working_dir=base)
+    assert daemon._resolve_working_dir(job) == view[0].working_dir
+    assert daemon._resolve_working_dir(job) == _resolve_run_path(run_path, base)
 
 
 def _recurring(conduit: str = "report", run_path: str = "/tmp/run") -> CreateScheduleInput:

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -293,6 +293,51 @@ def test_increment_runs_skips_when_file_gone(store):
     assert list(store.schedules_dir.glob("*.yaml")) == []
 
 
+def test_union_reads_project_and_global(tmp_path):
+    """A schedule living in the global dir is visible alongside project ones.
+
+    Mirrors the CLI(project)↔serve(global) split-brain fix: reads union both
+    dirs while writes stay project-local.
+
+    :param tmp_path: pytest temp directory fixture.
+    """
+    project = tmp_path / "project" / ".atelier"
+    global_dir = tmp_path / "global" / ".atelier"
+    # A schedule installed against the *global* dir (e.g. by a previous serve).
+    ScheduleStore(global_dir).create(
+        _recurring_payload(schedule={
+            "mode": "recurring", "name": "global job",
+            "days": [1], "times": ["06:00"],
+        })
+    )
+    store = ScheduleStore(project, global_dir=global_dir)
+    proj_job = store.create(_recurring_payload(schedule={
+        "mode": "recurring", "name": "project job",
+        "days": [2], "times": ["07:00"],
+    }))
+    names = {j.schedule.name for j in store.list()}
+    assert names == {"global job", "project job"}
+    # Writes land in the project dir, never the global dir.
+    assert list((project / "schedules").glob("project-job-*.yaml"))
+    assert not list((global_dir / "schedules").glob("project-job-*.yaml"))
+    # Project-side store can still find/delete the project job.
+    assert store.get(proj_job.id).id == proj_job.id
+
+
+def test_find_and_delete_reach_global_schedule(tmp_path):
+    """get/delete locate a schedule that physically lives in the global dir.
+
+    :param tmp_path: pytest temp directory fixture.
+    """
+    project = tmp_path / "project" / ".atelier"
+    global_dir = tmp_path / "global" / ".atelier"
+    global_job = ScheduleStore(global_dir).create(_recurring_payload())
+    store = ScheduleStore(project, global_dir=global_dir)
+    assert store.get(global_job.id) is not None
+    store.delete(global_job.id)
+    assert store.get(global_job.id) is None
+
+
 def test_recreate_after_load_round_trips(store, tmp_path):
     """Verify a fresh ScheduleStore reloads previously persisted data.
 

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -51,7 +51,7 @@ def _once_payload(**overrides):
         "schedule": {
             "mode": "once",
             "name": "tomorrow",
-            "run_at": "2026-05-01T09:00:00Z",
+            "run_at": "2099-05-01T09:00:00Z",
         },
     }
     base.update(overrides)
@@ -143,7 +143,7 @@ def test_create_rejects_empty_name(store):
     """
     with pytest.raises(ValueError):
         store.create(_once_payload(schedule={
-            "mode": "once", "name": "", "run_at": "2026-05-01T09:00:00Z",
+            "mode": "once", "name": "", "run_at": "2099-05-01T09:00:00Z",
         }))
 
 

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -87,7 +87,7 @@ def test_create_persists_to_yaml_file(store):
     :param store: ScheduleStore fixture.
     """
     job = store.create(_recurring_payload())
-    yaml_path = store.schedules_dir / "weekday-mornings.yaml"
+    (yaml_path,) = list(store.schedules_dir.glob("weekday-mornings-*.yaml"))
     assert yaml_path.exists()
     raw = yaml.safe_load(yaml_path.read_text())
     assert raw["id"] == job.id
@@ -97,7 +97,8 @@ def test_create_persists_to_yaml_file(store):
 
 
 def test_filename_is_slugified(store):
-    """Verify the filename is a lowercase slug of ``schedule.name``.
+    """Verify the filename keeps a lowercase slug of ``schedule.name`` as a
+    readable prefix (a disambiguating hash is appended).
 
     :param store: ScheduleStore fixture.
     """
@@ -106,7 +107,33 @@ def test_filename_is_slugified(store):
         "name": "Weekday Mornings!",
         "days": [1], "times": ["06:00"],
     }))
-    assert (store.schedules_dir / "weekday-mornings.yaml").exists()
+    files = list(store.schedules_dir.glob("weekday-mornings-*.yaml"))
+    assert len(files) == 1
+
+
+def test_distinct_names_same_slug_dont_collide(store):
+    """Two names that slug identically map to two distinct files, each
+    retrievable by its own name and id; an exact-duplicate name still raises.
+
+    :param store: ScheduleStore fixture.
+    """
+    a = store.create(_recurring_payload(schedule={
+        "mode": "recurring", "name": "My Job", "days": [1], "times": ["06:00"],
+    }))
+    b = store.create(_recurring_payload(schedule={
+        "mode": "recurring", "name": "my-job", "days": [1], "times": ["06:00"],
+    }))
+    assert len(list(store.schedules_dir.glob("*.yaml"))) == 2
+    assert a.id != b.id
+    assert store.get_by_name("My Job").id == a.id
+    assert store.get_by_name("my-job").id == b.id
+    assert store.get(a.id).id == a.id
+    assert store.get(b.id).id == b.id
+    # Exact-duplicate name still collides on one file.
+    with pytest.raises(FileExistsError):
+        store.create(_recurring_payload(schedule={
+            "mode": "recurring", "name": "My Job", "days": [1], "times": ["06:00"],
+        }))
 
 
 def test_create_rejects_empty_name(store):
@@ -174,7 +201,7 @@ def test_delete_removes_file(store):
     :param store: ScheduleStore fixture.
     """
     job = store.create(_recurring_payload())
-    path = store.schedules_dir / "weekday-mornings.yaml"
+    (path,) = list(store.schedules_dir.glob("weekday-mornings-*.yaml"))
     assert path.exists()
     deleted = store.delete(job.id)
     assert deleted.id == job.id
@@ -252,21 +279,18 @@ def test_atomic_write_does_not_leave_tmp(store):
     assert leftovers == []
 
 
-def test_increment_runs_skips_when_file_gone(store, monkeypatch):
-    """Simulate the delete-then-increment race: ``_iter_jobs`` returns a
-    stale view of a job whose YAML file has since been unlinked.
-    ``increment_runs`` must NOT resurrect the file.
+def test_increment_runs_skips_when_file_gone(store):
+    """The delete-then-increment race: once a job's YAML file is unlinked,
+    ``increment_runs`` must NOT resurrect it.
 
     :param store: ScheduleStore fixture.
-    :param monkeypatch: pytest monkeypatch fixture.
     """
     job = store.create(_recurring_payload())
-    path = store.schedules_dir / "weekday-mornings.yaml"
-    stale_view = [job]  # captured before the "concurrent" delete
+    (path,) = list(store.schedules_dir.glob("*.yaml"))
     path.unlink()
-    monkeypatch.setattr(store, "_iter_jobs", lambda: list(stale_view))
     store.increment_runs(job.id)
     assert not path.exists()
+    assert list(store.schedules_dir.glob("*.yaml")) == []
 
 
 def test_recreate_after_load_round_trips(store, tmp_path):

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -293,51 +293,6 @@ def test_increment_runs_skips_when_file_gone(store):
     assert list(store.schedules_dir.glob("*.yaml")) == []
 
 
-def test_union_reads_project_and_global(tmp_path):
-    """A schedule living in the global dir is visible alongside project ones.
-
-    Mirrors the CLI(project)↔serve(global) split-brain fix: reads union both
-    dirs while writes stay project-local.
-
-    :param tmp_path: pytest temp directory fixture.
-    """
-    project = tmp_path / "project" / ".atelier"
-    global_dir = tmp_path / "global" / ".atelier"
-    # A schedule installed against the *global* dir (e.g. by a previous serve).
-    ScheduleStore(global_dir).create(
-        _recurring_payload(schedule={
-            "mode": "recurring", "name": "global job",
-            "days": [1], "times": ["06:00"],
-        })
-    )
-    store = ScheduleStore(project, global_dir=global_dir)
-    proj_job = store.create(_recurring_payload(schedule={
-        "mode": "recurring", "name": "project job",
-        "days": [2], "times": ["07:00"],
-    }))
-    names = {j.schedule.name for j in store.list()}
-    assert names == {"global job", "project job"}
-    # Writes land in the project dir, never the global dir.
-    assert list((project / "schedules").glob("project-job-*.yaml"))
-    assert not list((global_dir / "schedules").glob("project-job-*.yaml"))
-    # Project-side store can still find/delete the project job.
-    assert store.get(proj_job.id).id == proj_job.id
-
-
-def test_find_and_delete_reach_global_schedule(tmp_path):
-    """get/delete locate a schedule that physically lives in the global dir.
-
-    :param tmp_path: pytest temp directory fixture.
-    """
-    project = tmp_path / "project" / ".atelier"
-    global_dir = tmp_path / "global" / ".atelier"
-    global_job = ScheduleStore(global_dir).create(_recurring_payload())
-    store = ScheduleStore(project, global_dir=global_dir)
-    assert store.get(global_job.id) is not None
-    store.delete(global_job.id)
-    assert store.get(global_job.id) is None
-
-
 def test_recreate_after_load_round_trips(store, tmp_path):
     """Verify a fresh ScheduleStore reloads previously persisted data.
 

--- a/tests/services/store/test_filesystem.py
+++ b/tests/services/store/test_filesystem.py
@@ -65,6 +65,18 @@ def test_read_conduit(store):
     assert c.tasks[0].name == "greet"
 
 
+def test_read_conduit_malformed_yaml_raises_one_line(store):
+    """Verify broken YAML raises a one-line ValueError, not a raw traceback.
+
+    :param store: FilesystemStore fixture.
+    """
+    (store.base_dir / "conduits" / "hello" / "conduit.yaml").write_text(
+        "name: hello\ntasks: [unclosed\n"
+    )
+    with pytest.raises(ValueError, match="hello: invalid YAML"):
+        store.read_conduit("hello")
+
+
 def test_list_conduits(store):
     """Verify list_conduits returns the names of available conduits.
 

--- a/tests/services/store/test_filesystem.py
+++ b/tests/services/store/test_filesystem.py
@@ -419,3 +419,49 @@ def test_delete_conduit_idempotent_returns_false(tmp_path):
     """
     s = FilesystemStore(tmp_path / ".atelier")
     assert s.delete_conduit("nope") is False
+
+
+# --------------------------------------------------------------- delete_flow
+
+
+def test_delete_flow_removes_dir_and_evicts_caches(store):
+    """delete_flow removes the directory and evicts both in-memory caches.
+
+    :param store: FilesystemStore fixture.
+    """
+    fid = store.create_flow("hello", {})
+    store._lock_for(fid)  # populate _log_locks for this id
+    flow_dir = store._flow_dir(fid)
+    assert flow_dir.exists()
+
+    assert store.delete_flow(fid) is True
+    assert not flow_dir.exists()
+    assert fid not in store._flow_paths
+    assert fid not in store._log_locks
+
+
+def test_delete_flow_unknown_returns_false(store):
+    """delete_flow returns False for an unknown flow id.
+
+    :param store: FilesystemStore fixture.
+    """
+    assert store.delete_flow("20260101_deadbeef_hello") is False
+
+
+def test_delete_flow_removes_nested_children(store):
+    """Deleting a parent removes its nested child subtree and evicts the
+    child's cached path/lock entries.
+
+    :param store: FilesystemStore fixture.
+    """
+    parent = store.create_flow("hello", {})
+    child = store.create_flow("hello", {}, parent_flow_id=parent)
+    store._lock_for(child)
+    child_dir = store._flow_dir(child)
+    assert child_dir.exists()
+
+    assert store.delete_flow(parent) is True
+    assert not child_dir.exists()
+    assert parent not in store._flow_paths
+    assert child not in store._flow_paths
+    assert child not in store._log_locks

--- a/tests/services/store/test_filesystem_resume.py
+++ b/tests/services/store/test_filesystem_resume.py
@@ -83,6 +83,17 @@ def test_read_outputs_overwrites(store):
     assert store.read_outputs(fid) == {"b": "2"}
 
 
+def test_read_outputs_non_mapping_yaml_returns_empty(store):
+    """Verify a non-mapping outputs.yaml (list/scalar) degrades to ``{}``
+    instead of raising downstream when callers do ``.get``/subscript.
+
+    :param store: FilesystemStore fixture.
+    """
+    fid = store.create_flow("hello", {})
+    (store._flow_dir(fid) / "outputs.yaml").write_text("- not\n- a\n- mapping\n")
+    assert store.read_outputs(fid) == {}
+
+
 # ---------------------------------------------------------------- create_flow(flow_id=...)
 
 

--- a/tests/test_api/test_conduits_api.py
+++ b/tests/test_api/test_conduits_api.py
@@ -113,6 +113,36 @@ async def test_create_conduit_invalid_returns_400(client):
     assert resp.status_code in (400, 422)
 
 
+async def test_create_conduit_traversal_name_rejected(client, tmp_path):
+    """Verify a path-traversal conduit name is rejected and writes nothing outside.
+
+    :param client: httpx client fixture.
+    :param tmp_path: pytest temp directory fixture.
+    """
+    outside = tmp_path / "evil"
+    resp = await client.post(
+        "/conduits", json=_payload(name=f"../../../../{outside}")
+    )
+    assert resp.status_code in (400, 422)
+    assert not outside.exists()
+
+
+async def test_update_conduit_traversal_rename_rejected(client, tmp_path):
+    """Verify renaming a conduit to a traversal name is rejected.
+
+    :param client: httpx client fixture.
+    :param tmp_path: pytest temp directory fixture.
+    """
+    await client.post("/conduits", json=_payload())
+    outside = tmp_path / "evil"
+    resp = await client.patch(
+        "/conduits/release_notes",
+        json={"name": f"../../../../{outside}"},
+    )
+    assert resp.status_code in (400, 422)
+    assert not outside.exists()
+
+
 # ---------------------------------------------------------------- update
 
 

--- a/tests/test_api/test_conduits_api.py
+++ b/tests/test_api/test_conduits_api.py
@@ -197,13 +197,19 @@ async def test_delete_unknown_returns_404(client):
 # ---------------------------------------------------------------- open-path
 
 
-async def test_open_path_invokes_opener(client, monkeypatch):
-    """Verify POST /conduits/open-path invokes the subprocess opener.
+async def test_open_path_invokes_opener(client, monkeypatch, tmp_path):
+    """Verify POST /conduits/open-path opens a recorded flow run path.
 
     :param client: httpx client fixture.
     :param monkeypatch: pytest monkeypatch fixture.
+    :param tmp_path: pytest temp directory fixture.
     """
     await client.post("/conduits", json=_payload())
+    # Register the path as a known flow run_path so the opener accepts it.
+    atelier = client._transport.app.state.atelier
+    run_path = tmp_path / "runs"
+    run_path.mkdir()
+    atelier.store.create_flow("release_notes", {"run_path": str(run_path)})
     calls = []
 
     class _FakeProc:
@@ -224,8 +230,26 @@ async def test_open_path_invokes_opener(client, monkeypatch):
     monkeypatch.setattr("subprocess.Popen", fake_popen)
     resp = await client.post(
         "/conduits/open-path",
-        json={"conduit_name": "release_notes", "run_path": "/tmp"},
+        json={"conduit_name": "release_notes", "run_path": str(run_path)},
     )
     assert resp.status_code == 200
     assert resp.json() == {"opened": True}
     assert calls
+
+
+async def test_open_path_refuses_unknown_path(client, monkeypatch):
+    """Verify POST /conduits/open-path refuses a path with no recorded flow.
+
+    :param client: httpx client fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    await client.post("/conduits", json=_payload())
+    calls = []
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: calls.append(a))
+    resp = await client.post(
+        "/conduits/open-path",
+        json={"conduit_name": "release_notes", "run_path": "/tmp/not-a-flow"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"opened": False}
+    assert not calls

--- a/tests/test_api/test_schedules_api.py
+++ b/tests/test_api/test_schedules_api.py
@@ -18,6 +18,20 @@ async def fixture(tmp_path, monkeypatch):
     """
     monkeypatch.delenv("ATELIER_GLOBAL_ATELIER_DIR", raising=False)
     atelier = Atelier(base_dir=tmp_path / ".atelier")
+    # create_schedule validates conduit_name, so the scheduled conduit must
+    # exist on disk.
+    conduit_dir = tmp_path / ".atelier" / "conduits" / "report"
+    conduit_dir.mkdir(parents=True)
+    (conduit_dir / "conduit.yaml").write_text(
+        "name: report\n"
+        "description: test conduit\n"
+        "tasks:\n"
+        "  - greet:\n"
+        "      description: say hi\n"
+        '      task: "echo hi"\n'
+        "      tool: tool:bash\n"
+        "      depends_on: []\n"
+    )
     app = FastApiServer().create_app(atelier)
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
@@ -100,6 +114,36 @@ async def test_create_schedule_invalid_returns_400(fixture):
         },
     )
     assert resp.status_code in (400, 422)
+
+
+async def test_create_schedule_unknown_conduit_returns_400(fixture):
+    """Verify POST /schedules with an unknown conduit_name returns 400.
+
+    :param fixture: client+atelier+tmp_path tuple fixture.
+    """
+    client, _, _ = fixture
+    resp = await client.post("/schedules", json=_payload(conduit_name="ghost"))
+    assert resp.status_code == 400, resp.text
+    assert "unknown conduit" in resp.text
+
+
+async def test_create_schedule_past_run_at_rejected(fixture):
+    """Verify a one-shot with a past run_at is rejected at validation.
+
+    :param fixture: client+atelier+tmp_path tuple fixture.
+    """
+    client, _, _ = fixture
+    resp = await client.post(
+        "/schedules",
+        json=_payload(
+            schedule={
+                "mode": "once",
+                "name": "backfill",
+                "run_at": "2000-01-01T00:00:00Z",
+            }
+        ),
+    )
+    assert resp.status_code == 422, resp.text
 
 
 async def test_delete_schedule_removes_from_list(fixture):

--- a/tests/test_api/test_schedules_api.py
+++ b/tests/test_api/test_schedules_api.py
@@ -76,7 +76,9 @@ async def test_create_schedule_persists_to_yaml_file(fixture):
     client, _, tmp_path = fixture
     resp = await client.post("/schedules", json=_payload())
     sch_id = resp.json()["id"]
-    yaml_path = tmp_path / ".atelier" / "schedules" / "weekday-mornings.yaml"
+    (yaml_path,) = list(
+        (tmp_path / ".atelier" / "schedules").glob("weekday-mornings-*.yaml")
+    )
     raw = yaml.safe_load(yaml_path.read_text())
     assert raw["id"] == sch_id
     assert raw["schedule"]["mode"] == "recurring"

--- a/tests/test_api/test_ws_manager.py
+++ b/tests/test_api/test_ws_manager.py
@@ -86,6 +86,49 @@ async def test_track_run_and_cancel(broker):
     assert fired["cancelled"] is True
 
 
+async def test_cancel_all_cancels_every_tracked_run(broker):
+    """Verify cancel_all cancels all tracked run tasks (disconnect cleanup).
+
+    :param broker: broker fixture.
+    """
+    async def long_running() -> None:
+        """Sleep until cancelled."""
+        await asyncio.sleep(60)
+
+    tasks = [asyncio.create_task(long_running()) for _ in range(3)]
+    for i, task in enumerate(tasks):
+        broker.track_run(f"T-{i}", task)
+    await asyncio.sleep(0)
+    broker.cancel_all()
+    for task in tasks:
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_cancel_all_unblocks_hung_hitl_await(broker):
+    """Verify cancel_all unblocks a run task parked on await_hitl_answer.
+
+    Mirrors the disconnect case: a tool:hitl task awaits an answer with no
+    timeout; the only socket that could deliver it is gone. Cancelling the
+    tracked task must unwind that await rather than pin the run forever.
+
+    :param broker: broker fixture.
+    """
+    broker.register_flow("T-hitl")
+
+    async def parked_run() -> None:
+        """Block forever awaiting an answer that never arrives."""
+        await broker.await_hitl_answer("T-hitl")
+
+    task = asyncio.create_task(parked_run())
+    broker.track_run("T-hitl", task)
+    await asyncio.sleep(0)
+    assert not task.done()
+    broker.cancel_all()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 async def test_cancel_unknown_flow_is_noop(broker):
     """Verify cancelling an unknown flow is a no-op.
 

--- a/tests/test_api/test_ws_scheduler_bus.py
+++ b/tests/test_api/test_ws_scheduler_bus.py
@@ -45,6 +45,34 @@ def test_ws_subscribes_to_scheduler_bus_when_attached(env):
         assert bus._subscribers == set()
 
 
+async def test_broadcast_drops_slow_subscriber_within_timeout():
+    """A subscriber slower than send_timeout is dropped, not waited on.
+
+    Bounds head-of-line blocking on the scheduler fire path.
+    """
+    bus = SchedulerEventBus(send_timeout=0.02)
+    fast_seen: list[dict] = []
+
+    async def fast(envelope: dict) -> None:
+        """Record the envelope immediately."""
+        fast_seen.append(envelope)
+
+    async def slow(envelope: dict) -> None:
+        """Block far longer than the bus timeout."""
+        await asyncio.sleep(5)
+
+    bus.subscribe(fast)
+    bus.subscribe(slow)
+    start = asyncio.get_running_loop().time()
+    await bus.broadcast({"type": "x"})
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 1.0  # did not wait the full 5s on the slow socket
+    assert fast_seen == [{"type": "x"}]
+    assert slow not in bus._subscribers  # dropped after timeout
+    assert fast in bus._subscribers
+
+
 def test_ws_with_no_bus_attached_still_connects(tmp_path, monkeypatch):
     """When no bus is attached the WS continues to work for run/HITL only.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1411,3 +1411,99 @@ tasks:
     assert result.exit_code == 1
     assert "hello" in result.output and "OK" in result.output
     assert "cyc" in result.output and "FAIL" in result.output
+
+
+def test_list_conduits_invalid_shows_reason(workdir):
+    """A malformed conduit shows ``(invalid: …)`` instead of ``(unreadable)``.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "broke",
+        """
+name: broke
+description: bad tool
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:nope
+      depends_on: []
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["list", "conduits"])
+    assert result.exit_code == 0, result.output
+    # The good conduit still renders normally; the bad one shows a reason.
+    assert "hello" in result.output
+    assert "invalid" in result.output
+    assert "(unreadable)" not in result.output
+    assert "Traceback" not in result.output
+
+
+def test_list_conduits_json_includes_error(workdir):
+    """JSON output carries an ``error`` reason for unreadable conduits.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(workdir, "broke", "name: broke\ntasks: [unclosed\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["list", "conduits", "--json"])
+    assert result.exit_code == 0, result.output
+    by_name = {e["name"]: e for e in _json.loads(result.output)}
+    assert by_name["hello"]["error"] is None
+    assert by_name["broke"]["error"]
+    assert "invalid YAML" in by_name["broke"]["error"]
+
+
+def test_run_invalid_conduit(workdir):
+    """`run <malformed>` exits 1 with a readable message and a fix pointer.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(workdir, "broke", "name: broke\ntasks: [unclosed\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "broke"])
+    assert result.exit_code == 1
+    assert "invalid conduit" in result.output
+    assert "fix conduits" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_run_resume_invalid_conduit(workdir):
+    """`run --resume` on a now-malformed conduit shows the friendly message.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "willfail",
+        """
+name: willfail
+description: fails
+tasks:
+  - boom:
+      description: boom
+      task: "exit 1"
+      tool: tool:bash
+      depends_on: []
+""",
+    )
+    runner = CliRunner()
+    r1 = runner.invoke(app, ["run", "willfail"])
+    assert r1.exit_code == 1
+    from flow_atelier.core.atelier import Atelier
+
+    flows = Atelier().list_flows("willfail")
+    assert flows
+    fid = flows[0]
+    # Corrupt the conduit, then resume the failed flow.
+    (workdir / ".atelier" / "conduits" / "willfail" / "conduit.yaml").write_text(
+        "name: willfail\ntasks: [unclosed\n"
+    )
+    r2 = runner.invoke(app, ["run", "--resume", fid])
+    assert r2.exit_code == 1
+    assert "invalid conduit" in r2.output
+    assert "fix conduits" in r2.output
+    assert "Traceback" not in r2.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1507,3 +1507,152 @@ tasks:
     assert "invalid conduit" in r2.output
     assert "fix conduits" in r2.output
     assert "Traceback" not in r2.output
+
+
+# --- liveness / crashed-flow detection -------------------------------------
+
+def _run_hello(runner, name="a"):
+    """Run the hello conduit and return its flow id.
+
+    :param runner: CliRunner instance.
+    :param name: value for the greet input.
+    :returns: the created flow id.
+    """
+    result = runner.invoke(app, ["run", "hello", "--input", f"name={name}"])
+    assert result.exit_code == 0, result.output
+    line = [l for l in result.output.splitlines() if "flow_id" in l][0]
+    return line.split()[-1]
+
+
+def _dead_local_pid():
+    """Return a pid that has provably exited on this host."""
+    import subprocess
+    import sys as _sys
+
+    proc = subprocess.Popen([_sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
+def _force_running(flow_id, pid):
+    """Rewrite a flow's progress.json to status=running with the given pid.
+
+    :param flow_id: flow to mutate.
+    :param pid: runner_pid to record (dead pid simulates a crash).
+    """
+    import socket
+
+    from flow_atelier.core.atelier import Atelier
+    from flow_atelier.schemas.progress import FlowStatus
+
+    atelier = Atelier()
+    progress = atelier.store.read_progress(flow_id)
+    progress.status = FlowStatus.running
+    progress.runner_pid = pid
+    progress.runner_host = socket.gethostname()
+    atelier.store.write_progress(flow_id, progress)
+
+
+def test_run_records_runner_identity(workdir):
+    """A started flow persists this process's pid and a non-empty host.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    flow_id = _run_hello(runner)
+    from flow_atelier.core.atelier import Atelier
+
+    progress = Atelier().store.read_progress(flow_id)
+    # CliRunner runs in-process, so the runner pid is this test process.
+    assert progress.runner_pid == os.getpid()
+    assert progress.runner_host
+
+
+def test_status_reports_crashed_with_resume_hint(workdir):
+    """status on a dead-runner flow shows crashed + a resume hint.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    flow_id = _run_hello(runner)
+    _force_running(flow_id, _dead_local_pid())
+
+    result = runner.invoke(app, ["status", flow_id])
+    assert result.exit_code == 0, result.output
+    assert "crashed" in result.output
+    assert f"--resume {flow_id}" in result.output
+
+    jr = runner.invoke(app, ["status", flow_id, "--json"])
+    assert jr.exit_code == 0
+    import json as _json
+
+    payload = _json.loads(jr.output)
+    assert payload["crashed"] is True
+    # Persisted status field is untouched.
+    assert payload["status"] == "running"
+
+
+def test_status_live_running_not_crashed(workdir):
+    """status on a live-runner running flow shows running, no hint.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    flow_id = _run_hello(runner)
+    _force_running(flow_id, os.getpid())
+
+    result = runner.invoke(app, ["status", flow_id])
+    assert result.exit_code == 0
+    assert "crashed" not in result.output
+    assert "--resume" not in result.output
+
+    jr = runner.invoke(app, ["status", flow_id, "--json"])
+    payload = __import__("json").loads(jr.output)
+    assert payload["crashed"] is False
+
+
+def test_list_flows_marks_crashed(workdir):
+    """list flows renders a dead-runner flow as crashed, a live one running.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    dead_flow = _run_hello(runner, "dead")
+    live_flow = _run_hello(runner, "live")
+    _force_running(dead_flow, _dead_local_pid())
+    _force_running(live_flow, os.getpid())
+
+    result = runner.invoke(app, ["list", "flows"])
+    assert result.exit_code == 0, result.output
+    assert "crashed" in result.output
+    assert "running" in result.output
+
+    jr = runner.invoke(app, ["list", "flows", "--json"])
+    import json as _json
+
+    rows = {r["flow_id"]: r for r in _json.loads(jr.output)}
+    assert rows[dead_flow]["crashed"] is True
+    assert rows[live_flow]["crashed"] is False
+
+
+def test_follow_logs_exits_on_crash(workdir):
+    """logs --follow on a dead-runner flow terminates instead of hanging.
+
+    :param workdir: isolated working directory fixture.
+    """
+    import threading
+
+    runner = CliRunner()
+    flow_id = _run_hello(runner)
+    _force_running(flow_id, _dead_local_pid())
+
+    box = {}
+
+    def _go():
+        box["result"] = runner.invoke(app, ["logs", flow_id, "--follow"])
+
+    t = threading.Thread(target=_go)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), "logs --follow hung on a crashed flow"
+    assert "crashed" in box["result"].output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -536,7 +536,7 @@ def test_schedule_add_and_list(workdir, tmp_path):
     result = runner.invoke(app, ["schedule", "add", str(src)])
     assert result.exit_code == 0, result.output
     assert "installed" in result.output
-    assert (workdir / ".atelier" / "schedules" / "nightly.yaml").exists()
+    assert list((workdir / ".atelier" / "schedules").glob("nightly-*.yaml"))
 
     listing = runner.invoke(app, ["schedule", "list"])
     assert listing.exit_code == 0, listing.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1156,3 +1156,258 @@ def test_no_prompt_for_conduit_without_inputs(workdir, monkeypatch):
     result = runner.invoke(app, ["run", "hello", "-i", "name=world"])
     assert result.exit_code == 0, result.output
     assert len(prompted_keys) == 0
+
+
+# ---------------------------------------------------------------- check cmd
+
+
+def _write_conduit(workdir, name, yaml_text, *, folder=None):
+    """Write a conduit.yaml under the workdir's project conduits dir.
+
+    :param workdir: tmp_path returned by the ``workdir`` fixture.
+    :param name: conduit name used for the YAML and (default) folder.
+    :param yaml_text: full conduit.yaml contents to write.
+    :param folder: override folder name to provoke name/folder mismatch.
+    """
+    folder = folder or name
+    d = workdir / ".atelier" / "conduits" / folder
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "conduit.yaml").write_text(yaml_text)
+
+
+def test_check_clean_conduit_ok(workdir):
+    """A valid conduit reports OK and exits 0.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "hello"])
+    assert result.exit_code == 0, result.output
+    assert "hello" in result.output
+    assert "OK" in result.output
+
+
+def test_check_unknown_conduit(workdir):
+    """`check <missing>` prints a clear error and exits 1.
+
+    :param workdir: isolated working directory fixture.
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "nope"])
+    assert result.exit_code == 1
+    assert "unknown conduit" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_check_cycle(workdir):
+    """A circular dependency is reported as FAIL with exit 1.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "cyc",
+        """
+name: cyc
+description: cycle
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: ["b"]
+  - b:
+      description: b
+      task: "echo b"
+      tool: tool:bash
+      depends_on: ["a"]
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "cyc"])
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+    assert "circular" in result.output
+
+
+def test_check_unknown_dep(workdir):
+    """A dependency on a missing task is reported as FAIL.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "udep",
+        """
+name: udep
+description: unknown dep
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: ["ghost"]
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "udep"])
+    assert result.exit_code == 1
+    assert "unknown task 'ghost'" in result.output
+
+
+def test_check_dangling_template_ref(workdir):
+    """A {{ref.output}} outside the depends_on chain is reported as FAIL.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "dang",
+        """
+name: dang
+description: dangling ref
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: []
+  - b:
+      description: b
+      task: "use {{a.output}}"
+      tool: tool:bash
+      depends_on: []
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "dang"])
+    assert result.exit_code == 1
+    assert "references 'a'" in result.output
+    assert "depends_on" in result.output
+
+
+def test_check_bad_predicate_regex(workdir):
+    """A malformed loop predicate regex is reported as FAIL.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "badre",
+        """
+name: badre
+description: bad regex
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: []
+      repeat: 3
+      until: "output.match([unclosed)"
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "badre"])
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+
+
+def test_check_duplicate_task_names(workdir):
+    """Duplicate task names are reported as FAIL.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "dup",
+        """
+name: dup
+description: dup names
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: []
+  - a:
+      description: a2
+      task: "echo a2"
+      tool: tool:bash
+      depends_on: []
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "dup"])
+    assert result.exit_code == 1
+    assert "duplicate task names" in result.output
+
+
+def test_check_name_folder_mismatch(workdir):
+    """A conduit whose name differs from its folder is reported as FAIL.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "inner",
+        """
+name: inner
+description: mismatch
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: []
+""",
+        folder="outer",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "outer"])
+    assert result.exit_code == 1
+    assert "!=" in result.output
+
+
+def test_check_malformed_yaml(workdir):
+    """Broken YAML is reported as a one-line FAIL, not a traceback.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(workdir, "broke", "name: broke\ntasks: [unclosed\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "broke"])
+    assert result.exit_code == 1
+    assert "invalid YAML" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_check_all_reports_good_and_bad(workdir):
+    """`check` (no arg) lists every conduit and exits 1 if any fails.
+
+    :param workdir: isolated working directory fixture.
+    """
+    _write_conduit(
+        workdir,
+        "cyc",
+        """
+name: cyc
+description: cycle
+tasks:
+  - a:
+      description: a
+      task: "echo a"
+      tool: tool:bash
+      depends_on: ["b"]
+  - b:
+      description: b
+      task: "echo b"
+      tool: tool:bash
+      depends_on: ["a"]
+""",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 1
+    assert "hello" in result.output and "OK" in result.output
+    assert "cyc" in result.output and "FAIL" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
# Engine & CLI hardening, retention tooling, and docs

## What

This branch hardens the conduit engine and CLI, adds opt-in reliability
controls and flow-retention tooling, tightens the scheduler / WebSocket
/ security surfaces, expands the `autonomous-projects` conduit, and
rewrites the project documentation.

Grouped by area:

- **Engine & schema**
  - Opt-in per-task `retries` (retry-on-failure), with `retries: 0`
    log entries kept free of attempt metadata.
  - Opt-in per-task `timeout` override (falls back to the conduit
    `timeout`).
  - Author-time validation of `{{...}}` template expressions and
    `{{loop.history}}` / `{{loop.previous}}` support.
  - Guards against nested-conduit cycles and hardened condition
    evaluation.

- **CLI**
  - `atelier check` — validate one or all conduits (structure + tool
    readiness) without running them.
  - `atelier rm` / `atelier prune` — delete a single flow or bulk-prune
    old flows by age / keep-count, backed by a `delete_flow` store
    primitive. `prune --json` honors the confirmation gate.
  - A preflight readiness gate so `atelier run` fails early with an
    actionable reason when a tool/harness is unavailable.
  - Clearer error messages for malformed conduits.

- **Reliability & lifecycle**
  - Liveness detection: hard-killed flows are detected and stopped
    instead of masquerading as running.
  - WebSocket: cancel in-flight runs on disconnect (no orphaned /
    HITL-hung flows), retain strong refs for fire-and-forget
    broadcasts, and bound/log-drain the scheduler bus.
  - Harness: deterministic notification drain and author-regex
    handling.

- **Scheduler**
  - Validate `conduit_name` and reject past one-shot `run_at` values.
  - Project + global schedule-dir handling (one union attempt was
    reverted pending review).

- **Security**
  - Validate conduit names to prevent path traversal.
  - Constrain the `open-path` endpoint to recorded flow run paths.

- **Conduits**
  - Expanded the `autonomous-projects` loop and added the
    `generate-idea` and `generate-review` nested conduits.

- **Docs & packaging**
  - Rewrote `README.md` and added `DEVELOPMENT.md`.
  - Synced `uv.lock` to project version `0.1.2`.

The change is heavily tested: the bulk of the diff is new and expanded
tests across the engine, CLI, scheduler, WebSocket, store, and harness.

## Why

- **Reliability under failure.** Tasks fail, processes get killed, and
  clients disconnect. Without per-task retries/timeouts, liveness
  detection, and disconnect cancellation, a single transient failure
  could wedge a flow or leave it falsely "running."
- **Operability.** Flows accumulate on disk forever; `rm`/`prune` give
  operators a way to manage retention. `check` and the readiness gate
  move failures to author time and run start, instead of surfacing them
  midway through a long run.
- **Safety.** Conduit names and `open-path` reach the filesystem;
  validating them closes path-traversal and out-of-scope read vectors.
- **Onboarding.** The previous README under-documented install, several
  commands, and had stale facts (log filename, flow-id format,
  templating). Accurate docs plus a `DEVELOPMENT.md` lower the barrier
  for both users and contributors.

## How

- **Per-task retries/timeout** are new fields on `TaskDefinition`
  (`schemas/conduit.py`); the engine (`modules/engine.py`) honors them
  per task, defaulting to the conduit-level `timeout` and `retries: 0`.
- **`check`** loads each conduit, runs `validate_conduit`, then probes
  `tool_readiness` so an unregistered tool or missing harness CLI fails
  the check.
- **`rm` / `prune`** are built on a new `delete_flow` store primitive
  (`services/store/`); `prune` selects candidates by `--older-than`
  (flow-id date prefix) and/or `--keep`, refuses to run with neither,
  and skips running flows unless `--force`.
- **Liveness** (`modules/liveness.py`) reconciles progress state so a
  flow whose process died is marked stopped rather than running.
- **WebSocket / scheduler** changes live in `services/api/` and
  `services/scheduler/`: disconnect cancels the run task, broadcasts
  keep strong task refs, and the scheduler validates input before
  scheduling.
- **Security** changes validate conduit names against a safe pattern and
  constrain `open-path` to paths recorded for real flow runs.
- **Docs** were fact-checked against the source: install now leads with
  the prebuilt-binary scripts (`install.sh` / `install.ps1`), and the
  reference was corrected for `logs.jsonl`, the `<YYYYMMDD>_<uuid8>_<conduit>`
  flow-id format, the `{{loop.*}}` templating forms, and the
  `check`/`logs`/`rm`/`prune` commands.

## Test plan

- `uv run pytest` (full suite; live harness tests excluded by default).
- Manual: `atelier check`, `atelier run` against a conduit with a
  missing harness (expect early readiness failure), `atelier rm` /
  `atelier prune --older-than/--keep`, and a scheduled run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `atelier check` command to validate conduits without execution
  * Added `atelier rm` and `atelier prune` commands for flow management and cleanup
  * Added crash detection for flows when runner process dies unexpectedly
  * Added per-task retry support with configurable backoff behavior
  * Added per-task timeout overrides for granular execution control
  * Enhanced autonomous-projects workflow with dedicated idea/review generation

* **Bug Fixes**
  * Fixed WebSocket task reference lifecycle issues preventing premature garbage collection
  * Fixed schedule filename collision handling using hash-based naming
  * Fixed runner process tracking in flow progress metadata

* **Documentation**
  * Rewrote README with updated installation instructions and feature documentation
  * Added DEVELOPMENT.md guide covering setup, architecture, and development workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->