### PR TITLE
Feat/scheduler interval mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,10 @@ schedule:
 
 `days` are `1=Mon` .. `7=Sun`; `times` are `"HH:mm"` 24-hour strings.
 One-shots use `mode: once` with a `run_at` ISO datetime instead of
-`days` / `times`. `atelier schedule add` also accepts the same shape
-in JSON if you prefer that format.
+`days` / `times`. Fixed intervals use `mode: interval` with
+`every_minutes` (e.g. `every_minutes: 30` for every half hour, `120`
+for every two hours) — these repeat forever. `atelier schedule add`
+also accepts the same shape in JSON if you prefer that format.
 
 - New or removed schedules are picked up on the next reload tick
   (default 30s).

--- a/flow_atelier/cli/rendering/render.py
+++ b/flow_atelier/cli/rendering/render.py
@@ -508,7 +508,7 @@ def render_planned_table(planned: list[PlannedJob]) -> Table:
         "id", "name", "conduit", "kind", "next fire", "last run", "working_dir"
     )
     for p in planned:
-        kind_style = "cyan" if p.schedule_kind == "recurring" else "magenta"
+        kind_style = "magenta" if p.schedule_kind == "once" else "cyan"
         next_cell = _format_next_fire(p.next_fire_time)
         if p.next_fire_time is None and p.schedule_kind == "once":
             next_cell = "[dim](already fired)[/dim]"

--- a/flow_atelier/schemas/api.py
+++ b/flow_atelier/schemas/api.py
@@ -93,11 +93,12 @@ class ScheduleConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    mode: Literal["recurring", "once"]
+    mode: Literal["recurring", "once", "interval"]
     name: str = ""
     days: list[int] | None = None
     times: list[str] | None = None
     run_at: datetime | None = None
+    every_minutes: int | None = None
     timezone: str | None = None
 
     @field_validator("timezone")
@@ -150,6 +151,18 @@ class ScheduleConfig(BaseModel):
                 )
         return v
 
+    @field_validator("every_minutes")
+    @classmethod
+    def _validate_every_minutes(cls, v: int | None) -> int | None:
+        """Ensure ``every_minutes`` is a positive count of minutes.
+
+        :param v: interval in minutes to validate, or ``None``.
+        :returns: the validated value unchanged, or ``None`` if not provided.
+        """
+        if v is not None and v < 1:
+            raise ValueError(f"every_minutes must be >= 1, got {v!r}")
+        return v
+
     @field_validator("run_at", mode="before")
     @classmethod
     def _parse_iso(cls, v: Any) -> Any:
@@ -176,6 +189,9 @@ class ScheduleConfig(BaseModel):
                 raise ValueError("recurring schedule requires at least one day")
             if not self.times:
                 raise ValueError("recurring schedule requires at least one time")
+        elif self.mode == "interval":
+            if self.every_minutes is None:
+                raise ValueError("interval schedule requires every_minutes")
         else:  # once
             if self.run_at is None:
                 raise ValueError("once schedule requires run_at")

--- a/flow_atelier/services/scheduler/triggers.py
+++ b/flow_atelier/services/scheduler/triggers.py
@@ -8,6 +8,7 @@ from apscheduler.triggers.base import BaseTrigger
 from apscheduler.triggers.combining import OrTrigger
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
 from flow_atelier.schemas.api import ScheduledJob
 
@@ -52,11 +53,15 @@ def to_trigger(job: ScheduledJob, default_zone: ZoneInfo) -> BaseTrigger:
     :param job: persisted schedule
     :param default_zone: timezone used when the schedule pins none and for
         naive ``run_at`` values
