### PR TITLE
fix(ci): store CLA signatures on an unprotected branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/LGuillermoAngaritaG/flow-atelier/blob/main/CLA.md"
-          branch: "main"
+          # Signatures are committed here directly; it must be an UNPROTECTED
+          # branch (the main ruleset requires PRs, which blocks the action).
+          branch: "cla-signatures"
           allowlist: LGuillermoAngaritaG,dependabot[bot],*[bot]
           custom-notsigned-prcomment: "Thank you for your contribution. Before we can merge it, please read our [Contributor License Agreement](https://github.com/LGuillermoAngaritaG/flow-atelier/blob/main/CLA.md) and sign it by posting the comment below."
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"


### PR DESCRIPTION
The CLA Assistant commits signatures directly to its configured branch. Pointing it at the protected `main` (ruleset: PR required + status checks) made every signature push fail. Store them on a dedicated `cla-signatures` branch instead so contributors can actually sign.