### PR TITLE
Release v0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.1.9"
+version = "0.1.10"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release v0.1.10

Bumps version 0.1.9 -> 0.1.10.

### Changes
- chore(deps): bump ACP adapters and agent-client-protocol
- refactor(package): stop atelier add from copying skills
- chore(release): bump version 0.1.9 -> 0.1.10
