### PR TITLE
feat(cli): interactive add scope prompt; flip multiline submit key

### DIFF
--- a/flow_atelier/cli/commands/add.py
+++ b/flow_atelier/cli/commands/add.py
@@ -1,6 +1,8 @@
 """`atelier add` command — install a conduit package from a repo or path."""
 from __future__ import annotations
 
+import sys
+
 import typer
 from rich.markup import escape
 
@@ -44,6 +46,21 @@ def _print_report(report: InstallReport) -> None:
         )
 
 
+def _prompt_scope() -> bool:
+    """Ask where to install; g/empty -> global, p -> project. Re-ask on bad input.
+
+    :returns: ``True`` for the project store, ``False`` for global.
+    """
+    while True:
+        ans = input(
+            "Install globally (~/.atelier) or in this project (./.atelier)? [g/p] "
+        ).strip().lower()
+        if ans in ("", "g"):
+            return False
+        if ans == "p":
+            return True
+
+
 @app.command("add", help="Install a conduit package from a git repo or local path.")
 def add_cmd(
     source: str = typer.Argument(
@@ -52,8 +69,10 @@ def add_cmd(
     force: bool = typer.Option(
         False, "--force", help="Overwrite existing conduits/skills on collision."
     ),
-    project: bool = typer.Option(
-        False, "--project", help="Install conduits into the project store, not global."
+    project: bool | None = typer.Option(
+        None,
+        "--project/--no-project",
+        help="Install conduits into the project store, not global.",
     ),
     ref: str = typer.Option(
         None, "--ref", help="git branch/tag/commit to check out."
@@ -63,9 +82,12 @@ def add_cmd(
 
     :param source: git URL, ``owner/repo`` shorthand, or a local path.
     :param force: overwrite colliding conduits/skills instead of skipping.
-    :param project: install conduits into the project store rather than global.
+    :param project: install conduits into the project store rather than global;
+        ``None`` resolves via an interactive prompt on a TTY, else global.
     :param ref: optional git ref to check out.
     """
+    if project is None:
+        project = _prompt_scope() if sys.stdin.isatty() else False
     try:
         report = Atelier().install_package(
             source, ref=ref, project=project, force=force

--- a/flow_atelier/cli/commands/run.py
+++ b/flow_atelier/cli/commands/run.py
@@ -238,7 +238,7 @@ def run_cmd(
             for key in missing:
                 value = multiline_input_sync(
                     f"  {key} ({conduit.inputs[key].description}): ",
-                    hint="Alt+Enter to submit",
+                    hint="Enter to submit · Alt+Enter for newline",
                 )
                 inputs[key] = value
         except KeyboardInterrupt:

--- a/flow_atelier/cli/rendering/multiline_input.py
+++ b/flow_atelier/cli/rendering/multiline_input.py
@@ -1,6 +1,6 @@
 """Multi-line terminal input using prompt_toolkit.
 
-Enter inserts a newline; Alt+Enter (Escape then Enter) submits.
+Enter submits; Alt+Enter (Escape then Enter) inserts a newline.
 Falls back to ``builtins.input()`` when stdin is not a TTY.
 """
 from __future__ import annotations
@@ -14,16 +14,24 @@ from prompt_toolkit.key_binding import KeyBindings
 
 
 def _make_key_bindings() -> KeyBindings:
-    """Alt+Enter submits; Enter inserts newline."""
+    """Enter submits; Alt+Enter inserts a newline."""
     kb = KeyBindings()
 
-    @kb.add("escape", "enter")
+    @kb.add("enter")
     def _submit(event):
-        """Submit the current buffer when Alt+Enter is pressed.
+        """Submit the current buffer when Enter is pressed.
 
         :param event: prompt_toolkit key event whose buffer is submitted.
         """
         event.current_buffer.validate_and_handle()
+
+    @kb.add("escape", "enter")
+    def _newline(event):
+        """Insert a newline when Alt+Enter (Escape then Enter) is pressed.
+
+        :param event: prompt_toolkit key event whose buffer gets the newline.
+        """
+        event.current_buffer.insert_text("\n")
 
     return kb
 

--- a/tests/cli/test_add_cmd.py
+++ b/tests/cli/test_add_cmd.py
@@ -1,6 +1,7 @@
 """CLI tests for `atelier add` — install a package from a local path."""
 from __future__ import annotations
 
+import builtins
 import json
 import os
 
@@ -63,7 +64,7 @@ def env(tmp_path, monkeypatch):
     (skill / "SKILL.md").write_text("# idea\n")
     (pkg / "atelier-package.yaml").write_text(MANIFEST_YAML)
 
-    return {"home": home, "global": global_dir, "pkg": pkg}
+    return {"home": home, "global": global_dir, "proj": proj, "pkg": pkg}
 
 
 def test_add_installs_conduit_skills_and_lockfile(env):
@@ -77,6 +78,54 @@ def test_add_installs_conduit_skills_and_lockfile(env):
     assert lock["demo-pkg"]["conduits"] == ["demo"]
     assert lock["demo-pkg"]["skills"] == ["idea"]
     assert "atelier run demo" in result.output
+
+
+def test_add_project_flag_installs_into_project_store(env):
+    """`add --project` installs the conduit into ./.atelier, not global."""
+    result = CliRunner().invoke(app, ["add", str(env["pkg"]), "--project"])
+    assert result.exit_code == 0, result.output
+    assert (env["proj"] / ".atelier" / "conduits" / "demo" / "conduit.yaml").exists()
+    assert not (env["global"] / "conduits" / "demo").exists()
+
+
+def test_add_no_project_flag_installs_global(env):
+    """`add --no-project` installs into the global store."""
+    result = CliRunner().invoke(app, ["add", str(env["pkg"]), "--no-project"])
+    assert result.exit_code == 0, result.output
+    assert (env["global"] / "conduits" / "demo" / "conduit.yaml").exists()
+
+
+def test_add_no_flag_non_tty_defaults_global_without_prompt(env):
+    """No flag on a non-TTY stdin (CliRunner) installs global, no prompt shown."""
+    result = CliRunner().invoke(app, ["add", str(env["pkg"])])
+    assert result.exit_code == 0, result.output
+    assert (env["global"] / "conduits" / "demo" / "conduit.yaml").exists()
+    assert "globally" not in result.output  # interactive prompt text absent
+
+
+def test_add_no_flag_tty_prompts_and_p_installs_project(env, monkeypatch):
+    """No flag on a TTY prompts; answering 'p' installs into the project store."""
+    import types
+
+    # CliRunner swaps the real sys.stdin, so rebind the name the command reads.
+    fake_sys = types.SimpleNamespace(stdin=types.SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr("flow_atelier.cli.commands.add.sys", fake_sys)
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "p")
+    result = CliRunner().invoke(app, ["add", str(env["pkg"])])
+    assert result.exit_code == 0, result.output
+    assert (env["proj"] / ".atelier" / "conduits" / "demo" / "conduit.yaml").exists()
+    assert not (env["global"] / "conduits" / "demo").exists()
+
+
+def test_prompt_scope_resolves_answers_and_reasks(monkeypatch):
+    """g/empty -> global (False), p -> project (True); invalid input re-asks."""
+    from flow_atelier.cli.commands.add import _prompt_scope
+
+    answers = iter(["", "g", "x", "p"])
+    monkeypatch.setattr(builtins, "input", lambda prompt="": next(answers))
+    assert _prompt_scope() is False  # empty -> global
+    assert _prompt_scope() is False  # g -> global
+    assert _prompt_scope() is True  # x (re-ask) then p -> project
 
 
 def test_add_collision_skips_without_force_exit_zero(env):

--- a/tests/cli/test_multiline_input.py
+++ b/tests/cli/test_multiline_input.py
@@ -64,7 +64,7 @@ class TestMultilineInputTTY:
         monkeypatch.setattr(
             "flow_atelier.cli.rendering.multiline_input.PromptSession", FakeSession
         )
-        result = await multiline_input("› ", hint="Alt+Enter to submit")
+        result = await multiline_input("› ", hint="Enter to submit · Alt+Enter for newline")
         assert result == "multiline text\nsecond line"
 
     async def test_hint_printed_on_tty(self, monkeypatch, capsys):
@@ -96,6 +96,21 @@ class TestMultilineInputTTY:
         monkeypatch.setattr(
             "flow_atelier.cli.rendering.multiline_input.PromptSession", FakeSession
         )
-        await multiline_input("› ", hint="Alt+Enter to submit")
+        await multiline_input("› ", hint="Enter to submit · Alt+Enter for newline")
         captured = capsys.readouterr()
-        assert "Alt+Enter to submit" in captured.out
+        assert "Enter to submit" in captured.out
+
+
+class TestKeyBindings:
+    """Enter submits; Alt+Enter inserts a newline."""
+
+    def test_enter_submits_and_alt_enter_inserts_newline(self):
+        """Verify the flipped bindings are registered for Enter and Alt+Enter."""
+        from prompt_toolkit.keys import Keys
+
+        from flow_atelier.cli.rendering.multiline_input import _make_key_bindings
+
+        # prompt_toolkit aliases "enter" to ControlM (c-m).
+        keysets = {tuple(b.keys) for b in _make_key_bindings().bindings}
+        assert (Keys.ControlM,) in keysets  # Enter submits
+        assert (Keys.Escape, Keys.ControlM) in keysets  # Alt+Enter newline


### PR DESCRIPTION
## Summary

Two small, isolated CLI changes:

1. **Interactive scope prompt in `atelier add`** — `--project` is now an optional `--project/--no-project` pair (default unset). When no flag is passed and stdin is a TTY, the command prompts `[g/p]` for where to install. Non-TTY (piped/CI) keeps today's global default so runs never hang. `install_package(..., project: bool)` is unchanged; `None` is resolved to a bool before the call.

2. **Flipped multiline submit key** — in `atelier run`'s interactive input, **Enter** now submits and **Alt+Enter** inserts a newline (previously reversed). The hint reads `Enter to submit · Alt+Enter for newline`.

## Note on Shift+Enter

The original spec asked for a Shift+Enter newline binding too, but prompt_toolkit 3.0.52 has no bindable key for it (`"s-enter"` and `Keys.ShiftEnter` both raise `ValueError`, and newer versions don't add it). Binding it would crash key-binding setup, so it was omitted — Alt+Enter is the reliable newline binding.

## Tests

- `add` scope matrix: `--project` -> project store, `--no-project` -> global, no-flag+non-TTY -> global, no-flag+TTY -> interactive prompt; plus a `_prompt_scope` unit test for the re-ask loop.
- `multiline_input`: asserts Enter and Alt+Enter bindings are registered; updated existing hint assertions.

Full suite: 873 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `atelier add` now supports interactive scope selection: choose between installing conduits to your project or global store. When not specified, the command prompts in interactive mode and defaults to global store in non-interactive environments.

* **Improvements**
  * Updated multiline input key bindings: Enter submits your input; Alt+Enter inserts a newline.
  * Clarified input prompt help text for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->