### PR TITLE
fix(test): Windows conduit_dir assertion + bump to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.1.7"
+version = "0.1.8"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/modules/test_engine.py
+++ b/tests/modules/test_engine.py
@@ -14,6 +14,7 @@ from flow_atelier.schemas.conduit import Conduit
 from flow_atelier.schemas.log import ExecutionResult
 from flow_atelier.schemas.progress import FlowStatus, TaskStatus
 from flow_atelier.services.executor.base import ExecutorBase
+from flow_atelier.services.executor.bash import to_bash_path
 from flow_atelier.services.executor.conduit import ConduitExecutor
 from flow_atelier.services.store.filesystem import FilesystemStore
 
@@ -365,7 +366,9 @@ async def test_conduit_dir_in_task_template_resolves(store):
     fake = _Capturing()
     engine = Engine({"tool:bash": fake}, store)
     await engine.run(conduit, {})
-    assert fake.cmd == f"echo {store.conduit_dir('test')}/x"
+    # conduit_dir is translated into the bash executor's namespace for
+    # tool:bash tasks (no-op on POSIX, /<drive>/... under git-bash on Windows).
+    assert fake.cmd == f"echo {to_bash_path(store.conduit_dir('test'))}/x"
 
 
 async def test_conduit_dir_default_resolves_at_apply_time(store):

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Why

After the `{{conduit_dir}}` WSL/git-bash translation landed (#44), `main`'s Windows CI is red: `test_conduit_dir_in_task_template_resolves` still asserts the raw host path (`C:\Users\...`), but a `tool:bash` task now resolves `{{conduit_dir}}` into the bash namespace (`/c/Users/...` under git-bash on the runner).

## Changes

- **Test fix**: assert against `to_bash_path(store.conduit_dir('test'))` instead of the raw path. No-op on POSIX (where the prior assertion already held); matches the translated path on Windows. The sibling `test_conduit_dir_default_resolves_at_apply_time` is untouched — input-default resolution doesn't go through the bash translation.
- **Version bump**: `0.1.7 -> 0.1.8` in `pyproject.toml` + `uv.lock`, so a `v0.1.8` tag will pass the release workflow's tag-vs-pyproject check.

## Verification

- `pytest tests/modules/test_engine.py` — 78 passed (macOS, POSIX no-op).
- `ruff check` clean.

## Release (after merge — NOT done here)

Releases are tag-triggered (`.github/workflows/release.yml` on `push: tags: ['v*']`): it publishes to PyPI and cuts a GitHub release. **No tag has been pushed.** Once this merges to `main`, tag the merge commit `v0.1.8` to trigger the release.