### PR TITLE
fix(bash): translate {{conduit_dir}} into the WSL/git-bash namespace

### DIFF
--- a/flow_atelier/modules/engine.py
+++ b/flow_atelier/modules/engine.py
@@ -52,6 +52,7 @@ from flow_atelier.schemas.flow import parse_flow_id
 from flow_atelier.schemas.log import ExecutionResult, LogEntry, TaskEvent
 from flow_atelier.schemas.progress import FlowStatus, Progress, TaskProgress, TaskStatus
 from flow_atelier.services.executor.base import ExecutorBase, FlowContext
+from flow_atelier.services.executor.bash import to_bash_path
 from flow_atelier.services.store.base import StoreBase
 
 TaskEventCallback = Callable[[TaskEvent], None]
@@ -611,13 +612,22 @@ class Engine:
                 loop_history: list[str] = list(prior_iterations.get(t.name, []))
                 start_iteration = min(len(loop_history) + 1, t.repeat)
 
+                # {{conduit_dir}} is engine-computed in the host namespace; a
+                # tool:bash body may run under WSL/git-bash (Windows), where a
+                # raw `D:\...` path is mangled. Translate it to the resolved
+                # bash's namespace for bash tasks only — harness/nested tasks
+                # run native on the host and want the host path unchanged.
+                task_conduit_dir: Path | str | None = conduit_dir
+                if conduit_dir is not None and t.tool == ToolType.bash:
+                    task_conduit_dir = to_bash_path(conduit_dir)
+
                 def _resolve_task() -> str:
                     return resolve(
                         t.task, runtime_inputs, outputs,
                         unavailable_tasks=unavailable, loop_history=loop_history,
                         loop_history_limit=self.loop_history_limit,
                         loop_history_entry_chars=self.loop_history_entry_chars,
-                        conduit_dir=conduit_dir,
+                        conduit_dir=task_conduit_dir,
                     )
 
                 try:

