### PR TITLE
docs: restore the image markdown in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-flow-atelier
+![flow-atelier](./atelier.jpg)
 
 # Flow Atelier
 
@@ -45,11 +45,11 @@ atelier serve                            # opens the visual editor on :8000
 The designer lays a conduit out by dependency depth, so each column is a set of
 steps that can run at the same time:
 
-Designer
+![Designer](./docs/img/designer.jpg)
 
 Runs stream to the dashboard, including the human-approval gates:
 
-Dashboard
+![Dashboard](./docs/img/dashboard.jpg)
 
 ## How it compares
 


### PR DESCRIPTION
The README renders the literal words `Designer` and `Dashboard` where the
screenshots should be, and has no hero image at all.

## Cause

The frontend redesign (`dd5d9b0`, which shipped in #52) added
`docs/img/designer.jpg` and `docs/img/dashboard.jpg` but wrote their captions as
bare text instead of image syntax. The same rewrite reduced the hero
`![flow-atelier](./atelier.png)` to a bare `flow-atelier` line and replaced
`atelier.png` with `atelier.jpg` — so all three images were tracked in git with
nothing pointing at them.

This was specific to image syntax, not a general markdown loss: across the same
rewrite inline links went **4 → 7** while images went **1 → 0**.

## Fix

Three lines:

| Line | Was | Now |
|---|---|---|
| 1 | `flow-atelier` | `![flow-atelier](./atelier.jpg)` |
| 48 | `Designer` | `![Designer](./docs/img/designer.jpg)` |
| 52 | `Dashboard` | `![Dashboard](./docs/img/dashboard.jpg)` |

Every referenced path is verified to resolve against a file tracked on `main`.

Docs only — no code, no tests affected.