### PR TITLE
chore(release): bump version 0.2.1 -> 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow-atelier"
-version = "0.2.1"
+version = "0.3.0"
 description = "CLI tool and async workflow engine for running reproducible DAG workflows (conduits)."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "flow-atelier"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

Prepare the backward-compatible feature and security release by updating the project version from `0.2.1` to `0.3.0`.

## Changes

- update `pyproject.toml` to `0.3.0`
- regenerate `uv.lock` so the editable package entry also reports `0.3.0`

## Validation

- `uv lock --check`
- `uv run atelier --version` → `flow-atelier 0.3.0`

After this PR is merged, tag the resulting main commit as `v0.3.0` to trigger the established release workflow.