--- a/flow_atelier/modules/templating.py
+++ b/flow_atelier/modules/templating.py
@@ -139,7 +139,7 @@ def resolve(
     loop_history: list[str] | None = None,
     loop_history_limit: int = 0,
     loop_history_entry_chars: int = 0,
-    conduit_dir: Path | None = None,
+    conduit_dir: Path | str | None = None,
 ) -> str:
     """Resolve `{{...}}` expressions in ``template``.
 

--- a/flow_atelier/services/executor/bash.py
+++ b/flow_atelier/services/executor/bash.py
@@ -2,13 +2,71 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
+import re
 import shutil
 import signal
+import subprocess
+from pathlib import Path
 
 from flow_atelier.schemas.conduit import TaskDefinition
 from flow_atelier.schemas.log import ExecutionResult
 from flow_atelier.services.executor.base import ExecutorBase, FlowContext
+
+# Windows drive-rooted path, e.g. ``D:\foo`` or ``C:/bar``. Engine-computed
+# path variables (``{{conduit_dir}}``) are the only values that arrive in this
+# flavor; bash-computed ones (``pwd -P``) are already POSIX.
+_WIN_DRIVE_RE = re.compile(r"^([A-Za-z]):[\\/]")
+
+
+@functools.cache
+def _bash_namespace() -> str:
+    """Path namespace the resolved ``bash`` expects: ``posix`` | ``wsl`` | ``msys``.
+
+    On non-Windows hosts ``bash`` is native, so host paths are already POSIX.
+    On Windows, ``shutil.which("bash")`` may be WSL bash (wants
+    ``/mnt/<drive>/...``) or git-bash/MSYS (wants ``/<drive>/...``). These need
+    different translations, so probe the actual bash for ``wslpath`` rather than
+    guessing from its path. Cached: the answer can't change within a run.
+    """
+    if os.name != "nt":
+        return "posix"
+    bash = shutil.which("bash")
+    if bash is None:
+        return "posix"
+    try:
+        probe = subprocess.run(
+            [bash, "-c", "command -v wslpath >/dev/null 2>&1 && echo wsl || echo msys"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "msys"  # ponytail: assume git-bash if the probe can't run
+    return "wsl" if probe.stdout.strip() == "wsl" else "msys"
+
+
+def to_bash_path(path: Path | str) -> str:
+    """Render a host path in the namespace the resolved ``bash`` expects.
+
+    No-op on POSIX hosts and on any value that isn't a Windows drive path — the
+    ``^[A-Za-z]:[\\/]`` guard keeps this idempotent (``wslpath -u`` is not:
+    ``wslpath -u /mnt/d/x`` returns ``/mnt/d/mnt/d/x``). A Windows drive path
+    becomes ``/mnt/<drive>/...`` under WSL bash or ``/<drive>/...`` under
+    git-bash/MSYS, so it survives the backslash-eating shell intact.
+
+    :param path: host path (or already-POSIX string) to translate.
+    :returns: the path in the bash executor's namespace.
+    """
+    text = str(path)
+    m = _WIN_DRIVE_RE.match(text)
+    if m is None or _bash_namespace() == "posix":
+        return text
+    drive = m.group(1).lower()
+    rest = text[2:].replace("\\", "/").lstrip("/")
+    prefix = f"/mnt/{drive}" if _bash_namespace() == "wsl" else f"/{drive}"
+    return f"{prefix}/{rest}" if rest else prefix
 
 
 class BashExecutor(ExecutorBase):

--- a/tests/services/executor/test_bash.py
+++ b/tests/services/executor/test_bash.py
@@ -5,9 +5,35 @@ import time
 
 import pytest
 
+import flow_atelier.services.executor.bash as bash_mod
 from flow_atelier.schemas.conduit import TaskDefinition, ToolType
 from flow_atelier.services.executor.base import FlowContext
-from flow_atelier.services.executor.bash import BashExecutor
+from flow_atelier.services.executor.bash import BashExecutor, to_bash_path
+
+
+@pytest.mark.parametrize(
+    ("ns", "src", "expected"),
+    [
+        # POSIX host: every path passes through untouched.
+        ("posix", "/mnt/d/autonomous-projects", "/mnt/d/autonomous-projects"),
+        ("posix", r"D:\foo\bar", r"D:\foo\bar"),
+        # WSL bash: Windows drive path -> /mnt/<drive>/...; backslashes gone.
+        ("wsl", r"D:\autonomous-projects\.atelier\conduits\ap",
+         "/mnt/d/autonomous-projects/.atelier/conduits/ap"),
+        ("wsl", "C:/foo/bar", "/mnt/c/foo/bar"),
+        ("wsl", r"D:\\", "/mnt/d"),
+        # git-bash/MSYS: Windows drive path -> /<drive>/...
+        ("msys", r"D:\foo\bar", "/d/foo/bar"),
+        # Idempotency guard: an already-POSIX value is never re-translated,
+        # even when the resolved bash is WSL.
+        ("wsl", "/mnt/d/autonomous-projects", "/mnt/d/autonomous-projects"),
+        ("msys", "/d/foo", "/d/foo"),
+    ],
+)
+def test_to_bash_path(monkeypatch, ns: str, src: str, expected: str) -> None:
+    """to_bash_path translates only real Windows drive paths, per bash namespace."""
+    monkeypatch.setattr(bash_mod, "_bash_namespace", lambda: ns)
+    assert to_bash_path(src) == expected
 
 
 def _task(cmd: str) -> TaskDefinition:


### PR DESCRIPTION
## Problem

On Windows, `tool:bash` tasks run under whatever `shutil.which("bash")` resolves to — commonly **WSL** bash. But the engine rendered `{{conduit_dir}}` as a host path with backslashes (`D:\autonomous-projects\.atelier\...`). WSL bash eats the backslashes as escapes, collapsing the path to garbage:

```
python3: can't open file '.../D:autonomous-projects.atelierconduits.../scripts/project_picker.py': [Errno 2] No such file or directory
```

Any conduit referencing `{{conduit_dir}}` inside a `tool:bash` body fails. Bash-computed paths (`pwd -P`, upstream `{{task.output}}`) were fine — only the engine-computed path var carried the wrong flavor.

## Fix

`to_bash_path()` (in `services/executor/bash.py`) translates a host path into the namespace the resolved `bash` expects:

- **POSIX hosts** (macOS/Linux): no-op.
- **Windows**: probes the resolved `bash` once for `wslpath` to distinguish **WSL** (`/mnt/<drive>/...`) from **git-bash/MSYS** (`/<drive>/...`) — these need different translations, so a blind `wslpath` call would corrupt paths for git-bash users.
- Guarded by `^[A-Za-z]:[\\/]` so only real Windows drive paths convert and the operation stays idempotent (`wslpath -u` is not).

Applied to `{{conduit_dir}}` for `tool:bash` tasks only. Harness and nested-conduit tasks run native on the host and keep the unchanged host path.

## Tests

- 8 new parametrized cases in `tests/services/executor/test_bash.py` covering posix/wsl/msys translation + the idempotency guard.
- 155 engine/templating/bash tests pass.

## Verification caveat

Validated on macOS, where the namespace resolves to `posix` (no-op). The live WSL/git-bash branches are exercised only via unit tests (monkeypatched namespace), **not** an end-to-end run on a real Windows+WSL box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced path translation and resolution for bash task execution on Windows systems with WSL and git-bash environments, ensuring file paths are correctly converted when executing bash-based tasks.

* **Tests**
  * Added comprehensive test coverage for Windows-to-bash path translation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->