-    :returns: ``DateTrigger`` for ``mode="once"``; ``CronTrigger`` (or
-        ``OrTrigger`` of crons) for ``mode="recurring"``
+    :returns: ``DateTrigger`` for ``mode="once"``; ``IntervalTrigger`` for
+        ``mode="interval"``; ``CronTrigger`` (or ``OrTrigger`` of crons) for
+        ``mode="recurring"``
     """
     schedule = job.schedule
     zone = ZoneInfo(schedule.timezone) if schedule.timezone else default_zone
+    if schedule.mode == "interval":
+        assert schedule.every_minutes is not None  # validated upstream
+        return IntervalTrigger(minutes=schedule.every_minutes, timezone=zone)
     if schedule.mode == "once":
         run_at = schedule.run_at
         assert run_at is not None  # validated upstream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.1.4"
+version = "0.1.5"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/schemas/test_api_schemas.py
+++ b/tests/schemas/test_api_schemas.py
@@ -133,6 +133,29 @@ def test_schedule_config_once_requires_run_at():
     assert sc.run_at is not None
 
 
+def test_schedule_config_interval_accepts_every_minutes():
+    """Verify interval-mode ScheduleConfig accepts every_minutes."""
+    sc = ScheduleConfig.model_validate(
+        {"mode": "interval", "name": "half hourly", "every_minutes": 30}
+    )
+    assert sc.mode == "interval"
+    assert sc.every_minutes == 30
+
+
+def test_schedule_config_interval_requires_every_minutes():
+    """Verify interval-mode ScheduleConfig rejects a missing every_minutes."""
+    with pytest.raises(Exception):
+        ScheduleConfig.model_validate({"mode": "interval", "name": "x"})
+
+
+def test_schedule_config_interval_rejects_non_positive():
+    """Verify interval-mode ScheduleConfig rejects every_minutes < 1."""
+    with pytest.raises(Exception):
+        ScheduleConfig.model_validate(
+            {"mode": "interval", "name": "x", "every_minutes": 0}
+        )
+
+
 def test_schedule_config_recurring_rejects_bad_day():
     """Verify recurring ScheduleConfig rejects an out-of-range day."""
     with pytest.raises(Exception):

--- a/tests/services/scheduler/test_store.py
+++ b/tests/services/scheduler/test_store.py
@@ -58,6 +58,25 @@ def _once_payload(**overrides):
     return CreateScheduleInput.model_validate(base)
 
 
+def _interval_payload(**overrides):
+    """Build an interval-mode CreateScheduleInput with optional overrides.
+
+    :param overrides: keyword overrides applied to the base payload.
+    """
+    base = {
+        "conduit_name": "poll",
+        "inputs": {},
+        "run_path": "/tmp/x",
+        "schedule": {
+            "mode": "interval",
+            "name": "half hourly",
+            "every_minutes": 30,
+        },
+    }
+    base.update(overrides)
+    return CreateScheduleInput.model_validate(base)
+
+
 # ----------------------------------------------------------- list / create
 
 
@@ -491,3 +510,17 @@ def test_recreate_after_load_round_trips(store, tmp_path):
     assert len(listed) == 1
     assert listed[0].id == job.id
     assert listed[0].schedule.times == ["06:00", "12:00"]
+
+
+def test_interval_schedule_round_trips(store, tmp_path):
+    """An interval schedule persists every_minutes across a reload.
+
+    :param store: ScheduleStore fixture.
+    :param tmp_path: pytest temp directory fixture.
+    """
+    job = store.create(_interval_payload())
+    fresh = ScheduleStore(tmp_path / ".atelier")
+    (loaded,) = fresh.list()
+    assert loaded.id == job.id
+    assert loaded.schedule.mode == "interval"
+    assert loaded.schedule.every_minutes == 30

--- a/tests/services/scheduler/test_triggers.py
+++ b/tests/services/scheduler/test_triggers.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 from apscheduler.triggers.combining import OrTrigger
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
 from flow_atelier.schemas.api import ScheduledJob
 from flow_atelier.services.scheduler.triggers import default_local_zone, to_trigger
@@ -130,6 +131,39 @@ def test_recurring_full_week():
     trig = to_trigger(job, default_zone=UTC)
     fire = trig.get_next_fire_time(None, datetime(2026, 4, 25, 12, 0, tzinfo=UTC))
     assert fire == datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
+
+
+# -------------------------------------------------------------- interval
+
+
+def test_interval_returns_interval_trigger():
+    """Verify interval-mode schedules return an IntervalTrigger."""
+    job = _job({"mode": "interval", "name": "x", "every_minutes": 30})
+    trig = to_trigger(job, default_zone=UTC)
+    assert isinstance(trig, IntervalTrigger)
+
+
+def test_interval_fires_every_n_minutes():
+    """Verify consecutive fires are exactly every_minutes apart."""
+    job = _job({"mode": "interval", "name": "x", "every_minutes": 30})
+    trig = to_trigger(job, default_zone=UTC)
+    prev = datetime(2026, 5, 1, 9, 0, tzinfo=UTC)
+    fire = trig.get_next_fire_time(prev, prev)
+    assert fire == datetime(2026, 5, 1, 9, 30, tzinfo=UTC)
+
+
+def test_interval_honors_schedule_timezone():
+    """An interval schedule's pinned timezone is carried into the trigger."""
+    job = _job(
+        {
+            "mode": "interval",
+            "name": "x",
+            "every_minutes": 120,
+            "timezone": "America/New_York",
+        }
+    )
+    trig = to_trigger(job, default_zone=UTC)
+    assert str(trig.timezone) == "America/New_York"
 
 
 def test_default_local_zone_returns_zoneinfo():

