### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.1.6"
+version = "0.1.7"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Bumps the package version to 0.1.7 for the next release.

- `pyproject.toml`: `0.1.6` → `0.1.7`
- `uv.lock`: synced project version entry (no dependency changes)

Pushing tag `v0.1.7` after merge triggers `release.yml`. Note: this bump alone does **not** publish to PyPI — the trusted-publisher setup (in progress with the owner) must also be completed, or the `publish-pypi` step will fail as it did for `v0.1.6`.
