### PR TITLE
chore(release): v0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.1.8"
+version = "0.1.9"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Bump version 0.1.8 -> 0.1.9 for release.

Ships PR #47 (interactive `add` scope prompt; flipped multiline submit key).

After merge, tag `v0.1.9` on main to trigger the release workflow (PyPI publish + binaries + GitHub release).