--- a/tests/test_api/test_schedules_api.py
+++ b/tests/test_api/test_schedules_api.py
@@ -82,6 +82,20 @@ async def test_create_schedule_returns_201(fixture):
     assert body["conduit_name"] == "report"
 
 
+async def test_create_interval_schedule_returns_201(fixture):
+    """Verify POST /schedules accepts an interval-mode payload.
+
+    :param fixture: client+atelier+tmp_path tuple fixture.
+    """
+    client, _, _ = fixture
+    payload = _payload(
+        schedule={"mode": "interval", "name": "half hourly", "every_minutes": 30}
+    )
+    resp = await client.post("/schedules", json=payload)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["schedule"]["every_minutes"] == 30
+
+
 async def test_create_schedule_persists_to_yaml_file(fixture):
     """Verify a created schedule is persisted to a YAML file under schedules/.
 

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
# feat: add interval schedule mode

## What

Adds a third schedule mode, `interval`, alongside the existing `recurring`
and `once` modes.

- `ScheduleConfig` gains `mode: "interval"` and an `every_minutes: int | None`
  field, validated to be `>= 1`. `interval` schedules require `every_minutes`.
- `to_trigger` maps `mode="interval"` to an APScheduler `IntervalTrigger`
  (`minutes=every_minutes`, in the schedule's timezone).
- Planned-table rendering treats `once` as the special-cased kind; every other
  kind (including `interval`) renders as recurring/cyan.
- README documents the new mode with examples.
- Version bumped `0.1.4` → `0.1.5`.

## Why

`recurring` (cron-style days/times) and `once` (single `run_at`) couldn't
express simple fixed cadences like "every 30 minutes" or "every 2 hours"
without enumerating times. `interval` covers that gap with one field and
repeats forever.

## How

- `mode: interval` with `every_minutes` (e.g. `every_minutes: 30`).
- Validation rejects `every_minutes < 1` and a missing `every_minutes` on an
  interval schedule.
- Backed by APScheduler's `IntervalTrigger`, so it reuses the existing
  scheduler/runner path — no new execution machinery.
- Covered by new tests in `tests/schemas/test_api_schemas.py`,
  `tests/services/scheduler/test_triggers.py`,
  `tests/services/scheduler/test_store.py`, and
  `tests/test_api/test_schedules_api.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interval-based scheduling mode, allowing jobs to repeat at regular minute intervals.

* **Documentation**
  * Updated schedule documentation to clarify interval scheduling behavior with explicit examples.

* **Style**
  * Improved visual distinction of schedule types in the job schedule display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->